### PR TITLE
Added automatic bash completion for microk8s.docker microk8s.kubectl …

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -193,36 +193,32 @@ parts:
         echo "Preparing istio"
         cp $KUBE_SNAP_BINS/istioctl .
         cp -r $KUBE_SNAP_BINS/istio-yaml ./actions/istio
+        # Add bash completion for istioctl. This is located here to make sure it is only added when istio is added.
+        if [ -f istioctl ]; then
+          ./istioctl collateral completion --bash -o .
+          sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -F __start_istioctl microk8s.istioctl/g" istioctl.bash
+          sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -o nospace -F __start_istioctl microk8s.istioctl/g" istioctl.bash
+        else
+           echo "NO istioctl FOUND!!!!!!!!!!!!!!! ABORTING istioctl bash completion!!!!!!!!!!!!"
+           exit -1
+        fi
       fi
 
       echo "Creating inspect hook"
       cp $KUBE_SNAP_ROOT/scripts/inspect.sh .
 
-      # create bash completion script for microk8s.docker, microk8s.kubectl and microk8s.istio
-      # create docker completion. At this stage, the latest from the docker repository is used as a basis, it should
-      # probably be replaced with something else which would bring the completion matching the specific version inside
-      # microk8s
+      # Add bash completion for microk8s.docker
+      cp $SNAPCRAFT_STAGE/usr/share/bash-completion/completions/docker docker.bash
+      sed  -i "s/complete -F _docker docker docker.exe dockerd dockerd.exe/complete -F _docker microk8s.docker/g" docker.bash
 
-      curl -L https://raw.githubusercontent.com/docker/cli/master/contrib/completion/bash/docker | sed "s/complete -F _docker docker docker.exe dockerd dockerd.exe/complete -F _docker microk8s.docker/g" > docker.bash
-
-      # Assume kubectl and istioctl are already copied to the current directory
+      # Add bash completion for microk8s.kubectl. 
       if [ -f kubectl ]; then
         ./kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s.kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
       else
          echo "NO kubectl FOUND!!!!!!!!!!!!!!! ABORTING kubectl bash completion!!!!!!!!!!!!"
-         touch kubectl.bash
+         exit -1
       fi
 
-      if [ -f istioctl ]; then
-        ./istioctl collateral completion --bash -o .
-        sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -F __start_istioctl microk8s.istioctl/g" istioctl.bash
-        sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -o nospace -F __start_istioctl microk8s.istioctl/g" istioctl.bash
-      else
-         echo "NO istioctl FOUND!!!!!!!!!!!!!!! ABORTING istioctl bash completion!!!!!!!!!!!!"
-         touch istioctl.bash
-      fi
-
-      # end completion scripts
       snapcraftctl build
 
   # Unfortunately we cannot add package repositories to our snaps

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,8 +41,10 @@ apps:
     daemon: simple
   kubectl:
     command: microk8s-kubectl.wrapper
+    completer: kubectl.bash
   docker:
     command: microk8s-docker.wrapper
+    completer: docker.bash
   inspect:
     command: sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh
   enable:
@@ -61,6 +63,7 @@ apps:
     command: microk8s-reset.wrapper
   istioctl:
     command: microk8s-istioctl.wrapper
+    completer: istioctl.bash
 
 parts:
   libnftnl:
@@ -195,6 +198,31 @@ parts:
       echo "Creating inspect hook"
       cp $KUBE_SNAP_ROOT/scripts/inspect.sh .
 
+      # create bash completion script for microk8s.docker, microk8s.kubectl and microk8s.istio
+      # create docker completion. At this stage, the latest from the docker repository is used as a basis, it should
+      # probably be replaced with something else which would bring the completion matching the specific version inside
+      # microk8s
+
+      curl -L https://raw.githubusercontent.com/docker/cli/master/contrib/completion/bash/docker | sed "s/complete -F _docker docker docker.exe dockerd dockerd.exe/complete -F _docker microk8s.docker/g" > docker.bash
+
+      # Assume kubectl and istioctl are already copied to the current directory
+      if [ -f kubectl ]; then
+        ./kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s.kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
+      else
+         echo "NO kubectl FOUND!!!!!!!!!!!!!!! ABORTING kubectl bash completion!!!!!!!!!!!!"
+         touch kubectl.bash
+      fi
+
+      if [ -f istioctl ]; then
+        ./istioctl collateral completion --bash -o .
+        sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -F __start_istioctl microk8s.istioctl/g" istioctl.bash
+        sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -o nospace -F __start_istioctl microk8s.istioctl/g" istioctl.bash
+      else
+         echo "NO istioctl FOUND!!!!!!!!!!!!!!! ABORTING istioctl bash completion!!!!!!!!!!!!"
+         touch istioctl.bash
+      fi
+
+      # end completion scripts
       snapcraftctl build
 
   # Unfortunately we cannot add package repositories to our snaps

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -194,14 +194,9 @@ parts:
         cp $KUBE_SNAP_BINS/istioctl .
         cp -r $KUBE_SNAP_BINS/istio-yaml ./actions/istio
         # Add bash completion for istioctl. This is located here to make sure it is only added when istio is added.
-        if [ -f istioctl ]; then
-          ./istioctl collateral completion --bash -o .
-          sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -F __start_istioctl microk8s.istioctl/g" istioctl.bash
-          sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -o nospace -F __start_istioctl microk8s.istioctl/g" istioctl.bash
-        else
-           echo "NO istioctl FOUND!!!!!!!!!!!!!!! ABORTING istioctl bash completion!!!!!!!!!!!!"
-           exit -1
-        fi
+        ./istioctl collateral completion --bash -o .
+        sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -F __start_istioctl microk8s.istioctl/g" istioctl.bash
+        sed -i  "s/complete -o default -F __start_istioctl istioctl/complete -o default -o nospace -F __start_istioctl microk8s.istioctl/g" istioctl.bash
       fi
 
       echo "Creating inspect hook"
@@ -212,12 +207,7 @@ parts:
       sed  -i "s/complete -F _docker docker docker.exe dockerd dockerd.exe/complete -F _docker microk8s.docker/g" docker.bash
 
       # Add bash completion for microk8s.kubectl. 
-      if [ -f kubectl ]; then
-        ./kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s.kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
-      else
-         echo "NO kubectl FOUND!!!!!!!!!!!!!!! ABORTING kubectl bash completion!!!!!!!!!!!!"
-         exit -1
-      fi
+      ./kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s.kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
 
       snapcraftctl build
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -188,6 +188,8 @@ parts:
         # Istio support
         rm "actions/enable.istio.sh"
         rm "actions/disable.istio.sh"
+        # added because the completer is still defined
+        touch istioctl.bash
       else
         # Istio addon
         echo "Preparing istio"


### PR DESCRIPTION
…and microk8s.istioctl

Note: the docker bash completion currently gets the latest from the docker repository (while istioctl and kubectl are from the actual binaries). It would be better if in the future we can figure out the exact version and match the completion to that.
For now this should be good enough