### PR TITLE
Allow lxc to reach /dev/kmsg

### DIFF
--- a/tests/lxc/microk8s-zfs.profile
+++ b/tests/lxc/microk8s-zfs.profile
@@ -23,4 +23,7 @@ devices:
     path: /dev/zfs
     source: /dev/zfs
     type: disk
-
+  aadisable3:
+    path: /dev/kmsg
+    source: /dev/kmsg
+    type: disk

--- a/tests/lxc/microk8s.profile
+++ b/tests/lxc/microk8s.profile
@@ -19,4 +19,7 @@ devices:
     path: /sys/module/apparmor/parameters/enabled
     source: /dev/null
     type: disk
-
+  aadisable2:
+    path: /dev/kmsg
+    source: /dev/kmsg
+    type: disk


### PR DESCRIPTION
Needed because of this upstream PR https://github.com/kubernetes/kubernetes/commit/b2ce446a8811ff65044a30173081df13696d1cce