### PR TITLE
Fix packages that need patchelf

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -129,6 +129,13 @@ parts:
       # snapcraftctl build
     organize:
       containerd/install/bin/*: bin/
+    stage-packages:
+    - conntrack
+    - aufs-tools
+    - gawk
+    - sed
+    - libssl1.0.0
+    - coreutils
     stage:
     - -sbin/xtables-multi
     - -sbin/iptables*
@@ -148,12 +155,6 @@ parts:
     - socat
     - iproute2
     - dpkg
-    - conntrack
-    - aufs-tools
-    - gawk
-    - sed
-    - libssl1.0.0
-    - coreutils
     source: .
     override-build: |
       set -eu


### PR DESCRIPTION
These libraries if pot patchelfed use libraries from the host and may fail if the used libs are missing. 

Fixes: https://github.com/ubuntu/microk8s/issues/370

We need to investigate if the rest of the libraries need to be patchelfed: https://github.com/ubuntu/microk8s/issues/371