### PR TITLE
Faster nvidia test abort

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -141,7 +141,7 @@ def microk8s_enable(addon):
         nv_out = run_until_success("lsmod", timeout_insec=10)
         if "nvidia" not in nv_out:
             print("Not a cuda capable system. Will not test gpu addon")
-            raise CalledProcessError("Nothing to do for gpu")
+            raise CalledProcessError(1, "Nothing to do for gpu")
 
     cmd = '/snap/bin/microk8s.enable {}'.format(addon)
     return run_until_success(cmd, timeout_insec=300)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -141,7 +141,7 @@ def microk8s_enable(addon):
         nv_out = run_until_success("lsmod", timeout_insec=10)
         if "nvidia" not in nv_out:
             print("Not a cuda capable system. Will not test gpu addon")
-            return nv_out
+            raise CalledProcessError("Nothing to do for gpu")
 
     cmd = '/snap/bin/microk8s.enable {}'.format(addon)
     return run_until_success(cmd, timeout_insec=300)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -136,6 +136,13 @@ def microk8s_enable(addon):
         addon: name of the addon
 
     """
+    # NVidia pre-check so as to not wait for a timeout.
+    if addon == 'gpu':
+        nv_out = run_until_success("lsmod", timeout_insec=10)
+        if "nvidia" not in nv_out:
+            print("Not a cuda capable system. Will not test gpu addon")
+            return nv_out
+
     cmd = '/snap/bin/microk8s.enable {}'.format(addon)
     return run_until_success(cmd, timeout_insec=300)
 


### PR DESCRIPTION
We increased the timeouts so our CI will not timeout, but travis fails if the tests run for more than 2 hours.

This PR will cause gpu tests to be aborted quickly in case no nvidia drivers are loaded.