### PR TITLE
Fix travis flakiness with more frequent cluster resets

### DIFF
--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -1,8 +1,18 @@
+import pytest
 from validators import validate_dns, validate_dashboard, validate_storage, validate_ingress
-from utils import microk8s_enable, wait_for_pod_state, microk8s_disable
+from utils import microk8s_enable, wait_for_pod_state, microk8s_disable, microk8s_reset
 from subprocess import Popen, PIPE, STDOUT
 
+
 class TestAddons(object):
+
+    @pytest.fixture(autouse=True)
+    def clean_up(self):
+        """
+        Clean up after a test
+        """
+        yield
+        microk8s_reset()
 
     def test_dns(self):
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -117,3 +117,11 @@ def microk8s_disable(addon):
     """
     cmd = '/snap/bin/microk8s.disable {}'.format(addon)
     return run_until_success(cmd)
+
+
+def microk8s_reset():
+    """
+    Call microk8s reset
+    """
+    cmd = '/snap/bin/microk8s.reset'
+    return run_until_success(cmd)


### PR DESCRIPTION
Our tests enable and disable dns multiple times. For some reason k8s freaks out and keeps a "Terminating" dns-pod entry for too long. Our tests wait for that dns pod to be deleted and travis sees no output for 10 minutes and kills the tests.

With this PR we make sure that at the end of each test we do a proper job in cleaning up all pods so that the next test will spawn dns-pod without k8s freaking out.  