### PR TITLE
fix: delete CRDs on reset

### DIFF
--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -21,6 +21,9 @@ clean_cluster() {
     $KUBECTL delete $REMOVEABLE_NSES
   fi
 
+  echo "Removing CRDs"
+  $KUBECTL delete --all customresourcedefinitions.apiextensions.k8s.io
+
   # Wait for 200 secs at most.
   echo "Waiting for kubernetes resources to be released"
   n=0


### PR DESCRIPTION
This change removes installed CRDs when microk8s.reset is executed. I find it useful, particularly for people playing with CRDs and Custom Operators, like myself.

See #261 