### PR TITLE
Test on other distributions

### DIFF
--- a/tests/lxc/install-deps/ubuntu:16.04
+++ b/tests/lxc/install-deps/ubuntu:16.04
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install python-pip -y
+pip install -U pytest requests pyyaml

--- a/tests/lxc/install-deps/ubuntu:18.04
+++ b/tests/lxc/install-deps/ubuntu:18.04
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+apt-get update
+apt-get install python-pip -y
+pip install -U pytest requests pyyaml

--- a/tests/lxc/microk8s-zfs.profile
+++ b/tests/lxc/microk8s-zfs.profile
@@ -1,0 +1,26 @@
+name: microk8s
+config:
+  boot.autostart: "true"
+  linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,nf_conntrack_ipv4,ip_tables,ip6_tables,netlink_diag,nf_nat,overlay
+  raw.lxc: |
+    lxc.apparmor.profile=unconfined
+    lxc.mount.auto=proc:rw sys:rw
+    lxc.cgroup.devices.allow=a
+    lxc.cap.drop=
+  security.nesting: "true"
+  security.privileged: "true"
+description: ""
+devices:
+  aadisable:
+    path: /sys/module/nf_conntrack/parameters/hashsize
+    source: /sys/module/nf_conntrack/parameters/hashsize
+    type: disk
+  aadisable1:
+    path: /sys/module/apparmor/parameters/enabled
+    source: /dev/null
+    type: disk
+  aadisable2:
+    path: /dev/zfs
+    source: /dev/zfs
+    type: disk
+

--- a/tests/lxc/microk8s.profile
+++ b/tests/lxc/microk8s.profile
@@ -1,0 +1,21 @@
+name: microk8s
+config:
+  boot.autostart: "true"
+  linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,nf_conntrack_ipv4,ip_tables,ip6_tables,netlink_diag,nf_nat,overlay
+  raw.lxc: |
+    lxc.apparmor.profile=unconfined
+    lxc.mount.auto=proc:rw sys:rw
+    lxc.cap.drop=
+  security.nesting: "true"
+  security.privileged: "true"
+description: ""
+devices:
+  aadisable:
+    path: /sys/module/nf_conntrack/parameters/hashsize
+    source: /sys/module/nf_conntrack/parameters/hashsize
+    type: disk
+  aadisable1:
+    path: /sys/module/apparmor/parameters/enabled
+    source: /dev/null
+    type: disk
+

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -5,7 +5,7 @@ if echo "$*" | grep -q -- 'help'; then
     echo "Usage: $prog LXC-IMAGE ORIGINAL-CHANNEL UPGRADE-WITH-CHANNEL"
     echo ""
     echo "Example: $prog ubuntu:18.04 beta edge"
-    echo "Use Ubuntu 18.04 for running our tests on."
+    echo "Use Ubuntu 18.04 for running our tests."
     echo "We test that microk8s from edge (UPGRADE-WITH-CHANNEL) runs fine."
     echo "We test that microk8s from beta (ORIGINAL-CHANNEL) can be upgraded"
     echo "to the revision that is currently on edge (UPGRADE-WITH-CHANNEL)."

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+if echo "$*" | grep -q -- 'help'; then
+    prog=$(basename -s.wrapper "$0")
+    echo "Usage: $prog LXC-IMAGE ORIGINAL-CHANNEL UPGRADE-WITH-CHANNEL"
+    echo ""
+    echo "Example: $prog ubuntu:18.04 beta edge"
+    echo "Use Ubuntu 18.04 for running our tests on."
+    echo "We test that microk8s from edge (UPGRADE-WITH-CHANNEL) runs fine."
+    echo "We test that microk8s from beta (ORIGINAL-CHANNEL) can be upgraded"
+    echo "to the revision that is currently on edge (UPGRADE-WITH-CHANNEL)."
+    echo
+    exit
+fi
+
+set -ue
+
+DISTRO=$1
+NAME=machine-$RANDOM
+FROM_CHANNEL=$2
+TO_CHANNEL=$3
+
+if ! lxc profile show microk8s
+then
+  lxc profile copy default microk8s
+  cat tests/lxc/microk8s.profile | lxc profile edit microk8s
+fi
+
+lxc launch -p default -p microk8s $DISTRO $NAME
+trap "lxc delete ${NAME} --force || true" EXIT
+# Allow for the machine to boot and get an IP
+sleep 20
+
+tar cf - ./tests | lxc exec $NAME -- tar xvf - -C /tmp
+lxc exec $NAME -- /bin/bash "/tmp/tests/lxc/install-deps/$DISTRO"
+lxc exec $NAME -- snap install microk8s --${TO_CHANNEL} --classic
+lxc exec $NAME -- pytest -s /tmp/tests/test-addons.py
+lxc exec $NAME -- microk8s.reset
+lxc exec $NAME -- snap remove microk8s
+lxc exec $NAME -- /bin/bash -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /tmp/tests/test-upgrade.py"

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -36,5 +36,4 @@ lxc exec $NAME -- /bin/bash "/tmp/tests/lxc/install-deps/$DISTRO"
 lxc exec $NAME -- snap install microk8s --${TO_CHANNEL} --classic
 lxc exec $NAME -- pytest -s /tmp/tests/test-addons.py
 lxc exec $NAME -- microk8s.reset
-lxc exec $NAME -- snap remove microk8s
 lxc exec $NAME -- /bin/bash -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /tmp/tests/test-upgrade.py"

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -9,7 +9,7 @@ from validators import (
     validate_registry,
     validate_forward
 )
-from subprocess import check_call
+from subprocess import check_call, CalledProcessError
 from utils import microk8s_enable, wait_for_pod_state, microk8s_disable, wait_for_installation
 
 upgrade_from = os.environ.get('UPGRADE_MICROK8S_FROM', 'beta')
@@ -106,5 +106,8 @@ class TestUpgrade(object):
             print("Testing {}".format(test))
             validation()
 
-        cmd = "sudo snap remove microk8s".split()
-        check_call(cmd)
+        # On lxc umount docker overlay is not permitted.
+        try:
+            check_call("sudo grep lxc /proc/1/environ".split())
+        except CalledProcessError:
+            check_call("sudo snap remove microk8s".split())


### PR DESCRIPTION
With this PR we add a test that would start an lxc container, run an sistribution specific `install-deps.sh` script and then run the tests and checn the upgrade path.

We should wire this to our CI to automate the releases to beta.