### PR TITLE
RBAC addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ With `microk8s.status` you can see the list of available addons and which ones a
 
 #### List of Available Addons
 - **dns**: Deploy kube dns. This addon may be required by others thus we recommend you always enable it. In environments where the external dns servers `8.8.8.8` and `8.8.4.4` are blocked you will need to update the upstream dns servers in `microk8s.kubectl -n kube-system edit configmap/kube-dns` after enabling the addon.
-- **rbac**: Enable RBAC (role-based access control) authorization mode.
+- **rbac**: Enable RBAC (role-based access control) authorization mode. **NOTE**: Most of the other addons will not work with the RBAC addon, since they are not RBAC enabled.
 - **dashboard**: Deploy kubernetes dashboard as well as grafana and influxdb. To access grafana point your browser to the url reported by `microk8s.kubectl cluster-info`.
 - **storage**: Create a default storage class. This storage class makes use of the hostpath-provisioner pointing to a directory on the host. Persistent volumes are created under `${SNAP_COMMON}/default-storage`. Upon disabling this addon you will be asked if you want to delete the persistent volumes created.
 - **ingress**: Create an ingress controller.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ With `microk8s.status` you can see the list of available addons and which ones a
 
 #### List of Available Addons
 - **dns**: Deploy kube dns. This addon may be required by others thus we recommend you always enable it. In environments where the external dns servers `8.8.8.8` and `8.8.4.4` are blocked you will need to update the upstream dns servers in `microk8s.kubectl -n kube-system edit configmap/kube-dns` after enabling the addon.
+- **rbac**: Enable RBAC (role-based access control) authorization mode.
 - **dashboard**: Deploy kubernetes dashboard as well as grafana and influxdb. To access grafana point your browser to the url reported by `microk8s.kubectl cluster-info`.
 - **storage**: Create a default storage class. This storage class makes use of the hostpath-provisioner pointing to a directory on the host. Persistent volumes are created under `${SNAP_COMMON}/default-storage`. Upon disabling this addon you will be asked if you want to delete the persistent volumes created.
 - **ingress**: Create an ingress controller.

--- a/microk8s-resources/actions/disable.rbac.sh
+++ b/microk8s-resources/actions/disable.rbac.sh
@@ -22,7 +22,7 @@ mkdir -p "${SNAP_USER_DATA}/tmp"
 touch "${tmp_manifest}"
 for type in rolebindings roles clusterrolebindings clusterroles; do
     echo -e "---\n" >> "${tmp_manifest}"
-    "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get ${type} --all-namespaces -o yaml >> "${tmp_manifest}"
+    "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get ${type} --all-namespaces --selector kubernetes.io/bootstrapping=rbac-defaults -o yaml >> "${tmp_manifest}"
 done
 "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" delete -f "${tmp_manifest}"
 rm "${tmp_manifest}"

--- a/microk8s-resources/actions/disable.rbac.sh
+++ b/microk8s-resources/actions/disable.rbac.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Disabling RBAC"
+
+echo "Reconfiguring apiserver"
+refresh_opt_in_config "authorization-mode" "AlwaysAllow" kube-apiserver
+sudo systemctl restart snap.${SNAP_NAME}.daemon-apiserver
+apiserver=$(wait_for_service apiserver)
+if [[ $apiserver == fail ]]
+then
+  echo "apiserver did not start on time. Proceeding."
+  sleep 15
+fi
+
+echo "Removing default RBAC resources"
+tmp_manifest="${SNAP_USER_DATA}/tmp/temp.rbac.yaml"
+mkdir -p "${SNAP_USER_DATA}/tmp"
+touch "${tmp_manifest}"
+for type in rolebindings roles clusterrolebindings clusterroles; do
+    echo -e "---\n" >> "${tmp_manifest}"
+    "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get ${type} --all-namespaces -o yaml >> "${tmp_manifest}"
+done
+"$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" delete -f "${tmp_manifest}"
+rm "${tmp_manifest}"
+
+echo "RBAC is disabled"

--- a/microk8s-resources/actions/disable.rbac.sh
+++ b/microk8s-resources/actions/disable.rbac.sh
@@ -21,14 +21,15 @@ else
 fi
 
 echo "Removing default RBAC resources"
+KUBECTL="$SNAP/kubectl --kubeconfig=$SNAP/client.config"
 tmp_manifest="${SNAP_USER_DATA}/tmp/temp.rbac.yaml"
 trap "rm -f '${tmp_manifest}'" EXIT ERR INT TERM
 mkdir -p "${SNAP_USER_DATA}/tmp"
 touch "${tmp_manifest}"
 for type in rolebindings roles clusterrolebindings clusterroles; do
   echo -e "---\n" >> "${tmp_manifest}"
-  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get ${type} --all-namespaces --selector kubernetes.io/bootstrapping=rbac-defaults -o yaml >> "${tmp_manifest}"
+  $KUBECTL get ${type} --all-namespaces --selector kubernetes.io/bootstrapping=rbac-defaults -o yaml >> "${tmp_manifest}"
 done
-"$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" delete -f "${tmp_manifest}"
+$KUBECTL delete -f "${tmp_manifest}"
 
 echo "RBAC is disabled"

--- a/microk8s-resources/actions/disable.rbac.sh
+++ b/microk8s-resources/actions/disable.rbac.sh
@@ -4,6 +4,7 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
+
 echo "Disabling RBAC"
 
 echo "Reconfiguring apiserver"
@@ -14,17 +15,20 @@ if [[ $apiserver == fail ]]
 then
   echo "apiserver did not start on time. Proceeding."
   sleep 15
+else
+  # Seems to need to wait a bit anyway
+  sleep 5
 fi
 
 echo "Removing default RBAC resources"
 tmp_manifest="${SNAP_USER_DATA}/tmp/temp.rbac.yaml"
+trap "rm -f '${tmp_manifest}'" EXIT ERR INT TERM
 mkdir -p "${SNAP_USER_DATA}/tmp"
 touch "${tmp_manifest}"
 for type in rolebindings roles clusterrolebindings clusterroles; do
-    echo -e "---\n" >> "${tmp_manifest}"
-    "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get ${type} --all-namespaces --selector kubernetes.io/bootstrapping=rbac-defaults -o yaml >> "${tmp_manifest}"
+  echo -e "---\n" >> "${tmp_manifest}"
+  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get ${type} --all-namespaces --selector kubernetes.io/bootstrapping=rbac-defaults -o yaml >> "${tmp_manifest}"
 done
 "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" delete -f "${tmp_manifest}"
-rm "${tmp_manifest}"
 
 echo "RBAC is disabled"

--- a/microk8s-resources/actions/enable.rbac.sh
+++ b/microk8s-resources/actions/enable.rbac.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Enabling RBAC"
+
+echo "Reconfiguring apiserver"
+refresh_opt_in_config "authorization-mode" "RBAC" kube-apiserver
+sudo systemctl restart snap.${SNAP_NAME}.daemon-apiserver
+
+echo "RBAC is enabled"

--- a/microk8s-resources/wrappers/microk8s-status.wrapper
+++ b/microk8s-resources/wrappers/microk8s-status.wrapper
@@ -80,7 +80,7 @@ function format_output() {
     if [ "$status" = "Running" ]
     then
       get_all="$($KUBECTL get all --all-namespaces 2>&1)"
-      get_all="$get_all\n$(kubectl get clusterroles --show-kind --no-headers 2>&1)"
+      get_all="$get_all\n$($KUBECTL get clusterroles --show-kind --no-headers 2>&1)"
       for a in "${!addon[@]}"
       do
         if echo "$get_all" | grep "${addon[$a]}" &> /dev/null

--- a/microk8s-resources/wrappers/microk8s-status.wrapper
+++ b/microk8s-resources/wrappers/microk8s-status.wrapper
@@ -12,6 +12,7 @@ KUBECTL="$SNAP/kubectl --kubeconfig=$SNAP/client.config"
 # Arrray of what we query per addon
 declare -A addon
 addon[dns]="pod/kube-dns"
+addon[rbac]="clusterrole.rbac.authorization.k8s.io/cluster-admin"
 addon[dashboard]="pod/kubernetes-dashboard"
 addon[ingress]="pod/nginx-ingress-microk8s-controller"
 addon[storage]="pod/hostpath-provisioner"
@@ -79,6 +80,7 @@ function format_output() {
     if [ "$status" = "Running" ]
     then
       get_all="$($KUBECTL get all --all-namespaces 2>&1)"
+      get_all="$get_all\n$(kubectl get clusterroles --show-kind --no-headers 2>&1)"
       for a in "${!addon[@]}"
       do
         if echo "$get_all" | grep "${addon[$a]}" &> /dev/null

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -15,6 +15,7 @@ from validators import (
     validate_fluentd,
     validate_jaeger,
     validate_linkerd,
+    validate_rbac,
 )
 from utils import (
     microk8s_enable,
@@ -174,3 +175,15 @@ class TestAddons(object):
         validate_linkerd()
         print("Disabling Linkerd")
         microk8s_disable("linkerd")
+
+    def test_rbac_addon(self):
+        """
+        Test RBAC.
+
+        """
+        print("Enabling RBAC")
+        microk8s_enable("rbac")
+        print("Validating RBAC")
+        validate_rbac()
+        print("Disabling RBAC")
+        microk8s_disable("rbac")

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -283,3 +283,12 @@ def validate_linkerd():
     kubectl("apply -f {}".format(manifest))
     wait_for_pod_state("", "emojivoto", "running", label="app=emoji-svc")
     kubectl("delete -f {}".format(manifest))
+    
+def validate_rbac():
+    """
+    Validate RBAC is actually on
+    """
+    output = kubectl("auth can-i --as=system:serviceaccount:default:default view pod")
+    assert "no" in output
+    output = kubectl("auth can-i --as=admin --as-group=system:masters view pod")
+    assert "yes" in output

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -283,12 +283,12 @@ def validate_linkerd():
     kubectl("apply -f {}".format(manifest))
     wait_for_pod_state("", "emojivoto", "running", label="app=emoji-svc")
     kubectl("delete -f {}".format(manifest))
-    
+
 def validate_rbac():
     """
     Validate RBAC is actually on
     """
-    output = kubectl("auth can-i --as=system:serviceaccount:default:default view pod")
+    output = kubectl("auth can-i --as=system:serviceaccount:default:default view pod", err_out='no')
     assert "no" in output
     output = kubectl("auth can-i --as=admin --as-group=system:masters view pod")
     assert "yes" in output


### PR DESCRIPTION
This PR will add a RBAC addon.

When enabled, the kube-apiserver `authorization-mode` will be set to `RBAC`. Kubernetes will then automatically add all default (cluster-)roles and (cluster-)rolebindings.

When disabled, the `authorization-mode` will be reset to `AlwaysAllow`, and all the (cluster-)roles and (cluster-)rolebindings labeled `kubernetes.io/bootstrapping=rbac-defaults` will be removed.

This PR is based on feature/containerd-access at this time since it needs the added features of PR #323.

Todo:
- ~Add label when finding resources to delete.~
- Provide warning if user is using insecure port as per comment from @ktsakalozos in #323.
- ~Add tests.~
- ~Disabling addin works first time, then fails.~