### PR TITLE
Adjust default backend targetPort for ingress.yaml

### DIFF
--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -49,7 +49,7 @@ spec:
   ports:
   - port: 80
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   selector:
     app: default-http-backend
 ---


### PR DESCRIPTION
The containerPort in the default-http-backend deployment is defined as 8080, but the service definition is pointing to 80. When I deployed this, I kept getting unreachable upstream errors from nginx. Making this change corrected the problem, which given the container definition, makes sense.