### PR TITLE
Fix socat needing patchelf (ubuntu/microk8s#286)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -136,6 +136,7 @@ parts:
     - aufs-tools
     - gawk
     - sed
+    - socat
     - grep
     - libssl1.0.0
     - coreutils
@@ -157,7 +158,6 @@ parts:
     - net-tools
     - util-linux
     - zfsutils-linux
-    - socat
     - iproute2
     source: .
     override-build: |


### PR DESCRIPTION
On Fedora 29, when using port forward, socat failed with:

    error while loading shared libraries: libnsl.so.1:
    cannot open shared object file: No such file or directory