### PR TITLE
Drain node before stopping it

### DIFF
--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -3,6 +3,8 @@
 set -eu
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+source $SNAP/actions/common/utils.sh
+
 
 if ! sudo snap start ${SNAP_NAME} --enable
 then
@@ -15,3 +17,6 @@ else
     sudo rm ${SNAP_DATA}/var/lock/stopped.lock &> /dev/null
   fi
 fi
+
+echo "Enabling pod scheduling"
+uncordon_node

--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -6,6 +6,30 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 source $SNAP/actions/common/utils.sh
 
 
+PARSED=$(getopt --options=lho: --longoptions=help,output: --name "$@" -- "$@")
+eval set -- "$PARSED"
+while true; do
+    case "$1" in
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo
+            echo "Start Kubernetes services"
+            echo
+            echo "Options:"
+            echo " -h, --help          Show this help"
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "$0: invalid option -- $1"
+            exit 1
+    esac
+done
+
+
 if ! sudo snap start ${SNAP_NAME} --enable
 then
   echo 'Failed to start microk8s services. Check snapd logs with "journalctl -u snapd.service"'

--- a/microk8s-resources/wrappers/microk8s-stop.wrapper
+++ b/microk8s-resources/wrappers/microk8s-stop.wrapper
@@ -6,13 +6,46 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 
 source $SNAP/actions/common/utils.sh
 
-echo "Disabling pod scheduling"
-drain_node
+FORCE=false
+PARSED=$(getopt --options=lho: --longoptions=force,help,output: --name "$@" -- "$@")
+eval set -- "$PARSED"
+while true; do
+    case "$1" in
+        -f|--force)
+            FORCE=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo
+            echo "Stop Kubernetes services"
+            echo
+            echo "Options:"
+            echo " -h, --help          Show this help"
+            echo " -f, --force         Stop services without draining the node"
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "$0: invalid option -- $1"
+            exit 1
+    esac
+done
+
+
+if [[ "$FORCE" == "false" ]]
+then
+    echo "Disabling pod scheduling"
+    drain_node
+fi
 
 if ! sudo snap stop ${SNAP_NAME} --disable
 then
-  echo 'Failed to stop microk8s services. Check snapd logs with "journalctl -u snapd.service"'
-  exit 1
+    echo 'Failed to stop microk8s services. Check snapd logs with "journalctl -u snapd.service"'
+    exit 1
 else
-  sudo touch ${SNAP_DATA}/var/lock/stopped.lock
+    sudo touch ${SNAP_DATA}/var/lock/stopped.lock
 fi

--- a/microk8s-resources/wrappers/microk8s-stop.wrapper
+++ b/microk8s-resources/wrappers/microk8s-stop.wrapper
@@ -4,6 +4,11 @@ set -eu
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 
+source $SNAP/actions/common/utils.sh
+
+echo "Disabling pod scheduling"
+drain_node
+
 if ! sudo snap stop ${SNAP_NAME} --disable
 then
   echo 'Failed to stop microk8s services. Check snapd logs with "journalctl -u snapd.service"'

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -10,10 +10,10 @@ snapctl stop ${SNAP_NAME}.daemon-containerd 2>&1 || true
 # because the mount points are busy
 sleep 10
 
-(cat /proc/mounts | grep ${SNAP_COMMON}/var/lib/kubelet/pods | cut -d ' ' -f 2 | xargs umount) || true
+(cat /proc/mounts | grep ${SNAP_COMMON}/var/lib/kubelet/pods | cut -d ' ' -f 2 | xargs umount -l) || true
 # in case this is a pre root-dir fix deployment
-(cat /proc/mounts | grep ${SNAP_COMMON}/pods | cut -d ' ' -f 2 | xargs umount) || true
-(cat /proc/mounts | grep ${SNAP_COMMON}/var/lib/containerd | cut -d ' ' -f 2 | xargs umount) || true
+(cat /proc/mounts | grep ${SNAP_COMMON}/pods | cut -d ' ' -f 2 | xargs umount -l) || true
+(cat /proc/mounts | grep ${SNAP_COMMON}/var/lib/containerd | cut -d ' ' -f 2 | xargs umount -l) || true
 (cat /proc/mounts | grep ${SNAP_COMMON}/run/containerd | cut -d ' ' -f 2 | xargs umount) || true
-(cat /proc/mounts | grep ${SNAP_COMMON}/var/lib/docker | cut -d ' ' -f 2 | xargs umount) || true
+(cat /proc/mounts | grep ${SNAP_COMMON}/var/lib/docker | cut -d ' ' -f 2 | xargs umount -l) || true
 (cat /proc/mounts | grep ${SNAP_COMMON}/var/run/docker | cut -d ' ' -f 2 | xargs umount) || true


### PR DESCRIPTION
This PR fixes two issues.
- The remove will hang incase a pod has mounted a filesystem that cannot be umounted. For example an nfs server is down
- The start/stop commands will uncordon/cordon, this way any mounted PVCs will be released and we will be able to remove the snap when microk8s is stopped.

We also pave the way to handle daemon restarts during new releases.