### PR TITLE
Reset and docker restart will load the right docker-default profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ snap install microk8s --classic --beta
 ```
 
 > At this time microk8s is an early beta, while this should be safe to install please beware.
-> In order to install microk8s make sure port 8080 is not used.
+> In order to install microk8s make sure
+> - port 8080 is not used and
+> - if you have AppArmor enabled (check with `sudo apparmor_status`) you do not have any other [dockerd installed](docs/dockerd.md). You can use the dockerd coming with microk8s.
 
 ### Accessing Kubernetes
 

--- a/docs/dockerd.md
+++ b/docs/dockerd.md
@@ -1,0 +1,14 @@
+# Dockerd in microk8s
+
+The docker daemon used by microk8s is listening on `unix:///var/snap/microk8s/docker.sock`. You can access it with the `microk8s.docker` command. To skip the `microk8s` prefix we suggest you employ a snap alias:
+```
+sudo snap alias microk8s.docker docker
+docker ps
+```
+
+When AppArmor is enabled all docker daemons running in a system will apply the same `docker-default` profile on running containers. Each daemon makes sure that it is the only process manging the docker containers (eg send start stop signals). Effectively this allowes only one dockerd running on any host. Therefore, you have to make sure no other dockerd is running on your sytem along with microk8s.
+
+Restarting microk8s' dockerd (`sudo systemctl restart snap.microk8s.daemon-docker`) or calling the `microk8s.reset` command will ensure the correct AppArmor profile is loaded.
+
+## References
+ - Issue describing the AppArmor profile limitation: https://forum.snapcraft.io/t/commands-and-aliases/3950

--- a/docs/dockerd.md
+++ b/docs/dockerd.md
@@ -6,7 +6,7 @@ sudo snap alias microk8s.docker docker
 docker ps
 ```
 
-When AppArmor is enabled all docker daemons running in a system will apply the same `docker-default` profile on running containers. Each daemon makes sure that it is the only process manging the docker containers (eg send start stop signals). Effectively this allowes only one dockerd running on any host. Therefore, you have to make sure no other dockerd is running on your sytem along with microk8s.
+When AppArmor is enabled all docker daemons running in a system will apply the same `docker-default` profile on running containers. Each daemon makes sure that it is the only process managing the docker containers (e.g., sending start stop signals). Effectively this allowes only one dockerd running on any host. Therefore, you have to make sure no other dockerd is running on your sytem along with microk8s.
 
 Restarting microk8s' dockerd (`sudo systemctl restart snap.microk8s.daemon-docker`) or calling the `microk8s.reset` command will ensure the correct AppArmor profile is loaded.
 

--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -32,5 +32,5 @@ clean_cluster() {
   done
 }
 
-
+sudo systemctl restart snap.${SNAP_NAME}.daemon-docker
 clean_cluster

--- a/microk8s-resources/wrappers/run-docker-with-args
+++ b/microk8s-resources/wrappers/run-docker-with-args
@@ -23,8 +23,10 @@ if [ -d "/etc/apparmor.d" ]; then
     cp ${SNAP}/docker-profile /etc/apparmor.d/docker
   fi
   echo "Reloading AppArmor profiles"
-  service apparmor reload
-  echo "AppArmor patched"
+  if ! service apparmor reload
+  then
+    echo "AppArmor profiles loading failed. AppArmor may be unavailable on this host."
+  fi
 fi
 
 app=dockerd

--- a/microk8s-resources/wrappers/run-docker-with-args
+++ b/microk8s-resources/wrappers/run-docker-with-args
@@ -15,19 +15,16 @@ if [ -d "/etc/apparmor.d" ]; then
     if ! $(grep -qE "snap.microk8s.daemon-docker" /etc/apparmor.d/docker); then
       echo "Patching docker-default profile"
       "$SNAP/bin/sed" 's/^}$/\ \ signal\ (receive)\ peer=snap.microk8s.daemon-docker,\n}/' -i /etc/apparmor.d/docker
-      echo "Reloading AppArmor profiles"
-      service apparmor reload
-      echo "AppArmor patched"
     else
       echo "Docker default profile already patched"
     fi
   else
     echo "Using a docker-default template"
     cp ${SNAP}/docker-profile /etc/apparmor.d/docker
-    echo "Reloading AppArmor profiles"
-    service apparmor reload
-    echo "AppArmor patched"
   fi
+  echo "Reloading AppArmor profiles"
+  service apparmor reload
+  echo "AppArmor patched"
 fi
 
 app=dockerd


### PR DESCRIPTION
This mitigates https://github.com/ubuntu/microk8s/issues/101

We reload the right docker-default profile upon dockerd restart and microk8s.reset.

Also documenting the issue with multiple dockerds and AppArmor.