### PR TITLE
replace $ARCH by $SNAP_ARCH as per snap shell environment variable name

### DIFF
--- a/microk8s-resources/actions/storage.yaml
+++ b/microk8s-resources/actions/storage.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: microk8s-hostpath
       containers:
         - name: hostpath-provisioner
-          image: cdkbot/hostpath-provisioner-$ARCH:latest
+          image: cdkbot/hostpath-provisioner-$SNAP_ARCH:latest
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
```bash
snap run --shell microk8s.kubectl
env | grep ARCH
```

This shows that there's no $ARCH environment variable available in the snap shell for microk8s.kubectl, but rather $SNAP_ARCH, which is why this action was failing for me. I propose this change to maintain compatibility with the snap environment.