### PR TITLE
Use snapcraft docker image from beta tag as it builds more often

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 services: [docker]
 
 script:
-  - docker run -v $(pwd):$(pwd) -w $(pwd) snapcore/snapcraft:stable sh -c "apt update && snapcraft"
+  - docker run -v $(pwd):$(pwd) -w $(pwd) snapcore/snapcraft:beta sh -c "apt update && snapcraft"
   - sudo apt update
   - sudo apt install --yes snapd
   - sudo snap install *.snap --classic --dangerous


### PR DESCRIPTION
snapcraft docker image is too old. We use the one from beta to get a newer.