### PR TITLE
Ingress to report 127.0.0.1 as address of endpoints

### DIFF
--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -110,3 +110,4 @@ spec:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
         - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
+        - --publish-status-address=127.0.0.1


### PR DESCRIPTION
Fixes: https://github.com/ubuntu/microk8s/issues/222

Ingress tries to get an external IP so it reports no address in `microk8s.kubectl get ingress`. With this PR we tell ingress to report 127.0.0.1.