### PR TITLE
Fix missing network during restart

### DIFF
--- a/microk8s-resources/wrappers/run-with-config-args
+++ b/microk8s-resources/wrappers/run-with-config-args
@@ -26,6 +26,22 @@ then
       sleep 2
     done
   fi
+elif [ "${app}" = "kube-apiserver" ] || [ "${app}" = "kube-proxy" ]
+then
+  # Check if we advertise an address. If we do we do not need to wait for a default network interface.
+  if ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null
+  then
+    # wait up to a minute for the default network interface to appear.
+    n=0
+    until [ $n -ge 20 ]
+    do
+      ip route | grep default &> /dev/null && break
+      ip -6 route | grep default &> /dev/null && break
+      echo "Waiting for default route to appear. (attempt $n)"
+      n=$[$n+1]
+      sleep 6
+    done
+  fi
 else
   # ensure docker dirs
   mkdir -p $SNAP_COMMON/var/run/docker

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -97,6 +97,7 @@ parts:
     - util-linux
     - zfsutils-linux
     - socat
+    - iproute2
     source: .
     override-build: |
       set -eu


### PR DESCRIPTION
This PR will cause kube-proxy and kube-api wait for a default route to appear. 

Fixes: https://github.com/ubuntu/microk8s/issues/149, https://github.com/ubuntu/microk8s/issues/73

Unfortunately this is a blind fix as I was not able to reproduce the issue. My intention is to have this merged and get @wallyworld to give it a try :) as soon as it gets to edge.