### PR TITLE
Add caching of juju images if available.

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -117,3 +117,11 @@ produce_server_cert() {
     openssl req -new -key ${SNAP_DATA}/certs/server.key -out ${SNAP_DATA}/certs/server.csr -config ${SNAP_DATA}/certs/csr.conf
     openssl x509 -req -in ${SNAP_DATA}/certs/server.csr -CA ${SNAP_DATA}/certs/ca.crt -CAkey ${SNAP_DATA}/certs/ca.key -CAcreateserial -out ${SNAP_DATA}/certs/server.crt -days 100000 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
 }
+
+maybe_cache_juju_operator_images() {
+    if [ ! -f /snap/bin/juju.cache-images ]; then
+        echo "No supported version of Juju installed."
+        exit 0
+    fi
+    /snap/bin/juju.cache-images
+}

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -99,3 +99,10 @@ then
     systemctl restart snap.${SNAP_NAME}.daemon-apiserver.service
     systemctl restart snap.${SNAP_NAME}.daemon-proxy.service
 fi
+
+# Cache Juju image if juju is present and this is an install/refresh
+if [ ! -e ${SNAP_DATA}/.cache-juju-image ]
+then
+   maybe_cache_juju_operator_images >> /tmp/mk8s.log
+   touch ${SNAP_DATA}/.cache-juju-image
+fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -32,3 +32,4 @@ chmod 644 ${SNAP_DATA}/credentials/client.config
 $SNAP/bin/sed -i 's/PASSWORD/'"${admin_token}"'/g' ${SNAP_DATA}/credentials/client.config
 ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
 $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/client.config
+

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Ensure juju images get cached if needed on refresh
+rm -fr ${SNAP_DATA}/.cache-juju-image


### PR DESCRIPTION
If Juju is installed when Microk8s is installed or refreshed cache the operator images that Juju uses for Caas.

There is similar work going into the Juju snap that checks for Microk8s and caches if found, as well as work going into Juju that will treat Microk8s as a built in k8s provider (much like how LXD is if installed on the system).