### PR TITLE
RBAC metrics rolebinding

### DIFF
--- a/microk8s-resources/actions/metrics-server.yaml
+++ b/microk8s-resources/actions/metrics-server.yaml
@@ -221,3 +221,16 @@ rules:
 - apiGroups: ["metrics.k8s.io"]
   resources: ["pods", "nodes"]
   verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: microk8s-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: 127.0.0.1

--- a/microk8s-resources/actions/metrics-server.yaml
+++ b/microk8s-resources/actions/metrics-server.yaml
@@ -208,3 +208,16 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list", "watch"]

--- a/microk8s-resources/actions/metrics-server.yaml
+++ b/microk8s-resources/actions/metrics-server.yaml
@@ -233,4 +233,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: 127.0.0.1
+  name: front-proxy-client


### PR DESCRIPTION
Commits:
* Add system:aggregated-metrics-reader Cluster Role
* Bind proxy client user to admin role

Together with #579 fixes #560

Links:
- https://github.com/kubernetes-incubator/metrics-server/blob/v0.3.3/deploy/1.8+/aggregated-metrics-reader.yaml