### PR TITLE
Start/stop will not drain/uncordon the node

### DIFF
--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -41,6 +41,3 @@ else
     sudo rm ${SNAP_DATA}/var/lock/stopped.lock &> /dev/null
   fi
 fi
-
-echo "Enabling pod scheduling"
-uncordon_node

--- a/microk8s-resources/wrappers/microk8s-stop.wrapper
+++ b/microk8s-resources/wrappers/microk8s-stop.wrapper
@@ -11,10 +11,6 @@ PARSED=$(getopt --options=lho: --longoptions=force,help,output: --name "$@" -- "
 eval set -- "$PARSED"
 while true; do
     case "$1" in
-        -f|--force)
-            FORCE=true
-            shift
-            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo
@@ -22,7 +18,6 @@ while true; do
             echo
             echo "Options:"
             echo " -h, --help          Show this help"
-            echo " -f, --force         Stop services without draining the node"
             exit 0
             ;;
         --)
@@ -35,12 +30,6 @@ while true; do
     esac
 done
 
-
-if [[ "$FORCE" == "false" ]]
-then
-    echo "Disabling pod scheduling"
-    drain_node
-fi
 
 if ! sudo snap stop ${SNAP_NAME} --disable
 then


### PR DESCRIPTION
Fixes: https://github.com/ubuntu/microk8s/issues/468

The user will have to drain the node himself if he wished to right before stopping MicroK8s.
