### PR TITLE
Bind the API server to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You can find the addon manifests and/or scripts under `${SNAP}/actions/`, with `
 - **storage**: Create a default storage class. This storage class makes use of the hostpath-provisioner pointing to a directory on the host. Persistent volumes are created under `${SNAP_COMMON}/default-storage`. Upon disabling this addon you will be asked if you want to delete the persistent volumes created.
 - **ingress**: Create an ingress controller.
 - **gpu**: Expose GPU(s) to microk8s by enabling the nvidia-docker runtime and nvidia-device-plugin-daemonset. Requires NVIDIA drivers to already be installed on the host system.
+- **external-access**: By default the API server will be available only on the localhost. This addon reconfigures microk8s to be available from the default network interface of the host, allowing for remote access.
 
 ### Stopping and Restarting microk8s
 

--- a/microk8s-resources/actions/disable.external-access.sh
+++ b/microk8s-resources/actions/disable.external-access.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Restricting microk8s access to localhost"
+
+refresh_opt_in_config "insecure-bind-address" "127.0.0.1" kube-apiserver
+sudo systemctl restart snap.${SNAP_NAME}.daemon-apiserver
+
+echo "Kube API server accessible only from localhost"

--- a/microk8s-resources/actions/enable.external-access.sh
+++ b/microk8s-resources/actions/enable.external-access.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Exposig microk8s to the default interface"
+
+refresh_opt_in_config "insecure-bind-address" "0.0.0.0" kube-apiserver
+sudo systemctl restart snap.${SNAP_NAME}.daemon-apiserver
+
+echo "Kube API server accessible from the default interface"

--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -1,5 +1,5 @@
 --v=4
---insecure-bind-address=0.0.0.0
+--insecure-bind-address=127.0.0.1
 --cert-dir=${SNAP_DATA}
 --etcd-servers='unix://etcd.socket:2379'
 --service-cluster-ip-range=10.152.183.0/24

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -4,7 +4,8 @@ from validators import (
     validate_dashboard,
     validate_storage,
     validate_ingress,
-    validate_gpu
+    validate_gpu,
+    validate_access
 )
 from utils import microk8s_enable, wait_for_pod_state, microk8s_disable, microk8s_reset
 from subprocess import Popen, PIPE, STDOUT, CalledProcessError
@@ -96,3 +97,10 @@ class TestAddons(object):
         microk8s_disable("gpu")
         print("Disabling DNS")
         microk8s_disable("dns")
+
+    def test_access(self):
+        """
+        Tests the API server access restrictions.
+
+        """
+        validate_access()

--- a/tests/test-live-addons.py
+++ b/tests/test-live-addons.py
@@ -1,4 +1,10 @@
-from validators import validate_dns, validate_dashboard, validate_storage, validate_ingress
+from validators import (
+    validate_dns,
+    validate_dashboard,
+    validate_storage,
+    validate_ingress,
+    validate_access
+)
 from utils import microk8s_enable, wait_for_pod_state, microk8s_disable
 
 
@@ -37,3 +43,11 @@ class TestLiveAddons(object):
 
         """
         validate_ingress()
+
+    def test_access(self):
+        """
+        Validates api access.
+
+        """
+        validate_access()
+

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -1,6 +1,13 @@
 import os
 import time
-from validators import validate_dns, validate_dashboard, validate_storage, validate_ingress, validate_gpu
+from validators import (
+    validate_dns,
+    validate_dashboard,
+    validate_storage,
+    validate_ingress,
+    validate_gpu,
+    validate_access
+)
 from subprocess import check_call
 from utils import microk8s_enable, wait_for_pod_state, microk8s_disable, wait_for_installation
 
@@ -63,6 +70,14 @@ class TestUpgrade(object):
             test_matrix['gpu'] = validate_gpu
         except:
             print('Will not test gpu')
+
+        try:
+            enable = microk8s_enable("external-access")
+            assert "Nothing to do for" not in enable
+            validate_access()
+            test_matrix['external-access'] = validate_access
+        except:
+            print('Will not test external access')
 
         # Refresh the snap to the target
         if upgrade_to.endswith('.snap'):

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -74,6 +74,9 @@ class TestUpgrade(object):
         try:
             enable = microk8s_enable("external-access")
             assert "Nothing to do for" not in enable
+            wait_for_installation()
+            microk8s_disable("external-access")
+            wait_for_installation()
             validate_access()
             test_matrix['external-access'] = validate_access
         except:


### PR DESCRIPTION
With this PR we bind by default to the localhost interface. If one want to expose microk8s he can do so with `microk8s.enabel external-access`.

Should address: https://github.com/ubuntu/microk8s/issues/63