### PR TITLE
Fix Docker docker path in docs

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -22,7 +22,7 @@ microk8s.docker push localhost:32000/my-busybox
 
 If you prefer to use an external docker client you should point it to the socket dockerd is listening on:
 ```
-docker -H unix:///var/snap/microk8s/docker.sock ps
+docker -H unix:///var/snap/microk8s/current/docker.sock ps
 ```
 
 To consume an image from the local registry we need to reference it in our yaml manifests:


### PR DESCRIPTION
Well at least on my system (`bento/ubuntu-18.04` in Vagrant) this is the path the socket ends up at.

Thanks for microk8s, it's great!