### PR TITLE
Reset restarts apiserver thus recreate extension-apiserver-authentica…

### DIFF
--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -33,3 +33,4 @@ clean_cluster() {
 
 sudo systemctl restart snap.${SNAP_NAME}.daemon-docker
 clean_cluster
+sudo systemctl restart snap.${SNAP_NAME}.daemon-apiserver

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -108,7 +108,7 @@ def wait_for_installation():
         else:
             time.sleep(3)
     # Allow rest of the services to come up
-    time.sleep(30)
+    time.sleep(10)
 
 
 def microk8s_enable(addon):
@@ -140,4 +140,5 @@ def microk8s_reset():
     Call microk8s reset
     """
     cmd = '/snap/bin/microk8s.reset'
-    return run_until_success(cmd)
+    run_until_success(cmd)
+    wait_for_installation()

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -217,3 +217,5 @@ def validate_metrics_server():
             pass
         time.sleep(10)
         attempt -= 1
+
+    assert attempt > 0


### PR DESCRIPTION
…tion

Reset cleans configmaps including the extension-apiserver-authentication configmap needed by the metrics server.