### PR TITLE
Do iptables by default

### DIFF
--- a/microk8s-resources/default-args/kube-proxy
+++ b/microk8s-resources/default-args/kube-proxy
@@ -1,5 +1,4 @@
 --master='http://127.0.0.1:8080'
 --cluster-cidr=10.152.183.0/24
 --kubeconfig=${SNAP}/kubeproxy.config
---proxy-mode="userspace"
 --healthz-bind-address=127.0.0.1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -92,7 +92,7 @@ def wait_for_pod_state(pod, namespace, desired_state, desired_reason=None, label
     deadline = datetime.datetime.now() + datetime.timedelta(seconds=timeout_insec)
     while True:
         if datetime.datetime.now() > deadline:
-            raise TimeoutError("Pod {} not in {} after {] seconds.".format(pod,
+            raise TimeoutError("Pod {} not in {} after {} seconds.".format(pod,
                                                                            desired_state,
                                                                            timeout_insec))
         cmd = 'po {} -n {}'.format(pod, namespace)


### PR DESCRIPTION
Use used userspace proxy mode because it was the oldest proxy mode and displayed better compatibility (in our tests on VMs containers). However, we had reports with:
degraded performance, non-standard behavior (https://github.com/kubernetes/kubernetes/issues/76645) and failing deployments in some platforms (https://github.com/ubuntu/microk8s/issues/140) so we are moving to iptables which is the default.