### PR TITLE
Kube proxy not touching conntrack hashsize in virtual envs

### DIFF
--- a/tests/patch-kube-proxy.sh
+++ b/tests/patch-kube-proxy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "--conntrack-max-per-core=0" >> /var/snap/microk8s/current/args/kube-proxy
+systemctl restart snap.microk8s.daemon-proxy

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -13,6 +13,22 @@ if echo "$*" | grep -q -- 'help'; then
     exit
 fi
 
+function create_machine() {
+  local NAME=$1
+  if ! lxc profile show microk8s
+  then
+    lxc profile copy default microk8s
+  fi
+  cat tests/lxc/microk8s.profile | lxc profile edit microk8s
+
+  lxc launch -p default -p microk8s $DISTRO $NAME
+  trap "lxc delete ${NAME} --force || true" EXIT
+  # Allow for the machine to boot and get an IP
+  sleep 20
+  tar cf - ./tests | lxc exec $NAME -- tar xvf - -C /tmp
+  lxc exec $NAME -- /bin/bash "/tmp/tests/lxc/install-deps/$DISTRO"
+}
+
 set -ue
 
 DISTRO=$1
@@ -20,22 +36,14 @@ NAME=machine-$RANDOM
 FROM_CHANNEL=$2
 TO_CHANNEL=$3
 
-if ! lxc profile show microk8s
-then
-  lxc profile copy default microk8s
-fi
-cat tests/lxc/microk8s.profile | lxc profile edit microk8s
-
-lxc launch -p default -p microk8s $DISTRO $NAME
-trap "lxc delete ${NAME} --force || true" EXIT
-# Allow for the machine to boot and get an IP
-sleep 20
-
-tar cf - ./tests | lxc exec $NAME -- tar xvf - -C /tmp
-lxc exec $NAME -- /bin/bash "/tmp/tests/lxc/install-deps/$DISTRO"
+create_machine $NAME
 lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL} --classic
 lxc exec $NAME -- /tmp/tests/patch-kube-proxy.sh
 lxc exec $NAME -- pytest -s /tmp/tests/test-addons.py
 lxc exec $NAME -- microk8s.reset
-lxc exec $NAME -- snap remove microk8s
+lxc delete $NAME --force
+
+NAME=machine-$RANDOM
+create_machine $NAME
 lxc exec $NAME -- /bin/bash -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /tmp/tests/test-upgrade.py"
+lxc delete $NAME --force

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -37,4 +37,5 @@ lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL} --classic
 lxc exec $NAME -- /tmp/tests/patch-kube-proxy.sh
 lxc exec $NAME -- pytest -s /tmp/tests/test-addons.py
 lxc exec $NAME -- microk8s.reset
+lxc exec $NAME -- snap remove microk8s
 lxc exec $NAME -- /bin/bash -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /tmp/tests/test-upgrade.py"

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -34,6 +34,7 @@ sleep 20
 tar cf - ./tests | lxc exec $NAME -- tar xvf - -C /tmp
 lxc exec $NAME -- /bin/bash "/tmp/tests/lxc/install-deps/$DISTRO"
 lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL} --classic
+lxc exec $NAME -- /tmp/tests/patch-kube-proxy.sh
 lxc exec $NAME -- pytest -s /tmp/tests/test-addons.py
 lxc exec $NAME -- microk8s.reset
 lxc exec $NAME -- /bin/bash -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /tmp/tests/test-upgrade.py"

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -133,7 +133,7 @@ def in_virtual_env():
 
     '''
     try:
-        check_call("sudo grep -E (lxc|hypervisor) /proc/1/environ /proc/cpuinfo".split())
+        check_call("systemd-detect-virt --container".split())
         return True
     except CalledProcessError:
         return False


### PR DESCRIPTION
Our CI cross-distro tests on LXC on top of GCE instances are failing with kube-proxy not starting after a `micrk8s.enable dns`.

This is a workaround (or not?) where the we tell kube-proxy not to update the conntrack hashsize during tests. The issue https://github.com/ubuntu/microk8s/issues/119 is here to further investigate this behavior.

