### PR TITLE
Use ClusterFirstWithHostNet for nginx dnsPolicy

### DIFF
--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -81,6 +81,7 @@ spec:
       terminationGracePeriodSeconds: 60
       # hostPort doesn't work with CNI, so we have to use hostNetwork instead
       # see https://github.com/kubernetes/kubernetes/issues/23920
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       serviceAccountName: nginx-ingress-microk8s-serviceaccount
       containers:


### PR DESCRIPTION
The nginx ingress pod is created with `hostNet: true`. This means that
it does not, by default, have access to kuebdns. We need that so that
the ingress controller can map things like ExternalName services to
internal services.

This fixes the problem by setting the dnsPolicy to
ClusterFirstWithHostNet.

Fixes #339