### PR TITLE
Call dpkg from the snap

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -37,7 +37,7 @@ skip_opt_in_config() {
 
 arch() {
     # Return the architecture we are on
-    local ARCH="${KUBE_ARCH:-`dpkg --print-architecture`}"
+    local ARCH="${KUBE_ARCH:-`$SNAP/usr/bin/dpkg --print-architecture`}"
     if [ "$ARCH" = "ppc64el" ]; then
         ARCH="ppc64le"
     elif [ "$ARCH" = "armhf" ]; then

--- a/microk8s-resources/wrappers/microk8s-istioctl.wrapper
+++ b/microk8s-resources/wrappers/microk8s-istioctl.wrapper
@@ -6,7 +6,7 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 export LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu"
 
 source $SNAP/actions/common/utils.sh
-ARCH=$(dpkg --print-architecture)
+ARCH=$(arch)
 if ! [ "${ARCH}" = "amd64" ]
 then
   echo "Istio is not available for ${ARCH}"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -108,6 +108,7 @@ parts:
     - zfsutils-linux
     - socat
     - iproute2
+    - dpkg
     source: .
     override-build: |
       set -eu


### PR DESCRIPTION
This is a fix for the distros that do not have dpkg. Since we are using it to get the architecture we have to have it in our snap. 