### PR TITLE
Cache kube binaries after download

### DIFF
--- a/build-scripts/fetch-binaries.sh
+++ b/build-scripts/fetch-binaries.sh
@@ -10,9 +10,17 @@ echo $KUBE_VERSION > $KUBE_SNAP_BINS/version
     mkdir -p $KUBE_ARCH
     (cd $KUBE_ARCH
       echo "Fetching $app $KUBE_VERSION $KUBE_ARCH"
-      curl -LO \
-        https://dl.k8s.io/${KUBE_VERSION}/bin/linux/$KUBE_ARCH/$app
-      chmod +x $app
+      cachepath="../../../../../../cache/kube-$KUBE_VERSION-$KUBE_ARCH"
+      if [ -e $cachepath/$app ]; then
+        echo "Copying $app from local cache"
+        cp $cachepath/$app $app
+      else
+        curl -LO \
+          https://dl.k8s.io/${KUBE_VERSION}/bin/linux/$KUBE_ARCH/$app
+        chmod +x $app
+        mkdir -p $cachepath
+        cp $app $cachepath/$app
+      fi
       if ! file ${app} 2>&1 | grep -q 'executable'; then
         echo "${app} is not an executable"
         exit 1


### PR DESCRIPTION
This PR adds a quick-and-dirty cache for storing downloaded kubernetes
binaries under `parts/cache/kube-$KUBE_VERSION-$ARCH/` after the
first time that they're downloaded.

Otherwise every time you do `snapcraft clean microk8s` and `snapcraft`
it has to spend several minutes downloading these binaries again.