### PR TITLE
Use ip and not ifconfig for IP detection

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -95,8 +95,13 @@ wait_for_service() {
 get_default_ip() {
     # Get the IP of the default interface
     local DEFAULT_INTERFACE="$($SNAP/bin/netstat -rn | $SNAP/bin/grep '^0.0.0.0' | $SNAP/usr/bin/gawk '{print $NF}' | head -1)"
-    local IP_ADDR="$($SNAP/sbin/ifconfig "$DEFAULT_INTERFACE" | $SNAP/bin/grep 'inet ' | $SNAP/usr/bin/gawk '{print $2}' | $SNAP/bin/sed -e 's/addr://')"
-    echo ${IP_ADDR}
+    local IP_ADDR="$($SNAP/sbin/ip -o -4 addr list "$DEFAULT_INTERFACE" | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1)"
+    if [[ -z "$IP_ADDR" ]]
+    then
+        echo "none"
+    else
+        echo "${IP_ADDR}"
+    fi
 }
 
 
@@ -108,7 +113,7 @@ produce_server_cert() {
     local IP_ADDR="$1"
 
     cp ${SNAP}/certs/csr.conf.template ${SNAP_DATA}/certs/csr.conf
-    if ! [ "$IP_ADDR" == "127.0.0.1" ] && ! [ "$IP_ADDR" == "" ]
+    if ! [ "$IP_ADDR" == "127.0.0.1" ] && ! [ "$IP_ADDR" == "none" ]
     then
         "$SNAP/bin/sed" -i 's/#MOREIPS/IP.3 = '"${IP_ADDR}"'/g' ${SNAP_DATA}/certs/csr.conf
     else

--- a/microk8s-resources/wrappers/microk8s-config.wrapper
+++ b/microk8s-resources/wrappers/microk8s-config.wrapper
@@ -4,6 +4,8 @@ set -eu
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 
+source $SNAP/actions/common/utils.sh
+
 USE_LOOPBACK=false
 PARSED=$(getopt --options=lho: --longoptions=use-loopback,help,output: --name "$@" -- "$@")
 eval set -- "$PARSED"
@@ -37,7 +39,6 @@ done
 if [[ "$USE_LOOPBACK" == "true" ]]; then
     cat "$SNAP_DATA/credentials/client.config"
 else
-    DEFAULT_INTERFACE="$(netstat -rn | grep '^0.0.0.0' | awk '{print $NF}' | head -1)"
-    IP_ADDR="$(ifconfig "$DEFAULT_INTERFACE" | grep 'inet ' | "$SNAP/usr/bin/gawk" '{print $2}' | "$SNAP/bin/sed" -e 's/addr://')"
+    IP_ADDR="$(get_default_ip)"
     "$SNAP/bin/sed" -e "s/127.0.0.1/$IP_ADDR/" "$SNAP_DATA/credentials/client.config"
 fi

--- a/microk8s-resources/wrappers/run-with-config-args
+++ b/microk8s-resources/wrappers/run-with-config-args
@@ -46,9 +46,7 @@ then
 
     if ip route | grep default &> /dev/null
     then
-
-        DEFAULT_INTERFACE="$(netstat -rn | grep '^0.0.0.0' | gawk '{print $NF}' | head -1)"
-        IP_ADDR="$(ifconfig "$DEFAULT_INTERFACE" | grep 'inet ' | gawk '{print $2}' | sed -e 's/addr://')"
+        IP_ADDR="$(get_default_ip)"
         mkdir -p ${SNAP_DATA}/var
         echo ${IP_ADDR} > ${SNAP_DATA}/external_ip.txt
     fi


### PR DESCRIPTION
Seems ifconfig output is locale sensitive so we use ip to extract the IP.

We also improve the case where no IP is detected.

Fixes: https://github.com/ubuntu/microk8s/issues/402 https://github.com/ubuntu/microk8s/issues/395 https://github.com/ubuntu/microk8s/issues/400