### PR TITLE
adds command to make iptables -P FORWARD ACCEPT save

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,10 @@ The [Kubenet](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-stor
 Make sure packets to/from the pod network interface can be forwarded
 to/from the default interface on the host:
 
-`sudo iptables -P FORWARD ACCEPT`
+```
+sudo iptables -P FORWARD ACCEPT
+sudo apt-get install iptables-persistent # this package allows you to persist this iptable rule across reboot
+```
 
 or, if using `ufw`:
 

--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ The [Kubenet](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-stor
 
 ### My pods can't reach the internet or each other (but my MicroK8s host machine can).
 Make sure packets to/from the pod network interface can be forwarded
-to/from the default interface on the host:
+to/from the default interface on the host via the iptables tool.  As shown below such changes can be made persistent via installation of the iptables-persistent package:
 
 ```
 sudo iptables -P FORWARD ACCEPT
-sudo apt-get install iptables-persistent # this package allows you to persist this iptable rule across reboot
+sudo apt-get install iptables-persistent
 ```
 
 or, if using `ufw`:

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -95,6 +95,7 @@ function suggest_fixes {
   then
       printf -- '\033[0;33m WARNING: \033[0m IPtables FORWARD policy is DROP. '
       printf -- 'Consider enabling traffic forwarding with: sudo iptables -P FORWARD ACCEPT \n'
+      printf -- 'You can make this change persistent with sudo apt-get install iptables-persistent \n'
   fi
 
   ufw=$(ufw status)

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -95,7 +95,7 @@ function suggest_fixes {
   then
       printf -- '\033[0;33m WARNING: \033[0m IPtables FORWARD policy is DROP. '
       printf -- 'Consider enabling traffic forwarding with: sudo iptables -P FORWARD ACCEPT \n'
-      printf -- 'You can make this change persistent with sudo apt-get install iptables-persistent \n'
+      printf -- 'The change can be made persistent with: sudo apt-get install iptables-persistent\n'
   fi
 
   ufw=$(ufw status)


### PR DESCRIPTION
I just got bit by this the other day.  It looked like a DNS issue that other users had in the past, so I geared up to diagnose DNS issues (2hr because I was quite rusty with docker).  Then I realized that it was a complete network issue after pinging 8.8.8.8 and getting nothing which luckily reminded me of a blog post where a guy lost tons of time diagnosing the issue.  I hope there weren't technical reasons why this package wasn't added to the readme.  