### PR TITLE
Use newer containerd and runc versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 services: [docker]
 
 script:
-  - docker run -v $(pwd):$(pwd) -w $(pwd) snapcore/snapcraft:stable sh -c "apt update && snapcraft"
+  - docker run -v $(pwd):$(pwd) -w $(pwd) snapcore/snapcraft:beta sh -c "apt update && snapcraft"
   - sudo apt update
   - sudo apt install --yes snapd
   - sudo snap install *.snap --classic --dangerous

--- a/build-scripts/prepare-env.sh
+++ b/build-scripts/prepare-env.sh
@@ -15,10 +15,10 @@ export ETCD_VERSION="${ETCD_VERSION:-v3.3.4}"
 export CNI_VERSION="${CNI_VERSION:-v0.7.1}"
 export ISTIO_VERSION="${ISTIO_VERSION:-v1.0.5}"
 # RUNC commit matching the containerd release commit
-# Tag 1.2.2
-export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-9754871865f7fe2f4e74d43e2fc7ccd237edcbce}"
-# Release v1.0.0~rc6
-export RUNC_COMMIT="${RUNC_COMMIT:-ccb5efd37fb7c86364786e9137e22948751de7ed}"
+# Tag 1.2.4
+export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-e6b3f5632f50dbc4e9cb6288d911bf4f5e95b18e}"
+# Release v1.0.0~rc6 with CVE-2019-5736 fix
+export RUNC_COMMIT="${RUNC_COMMIT:-6635b4f0c6af3810594d2770f662f34ddc15b40d}"
 
 export KUBE_TRACK="${KUBE_TRACK:-}"
 export KUBE_SNAP_BINS="${KUBE_SNAP_BINS:-}"

--- a/docs/community.md
+++ b/docs/community.md
@@ -15,9 +15,9 @@ Feel free to update the table below by submitting a Pull Request.
 | [Get into Kubernetes with MicroK8s](https://medium.com/devopslinks/get-into-kubernetes-with-microk8s-85f0e0231c4a) | Milindu S. Kumarage | medium.com | 06-Jan-2019 |
 | [Serverless MicroK8s Kubernetes](https://medium.com/@bluszcz/serverless-microk8s-kubernetes-fcd6b875cd33) | Rafał bluszcz Zawadzki | medium.com | 06-Jan-2019 |
 | [Deploy OpenFaaS with MicroK8s](https://johnmccabe.net/technology/projects/openfaas-on-microk8s/) | John McCabe | johnmccabe.net | 01-Jan-2019 |
-| [Docker desktop, microk8s and the battle for the k8s laptop](https://blog.linnovate.net/docker-desktop-microk8s-and-the-battle-for-the-k8s-laptop-8d3fb50dd543) | liorkesos | blog.linnovate.net | 18-Dec-2019 |
-| [Canonical Launches MicroK8s](http://www.linux-magazine.com/Online/News/Canonical-Launches-MicroK8s) | Swapnil Bhartiya | linux-magazine.com | 12-Dec-2019 |
-| [Kubernetes single node cluster using microk8s](https://www.youtube.com/watch?v=FEELm-o__gU) | Just me and Opensource | youtube.com | 02-Dec-2019 |
+| [Docker desktop, microk8s and the battle for the k8s laptop](https://blog.linnovate.net/docker-desktop-microk8s-and-the-battle-for-the-k8s-laptop-8d3fb50dd543) | liorkesos | blog.linnovate.net | 18-Dec-2018 |
+| [Canonical Launches MicroK8s](http://www.linux-magazine.com/Online/News/Canonical-Launches-MicroK8s) | Swapnil Bhartiya | linux-magazine.com | 12-Dec-2018 |
+| [Kubernetes single node cluster using microk8s](https://www.youtube.com/watch?v=FEELm-o__gU) | Just me and Opensource | youtube.com | 02-Dec-2018 |
 | [Getting started with Kubeflow (machine learning toolkit for Kubernetes) via Microk8s and Multipass](https://github.com/leigh-johnson/kubeflow-microk8s-demo) | Leigh Johnson | github.com | 20-Nov-2018 |
 | [Kubernetes CICD Hacks with MicroK8s and Kubeflow](https://www.youtube.com/watch?v=1SSvS2w5OMQ), KubeCon China 2018 | Land Lu, Zhang Lei Mao from Canonical | KubeCon 2018 | 14-Nov-2018 |
 | [Kubernetes On A Laptop](https://kubedex.com/local-kubernetes/) | Steven Acreman | kubedex.com | 03-Nov-2018 |

--- a/microk8s-resources/actions/disable.ingress.sh
+++ b/microk8s-resources/actions/disable.ingress.sh
@@ -7,7 +7,7 @@ source $SNAP/actions/common/utils.sh
 echo "Disabling Ingress"
 
 ARCH=$(arch)
-TAG="0.15.0"
+TAG="0.22.0"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 if [ "${ARCH}" = arm64 ]
 then

--- a/microk8s-resources/actions/enable.ingress.sh
+++ b/microk8s-resources/actions/enable.ingress.sh
@@ -7,7 +7,7 @@ source $SNAP/actions/common/utils.sh
 echo "Enabling Ingress"
 
 ARCH=$(arch)
-TAG="0.15.0"
+TAG="0.22.0"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 if [ "${ARCH}" = arm64 ]
 then

--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -81,6 +81,7 @@ spec:
       terminationGracePeriodSeconds: 60
       # hostPort doesn't work with CNI, so we have to use hostNetwork instead
       # see https://github.com/kubernetes/kubernetes/issues/23920
+      dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       serviceAccountName: nginx-ingress-microk8s-serviceaccount
       containers:
@@ -109,5 +110,5 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
-        - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
+        - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-microk8s-conf
         $EXTRA_ARGS


### PR DESCRIPTION
This change uses a newer containerd and runc mainly so that we have the fix for CVE-2019-5736.