### PR TITLE
Build option to follow the latest stable on a release series/track

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ You can set the following environment variables prior to building:
  - KUBE_VERSION: kubernetes release to package. Defaults to latest stable.
  - ETCD_VERSION: version of etcd. Defaults to v3.3.4.
  - CNI_VERSION: version of CNI tools. Defaults to v0.6.0.
+ - KUBE_TRACK: kubernetes release series (e.g., 1.10) to package. Defaults to latest stable.
 
 For example:
 ```

--- a/build-scripts/prepare-env.sh
+++ b/build-scripts/prepare-env.sh
@@ -14,9 +14,14 @@ export KUBE_ARCH
 export ETCD_VERSION="${ETCD_VERSION:-v3.3.4}"
 export CNI_VERSION="${CNI_VERSION:-v0.6.0}"
 
+export KUBE_TRACK="${KUBE_TRACK:-}"
 export KUBE_SNAP_BINS="${KUBE_SNAP_BINS:-}"
 if [ -z "$KUBE_SNAP_BINS" ]; then
-  export KUBE_VERSION="${KUBE_VERSION:-`curl -L https://dl.k8s.io/release/stable.txt`}"
+  if [ -z "$KUBE_TRACK" ]; then
+    export KUBE_VERSION="${KUBE_VERSION:-`curl -L https://dl.k8s.io/release/stable.txt`}"
+  else
+    export KUBE_VERSION="${KUBE_VERSION:-`curl -L https://dl.k8s.io/release/stable-${KUBE_TRACK}.txt`}"
+  fi
 else
   export KUBE_VERSION=`cat $KUBE_SNAP_BINS/version`
 fi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,10 +1,7 @@
 name: microk8s
 version-script: |
-  if [ -z "$KUBE_SNAP_BINS" ]; then
-    curl -L https://dl.k8s.io/release/stable.txt
-  else
-    cat $KUBE_SNAP_BINS/version
-  fi
+  . build-scripts/prepare-env.sh > /dev/null
+  echo $KUBE_VERSION
 version: "latest"
 summary: Kubernetes in your box.
 description: Microk8s deploys and configures all kubernetes services in a snap.


### PR DESCRIPTION
This PR introduces a environment variable called KUBE_TARCK. Setting KUBE_TRACK to the desired k8s series (eg 1.10) allows for building the latest stable k8s from that release series (eg 1.10.5 at the time of this writting).

This PR is needed for releasing microk8s into snap tracks (eg 1.10/edge)