### PR TITLE
"enable-admission-plugins" is not needed anymore

### DIFF
--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -4,7 +4,6 @@
 --service-cluster-ip-range=10.152.183.0/24
 --authorization-mode=AlwaysAllow
 --basic-auth-file=${SNAP_DATA}/credentials/basic_auth.csv
---enable-admission-plugins="NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 --service-account-key-file=${SNAP_DATA}/certs/serviceaccount.key
 --client-ca-file=${SNAP_DATA}/certs/ca.crt
 --tls-cert-file=${SNAP_DATA}/certs/server.crt


### PR DESCRIPTION
Starting from k8s 1.10 default plugins are enabled unless disabled by "disable-admission-plugins" so "enable-admission-plugins" can be removed.

> For Kubernetes version 1.10 and later, the recommended admission controllers are enabled by default (shown here), so you do not need to explicitly specify them. You can enable additional admission controllers beyond the default set using the --enable-admission-plugins flag (order doesn’t matter).

Links:
- https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use
- https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options