### PR TITLE
Use the correct ConfigMap for nginx ingress

### DIFF
--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -109,5 +109,5 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
-        - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
+        - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-microk8s-conf
         $EXTRA_ARGS


### PR DESCRIPTION
By default, the ingress installation seems to use a non-existing ConfigMap and having another one that exists but isn't used is confusing. This switches the controller to use the one that microk8s creates.