### PR TITLE
Add link to Cilium MicroK8s guide

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -6,6 +6,7 @@ Feel free to update the table below by submitting a Pull Request.
 
 | Event/Mention                                          | Author(s)       | Source     | Date          |
 |---------------------------------------------------------------------|--------------|----------|---------------|
+| [Getting Started with Cilium on Microk8s](https://docs.cilium.io/en/stable/gettingstarted/microk8s/)| Joe Stringer | docs.cilium.io | 23-Apr-2019 |
 | [Single-User Production on Microk8s](https://transcrob.es/post/single-user-prod-microk8s/)| Anton Melser | transcrob.es | 05-Feb-2019 |
 | [MicroK8s, Part 3: How To Deploy a Pod in Kubernetes](https://virtualizationreview.com/articles/2019/02/01/microk8s-part-3-how-to-deploy-a-pod-in-kubernetes.aspx)| Tom Fenton | virtualizationreview.com | 02-Feb-2019 |
 | [MicroK8s, Part 2: How To Monitor and Manage Kubernetes](https://virtualizationreview.com/articles/2019/01/30/microk8s-part-2-how-to-monitor-and-manage-kubernetes.aspx)| Tom Fenton | virtualizationreview.com | 30-Jan-2019 |


### PR DESCRIPTION
There's a short guide in the Cilium docs about how to bootstrap microk8s with Cilium providing the networking/security as a CNI. Add it to the community links.