### PR TITLE
Use netstat to get the default interface name

### DIFF
--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -22,7 +22,7 @@ do
        systemctl is-active --quiet snap.microk8s.daemon-apiserver.service
     then
         # Get current IP
-        DEFAULT_INTERFACE="$(ip route | gawk '/default/ { print $5 }' | head -1)"
+        DEFAULT_INTERFACE="$(netstat -rn | grep '^0.0.0.0' | awk '{print $NF}' | head -1)"
         IP_ADDR="$(ifconfig "$DEFAULT_INTERFACE" | grep 'inet ' | gawk '{print $2}' | sed -e 's/addr://')"
         USED_IP_ADDR=$(cat "${SNAP_DATA}"/external_ip.txt)
         if ! [ "$IP_ADDR" == "$USED_IP_ADDR" ]

--- a/microk8s-resources/wrappers/run-with-config-args
+++ b/microk8s-resources/wrappers/run-with-config-args
@@ -45,7 +45,7 @@ then
 
     if ip route | grep default &> /dev/null
     then
-        DEFAULT_INTERFACE="$(ip route | gawk '/default/ { print $5 }' | head -1)"
+        DEFAULT_INTERFACE="$(netstat -rn | grep '^0.0.0.0' | awk '{print $NF}' | head -1)"
         IP_ADDR="$(ifconfig "$DEFAULT_INTERFACE" | grep 'inet ' | gawk '{print $2}' | sed -e 's/addr://')"
         mkdir -p ${SNAP_DATA}/var
         echo ${IP_ADDR} > ${SNAP_DATA}/external_ip.txt


### PR DESCRIPTION
The script that runs detection of new IP addresses fails under Ubuntu 18.04 with the message:

```
microk8s.daemon-apiserver-kicker[29730]: link: error fetching interface information: Device not found
```

In one place, `netstat` is used, and the other two `ip` is. `netstat` appears to work, so use that instead.