### PR TITLE
Use script to trigger pytest. CI slaves need this.

### DIFF
--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -29,7 +29,7 @@ function create_machine() {
   lxc exec $NAME -- /bin/bash "/tmp/tests/lxc/install-deps/$DISTRO"
 }
 
-set -ue
+set -uex
 
 DISTRO=$1
 NAME=machine-$RANDOM
@@ -39,11 +39,11 @@ TO_CHANNEL=$3
 create_machine $NAME
 lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL} --classic
 lxc exec $NAME -- /tmp/tests/patch-kube-proxy.sh
-lxc exec $NAME -- pytest -s /tmp/tests/test-addons.py
+lxc exec $NAME -- script -e -c "pytest -s /tmp/tests/test-addons.py"
 lxc exec $NAME -- microk8s.reset
 lxc delete $NAME --force
 
 NAME=machine-$RANDOM
 create_machine $NAME
-lxc exec $NAME -- /bin/bash -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /tmp/tests/test-upgrade.py"
+lxc exec $NAME -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /tmp/tests/test-upgrade.py"
 lxc delete $NAME --force


### PR DESCRIPTION
Seems CI slave do not have a tty and script will create one for us.

https://github.com/lxc/lxd/issues/1724#issuecomment-194416774