### PR TITLE
fix uninstall failure when Btrfs is used as the storage driver

### DIFF
--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -9,6 +9,13 @@ snapctl stop ${SNAP_NAME}.daemon-docker 2>&1 || true
 (cat /proc/mounts | grep ${SNAP_COMMON}/var/lib/docker | cut -d ' ' -f 2 | xargs umount) || true
 (cat /proc/mounts | grep ${SNAP_COMMON}/var/run/docker | cut -d ' ' -f 2 | xargs umount) || true
 
+BTRFS_SUBVOL_DIR=${SNAP_COMMON}/var/lib/docker/btrfs/subvolumes/
+if [ -d ${BTRFS_SUBVOL_DIR} ] ; then
+  for snap in $(ls ${BTRFS_SUBVOL_DIR}) ; do
+    btrfs sub del ${BTRFS_SUBVOL_DIR}/${snap} 2>&1 || true
+  done
+fi
+
 #TODO(kjackal): Make sure this works everywhere we want
 if [ -f /etc/apparmor.d/docker ]; then
   echo "Updating docker-default profile"


### PR DESCRIPTION
`snap remove microk8s` fails as follows if the storage driver is Btrfs.

```
$ sudo snap remove microk8s
error: cannot perform the following tasks:
- Remove data for snap "microk8s" (383) (remove /var/snap/microk8s/common/var/lib/docker/btrfs/subvolumes/<id>: operation not permitted)
```

It's because Btrfs subvolumes can't be deleted by rmdir() syscall.
Although this problem disappear if the linux kernel version is
v4.18 or more, it's better to fix it for older kernel users.