### PR TITLE
update the csr.conf when csr.conf.template changed.

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -156,7 +156,7 @@ produce_server_cert() {
         echo "changeme" >  "${SNAP_DATA}/certs/csr.conf" 
     fi
 
-    if ! cmp -s "${SNAP_DATA}/certs/csr.conf.rendered" "${SNAP_DATA}/certs/csr.conf"; then
+    if ! "${SNAP}/usr/bin/cmp" -s "${SNAP_DATA}/certs/csr.conf.rendered" "${SNAP_DATA}/certs/csr.conf"; then
       cp ${SNAP_DATA}/certs/csr.conf.rendered ${SNAP_DATA}/certs/csr.conf
       openssl req -new -key ${SNAP_DATA}/certs/server.key -out ${SNAP_DATA}/certs/server.csr -config ${SNAP_DATA}/certs/csr.conf
       openssl x509 -req -in ${SNAP_DATA}/certs/server.csr -CA ${SNAP_DATA}/certs/ca.crt -CAkey ${SNAP_DATA}/certs/ca.key -CAcreateserial -out ${SNAP_DATA}/certs/server.crt -days 100000 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
@@ -170,14 +170,14 @@ produce_server_cert() {
 render_csr_conf() {
     # Render csr.conf.template to csr.conf.rendered
 
-    local IP_ADDR="$(get_ips)"
+    local IP_ADDRESSES="$(get_ips)"
 
     cp ${SNAP_DATA}/certs/csr.conf.template ${SNAP_DATA}/certs/csr.conf.rendered
-    if ! [ "$IP_ADDR" == "127.0.0.1" ] && ! [ "$IP_ADDR" == "none" ]
+    if ! [ "$IP_ADDRESSES" == "127.0.0.1" ] && ! [ "$IP_ADDRESSES" == "none" ]
     then
         local ips='' sep=''
         local -i i=3
-        for IP_ADDR in "$@"; do
+        for IP_ADDR in $(echo "$IP_ADDRESSES"); do
             ips+="${sep}IP.$((i++)) = ${IP_ADDR}"
             sep='\n'
         done

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -143,7 +143,9 @@ get_ips() {
 
 
 produce_server_cert() {
-    # Produce the server certificate adding the IP passed as a parameter
+    # Produce the server certificates based on the rendered csr.conf.rendered.
+    # The file csr.conf.rendered is compared with csr.conf to determine if a regeneration of server certs must be done.
+    #
     # Returns 
     #  0 if no change
     #  1 otherwise. 
@@ -155,20 +157,18 @@ produce_server_cert() {
     fi
 
     if ! cmp -s "${SNAP_DATA}/certs/csr.conf.rendered" "${SNAP_DATA}/certs/csr.conf"; then
-      echo "CSR modified."
       cp ${SNAP_DATA}/certs/csr.conf.rendered ${SNAP_DATA}/certs/csr.conf
       openssl req -new -key ${SNAP_DATA}/certs/server.key -out ${SNAP_DATA}/certs/server.csr -config ${SNAP_DATA}/certs/csr.conf
       openssl x509 -req -in ${SNAP_DATA}/certs/server.csr -CA ${SNAP_DATA}/certs/ca.crt -CAkey ${SNAP_DATA}/certs/ca.key -CAcreateserial -out ${SNAP_DATA}/certs/server.crt -days 100000 -extensions v3_ext -extfile ${SNAP_DATA}/certs/csr.conf
-      return 1
+      echo "1"
     else
-      echo "No changes"
-      return 0
+      echo "0"
     fi
 
 }
 
 render_csr_conf() {
-    # Render csr.conf.template to be used to compare if there is difference between the rendered csr.conf.rendered and csr.conf
+    # Render csr.conf.template to csr.conf.rendered
 
     local IP_ADDR="$(get_ips)"
 

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -19,19 +19,15 @@ do
 
     # every 3 seconds
     sleep 3
-    if [ -f "${SNAP_DATA}/external_ip.txt" ] &&
-       ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
+    if ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
        ip route | grep default &> /dev/null &&
        systemctl is-active --quiet snap.microk8s.daemon-apiserver.service
     then
-        IP_ADDR="$(get_ips)"
-        USED_IP_ADDR="$(cat "${SNAP_DATA}"/external_ip.txt)"
-        if ! [ "$IP_ADDR" == "$USED_IP_ADDR" ]
+        CSR_MODIFIED="$(produce_server_cert)"
+        if [ "$CSR_MODIFIED" -eq "1" ]
         then
-            echo "IP change detected. Reconfiguring the kube-apiserver"
-            produce_server_cert $IP_ADDR
+            echo "CSR change detected. Reconfiguring the kube-apiserver"
             rm -rf .srl
-
             systemctl restart snap.microk8s.daemon-containerd.service
             systemctl restart snap.microk8s.daemon-apiserver.service
             systemctl restart snap.microk8s.daemon-proxy.service

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -23,8 +23,8 @@ do
        ip route | grep default &> /dev/null &&
        systemctl is-active --quiet snap.microk8s.daemon-apiserver.service
     then
-        CSR_MODIFIED="$(produce_server_cert)"
-        if [ "$CSR_MODIFIED" -eq "1" ]
+        csr_modified="$(produce_server_cert)"
+        if [[ "$csr_modified" -eq "1" ]];
         then
             echo "CSR change detected. Reconfiguring the kube-apiserver"
             rm -rf .srl

--- a/microk8s-resources/wrappers/run-with-config-args
+++ b/microk8s-resources/wrappers/run-with-config-args
@@ -32,6 +32,7 @@ then
   # Check if we advertise an address. If we do we do not need to wait for a default network interface.
   if ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null
   then
+    # we keep this command to cleanup the file, as it is no longer needed.
     rm -f ${SNAP_DATA}/external_ip.txt
     # wait up to two minutes for the default network interface to appear.
     n=0
@@ -44,12 +45,6 @@ then
       sleep 6
     done
 
-    if ip route | grep default &> /dev/null
-    then
-        IP_ADDR="$(get_ips)"
-        mkdir -p ${SNAP_DATA}/var
-        echo "${IP_ADDR}" > "${SNAP_DATA}"/external_ip.txt
-    fi
   fi
   if [ -e ${SNAP_DATA}/var/lock/stopped.lock ]
   then

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -99,8 +99,7 @@ fi
 # Make sure the server certificate includes the IP we are using
 if ! [ -f ${SNAP_DATA}/certs/csr.conf ]
 then
-    IP_ADDR="$(get_ips)"
-    produce_server_cert $IP_ADDR
+    produce_server_cert
     rm -rf .srl
     systemctl restart snap.${SNAP_NAME}.daemon-apiserver.service
     systemctl restart snap.${SNAP_NAME}.daemon-proxy.service

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -17,8 +17,7 @@ openssl genrsa -out ${SNAP_DATA}/certs/serviceaccount.key 2048
 openssl genrsa -out ${SNAP_DATA}/certs/ca.key 2048
 openssl req -x509 -new -nodes -key ${SNAP_DATA}/certs/ca.key -subj "/CN=127.0.0.1" -days 10000 -out ${SNAP_DATA}/certs/ca.crt
 openssl genrsa -out ${SNAP_DATA}/certs/server.key 2048
-IP_ADDR="$(get_ips)"
-produce_server_cert $IP_ADDR
+produce_server_cert
 rm -rf .srl
 
 # Create the basic tokens

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -141,6 +141,7 @@ parts:
     - libssl1.0.0
     - coreutils
     - hostname
+    - diffutils    
     stage:
     - -sbin/xtables-multi
     - -sbin/iptables*
@@ -159,7 +160,6 @@ parts:
     - util-linux
     - zfsutils-linux
     - iproute2
-    - diffutils
     source: .
     override-build: |
       set -eu

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -159,6 +159,7 @@ parts:
     - util-linux
     - zfsutils-linux
     - iproute2
+    - diffutils
     source: .
     override-build: |
       set -eu


### PR DESCRIPTION
creates a csr.conf.rendered and compare it with csr.conf.
Forces the apiserver-kicker to recreate and reload the certificates when changes are detected.