### PR TITLE
Add troubleshooting section about log collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ microk8s.stop
 microk8s.start
 ```
 
-### My log collector not collecting any logs.
+### My log collector is not collecting any logs.
 By default docker container logs are located in `/var/lib/docker/containers/{id}/{id}-json.log` but microk8s is packaged with snap and it uses it's own docker. So the logs are located in `/var/snap/microk8s/common/var/lib/docker/containers/{id}/{id}-json.log`. You have to mount this location in your log collector for that to work. Following is an example diff for [fluent-bit](https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/output/elasticsearch/fluent-bit-ds.yaml):
 
 ```diff

--- a/README.md
+++ b/README.md
@@ -176,6 +176,31 @@ microk8s.stop
 microk8s.start
 ```
 
+### My log collector not collecting any logs.
+By default docker container logs are located in `/var/lib/docker/containers/{id}/{id}-json.log` but microk8s is packaged with snap and it uses it's own docker. So the logs are located in `/var/snap/microk8s/common/var/lib/docker/containers/{id}/{id}-json.log`. You have to mount this location in your log collector for that to work. Following is an example diff for [fluent-bit](https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/output/elasticsearch/fluent-bit-ds.yaml):
+
+```diff
+@@ -36,6 +36,9 @@
+         - name: varlibdockercontainers
+           mountPath: /var/lib/docker/containers
+           readOnly: true
++        - name: varlibdockercontainers
++          mountPath: /var/snap/microk8s/common/var/lib/docker/containers/
++          readOnly: true
+         - name: fluent-bit-config
+           mountPath: /fluent-bit/etc/
+       terminationGracePeriodSeconds: 10
+@@ -45,7 +48,7 @@
+           path: /var/log
+       - name: varlibdockercontainers
+         hostPath:
+-          path: /var/lib/docker/containers
++          path: /var/snap/microk8s/common/var/lib/docker/containers/
+       - name: fluent-bit-config
+         configMap:
+           name: fluent-bit-config
+```
+
 ## Building from source
 
 Build the snap with:


### PR DESCRIPTION
I'm migrating my application from docker-compose to kubernetes. While i was doing that i wanted to add efk stack to the mix. I spent some hours before i realized that i was trying to collect logs from an irrelevant docker daemon :)

I wanted to add this to troubleshooting section so that other people can save this time