### PR TITLE
Enable digitalSignature key usage for CA

### DIFF
--- a/microk8s-resources/certs/csr.conf
+++ b/microk8s-resources/certs/csr.conf
@@ -28,6 +28,6 @@ IP.2 = 10.152.183.1
 [ v3_ext ]
 authorityKeyIdentifier=keyid,issuer:always
 basicConstraints=CA:FALSE
-keyUsage=keyEncipherment,dataEncipherment
+keyUsage=keyEncipherment,dataEncipherment,digitalSignature
 extendedKeyUsage=serverAuth,clientAuth
 subjectAltName=@alt_names


### PR DESCRIPTION
- fix "KeyUsage does not allow digital signatures" error when
  connecting to api manager with Java based https client