### PR TITLE
Add socat package

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -93,6 +93,7 @@ parts:
     - file
     stage-packages:
     - util-linux
+    - socat
     source: .
     override-build: |
       set -eu

--- a/tests/templates/nginx-pod.yaml
+++ b/tests/templates/nginx-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+  namespace: default
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+  restartPolicy: Always

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -6,7 +6,8 @@ from validators import (
     validate_ingress,
     validate_gpu,
     validate_istio,
-    validate_registry
+    validate_registry,
+    validate_forward,
 )
 from utils import microk8s_enable, wait_for_pod_state, microk8s_disable, microk8s_reset
 from subprocess import Popen, PIPE, STDOUT, CalledProcessError
@@ -118,4 +119,12 @@ class TestAddons(object):
         microk8s_disable("istio")
         print("Disabling DNS")
         microk8s_disable("dns")
+
+    def test_forward(self):
+        """
+        Test port forward.
+
+        """
+        print("Validating Port Forward")
+        validate_forward()
 

--- a/tests/test-live-addons.py
+++ b/tests/test-live-addons.py
@@ -5,6 +5,7 @@ from validators import (
     validate_ingress,
     validate_istio,
     validate_registry,
+    validate_forward,
 )
 from utils import microk8s_enable, wait_for_pod_state, microk8s_disable
 
@@ -58,4 +59,11 @@ class TestLiveAddons(object):
 
         """
         validate_registry()
+
+    def test_forward(self):
+        """
+        Validates port forward works.
+
+        """
+        validate_forward()
 

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -6,7 +6,8 @@ from validators import (
     validate_storage,
     validate_ingress,
     validate_gpu,
-    validate_registry
+    validate_registry,
+    validate_forward
 )
 from subprocess import check_call
 from utils import microk8s_enable, wait_for_pod_state, microk8s_disable, wait_for_installation
@@ -83,6 +84,12 @@ class TestUpgrade(object):
             test_matrix['registry'] = validate_registry
         except:
             print('Will not test registry')
+
+        try:
+            validate_forward()
+            test_matrix['forward'] = validate_forward
+        except:
+            print('Will not test port forward')
 
         # Refresh the snap to the target
         if upgrade_to.endswith('.snap'):


### PR DESCRIPTION
This fixes the following error:

```
ubuntu@ip-172-31-52-95:~/microk8s$ microk8s.kubectl port-forward pod/microbot-55d84d48c-8lth9 8000:80                                                                                                               
Forwarding from 127.0.0.1:8000 -> 80
Forwarding from [::1]:8000 -> 80
Handling connection for 8000
E0817 11:39:15.683666    1239 portforward.go:331] an error occurred forwarding 8000 -> 80: error forwarding port 80 to pod 8ffaeb0889cdc05ef2167ed74e3c7420becdf77b1e5bfb3c6b6bba3c58550a6b, uid : unable to do port forwarding: socat not found.
```

As a workaround you can `apt-get install socat`.