### PR TITLE
Fix reuse istio binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ To speed-up a build you can reuse the binaries already downloaded from a previou
 ... this build will take a long time and will download all binaries ...
 > cp -r parts/microk8s/build/build/kube_bins .
 > export KUBE_SNAP_BINS=$PWD/kube_bins/v1.10.3/
+> snapcraft clean
 > snapcraft
 ... this build will be much faster and will reuse binaries in KUBE_SNAP_BINS
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -189,7 +189,7 @@ parts:
         # Istio addon
         echo "Preparing istio"
         cp $KUBE_SNAP_BINS/istioctl .
-        mv $KUBE_SNAP_BINS/istio-yaml ./actions/istio
+        cp -r $KUBE_SNAP_BINS/istio-yaml ./actions/istio
       fi
 
       echo "Creating inspect hook"


### PR DESCRIPTION
This PR fixes the re-usability of istio binaries.

The bug was that we were moving the binaries during the first build instead of copying them, so reusing them was not possible.