### PR TITLE
Add helm, cilium addons

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -18,7 +18,7 @@ refresh_opt_in_config() {
     local config_file="$SNAP_DATA/args/$3"
     local replace_line="$opt=$value"
     if $(grep -qE "^$opt=" $config_file); then
-        sudo "$SNAP/bin/sed" -i "s/^$opt=.*/$replace_line/" $config_file
+        sudo "$SNAP/bin/sed" -i "s;^$opt=.*;$replace_line;" $config_file
     else
         sudo "$SNAP/bin/sed" -i "$ a $replace_line" "$config_file"
     fi

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -118,6 +118,26 @@ wait_for_service() {
     fi
 }
 
+wait_for_service_shutdown() {
+    # Wait for a service to stop
+    # Return  fail if the service did not stop in 30 seconds
+
+    local namespace="$1"
+    local labels="$2"
+    local shutdown_timeout=30
+    local start_timer="$(date +%s)"
+    KUBECTL="$SNAP/kubectl --kubeconfig=$SNAP/client.config"
+
+    while ($KUBECTL get po -n "$namespace" -l "$labels" | grep -z " Terminating") &> /dev/null
+    do
+      now="$(date +%s)"
+      if [[ "$now" > "$(($start_timer + $shutdown_timeout))" ]] ; then
+        echo "fail"
+        break
+      fi
+      sleep 5
+    done
+}
 
 get_default_ip() {
     # Get the IP of the default interface

--- a/microk8s-resources/actions/disable.cilium.sh
+++ b/microk8s-resources/actions/disable.cilium.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Disabling Cilium"
+
+if [ -L "${SNAP_DATA}/bin/cilium" ]
+then
+  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" delete -f "$SNAP_DATA/actions/cilium.yaml"
+
+  sudo rm -f "$SNAP_DATA/args/cni-network/05-cilium-cni.conf"
+  sudo rm -f "$SNAP_DATA/opt/cni/bin/cilium-cni"
+  sudo rm -rf $SNAP_DATA/bin/cilium*
+  sudo rm -f "$SNAP_DATA/actions/cilium.yaml"
+  sudo rm -rf "$SNAP_DATA/actions/cilium"
+  sudo rm -rf "$SNAP_DATA/var/run/cilium"
+  sudo rm -rf "$SNAP_DATA/sys/fs/bpf"
+
+  echo "Restarting kubelet"
+  refresh_opt_in_config "network-plugin" "kubenet" kubelet
+  refresh_opt_in_config "cni-bin-dir" "\${SNAP}/opt/cni/bin/" kubelet
+  sudo systemctl restart snap.${SNAP_NAME}.daemon-kubelet
+  echo "Restarting containerd"
+  if ! grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
+    sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
+  fi
+  sudo systemctl restart snap.${SNAP_NAME}.daemon-containerd
+
+  echo "Cilium is terminating"
+  cilium=$(wait_for_service_shutdown "kube-system" "k8s-app=cilium")
+  if [[ $cilium == fail ]]
+  then
+    echo "Cilium did not shut down on time. Proceeding."
+  fi
+fi

--- a/microk8s-resources/actions/disable.dns.sh
+++ b/microk8s-resources/actions/disable.dns.sh
@@ -21,16 +21,11 @@ then
   use_manifest coredns delete
 fi
 sleep 15
-timeout=30
-start_timer="$(date +%s)"
-while ($KUBECTL get po -n kube-system | grep -z " Terminating") &> /dev/null
-do
-  now="$(date +%s)"
-  if [[ "$now" > "$(($start_timer + $timeout))" ]] ; then
-    break
-  fi
-  sleep 5
-done
+dns=$(wait_for_service_shutdown "kube-system" "k8s-app=kube-dns")
+if [[ $dns == fail ]]
+then
+  echo "DNS did not shut down on time. Proceeding."
+fi
 
 skip_opt_in_config "cluster-domain" kubelet
 skip_opt_in_config "cluster-dns" kubelet

--- a/microk8s-resources/actions/disable.helm.sh
+++ b/microk8s-resources/actions/disable.helm.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Disabling Helm"
+
+if [ -f "${SNAP_DATA}/bin/helm" ]
+then
+  sudo rm -f "$SNAP_DATA/bin/helm"
+fi

--- a/microk8s-resources/actions/enable.cilium.sh
+++ b/microk8s-resources/actions/enable.cilium.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+ARCH=$(arch)
+if ! [ "${ARCH}" = "amd64" ]; then
+  echo "Cilium is not available for ${ARCH}" >&2
+  exit 1
+fi
+
+"$SNAP/microk8s-enable.wrapper" helm
+
+echo "Restarting kube-apiserver"
+refresh_opt_in_config "allow-privileged" "true" kube-apiserver
+sudo systemctl restart snap.${SNAP_NAME}.daemon-apiserver
+
+# Reconfigure kubelet/containerd to pick up the new CNI config and binary.
+echo "Restarting kubelet"
+refresh_opt_in_config "network-plugin" "cni" kubelet
+refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
+sudo systemctl restart snap.${SNAP_NAME}.daemon-kubelet
+
+if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
+  echo "Restarting containerd"
+  sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
+  sudo systemctl restart snap.${SNAP_NAME}.daemon-containerd
+fi
+
+echo "Enabling Cilium"
+
+read -ra CILIUM_VERSION <<< "$1"
+if [ -z "$CILIUM_VERSION" ]; then
+  CILIUM_VERSION="v1.6"
+fi
+CILIUM_ERSION=$(echo $CILIUM_VERSION | sed 's/v//g')
+
+if [ -f "${SNAP_DATA}/bin/cilium-$CILIUM_ERSION" ]
+then
+  echo "Cilium version $CILIUM_VERSION is already installed."
+else
+  CILIUM_DIR="cilium-$CILIUM_ERSION"
+  SOURCE_URI="https://github.com/cilium/cilium/archive"
+  CILIUM_CNI_CONF="plugins/cilium-cni/05-cilium-cni.conf"
+  CILIUM_LABELS="k8s-app=cilium"
+  NAMESPACE=kube-system
+
+  echo "Fetching cilium version $CILIUM_VERSION."
+  sudo mkdir -p "${SNAP_DATA}/tmp/cilium"
+  (cd "${SNAP_DATA}/tmp/cilium"
+  sudo "${SNAP}/usr/bin/curl" -L $SOURCE_URI/$CILIUM_VERSION.tar.gz -o "$SNAP_DATA/tmp/cilium/cilium.tar.gz"
+  if ! sudo gzip -f -d "$SNAP_DATA/tmp/cilium/cilium.tar.gz"; then
+    echo "Invalid version \"$CILIUM_VERSION\". Must be a branch on https://github.com/cilium/cilium."
+    exit 1
+  fi
+  sudo tar -xf "$SNAP_DATA/tmp/cilium/cilium.tar" "$CILIUM_DIR/install" "$CILIUM_DIR/$CILIUM_CNI_CONF")
+
+  sudo mv "$SNAP_DATA/args/cni-network/cni.conf" "$SNAP_DATA/args/cni-network/10-kubenet.conf" 2>/dev/null || true
+  sudo cp "$SNAP_DATA/tmp/cilium/$CILIUM_DIR/$CILIUM_CNI_CONF" "$SNAP_DATA/args/cni-network/05-cilium-cni.conf"
+
+  # Generate the YAMLs for Cilium and apply them
+  (cd "${SNAP_DATA}/tmp/cilium/$CILIUM_DIR/install/kubernetes"
+  ${SNAP_DATA}/bin/helm template cilium \
+      --namespace $NAMESPACE \
+      --set global.cni.confPath="$SNAP_DATA/args/cni-network" \
+      --set global.cni.binPath="$SNAP_DATA/opt/cni/bin" \
+      --set global.cni.customConf=true \
+      --set global.containerRuntime.integration="containerd" \
+      --set global.containerRuntime.socketPath="$SNAP_COMMON/run/containerd.sock" \
+      | sudo tee cilium.yaml >/dev/null)
+
+  sudo mkdir -p "$SNAP_DATA/actions/cilium/"
+  sudo cp "$SNAP_DATA/tmp/cilium/$CILIUM_DIR/install/kubernetes/cilium.yaml" "$SNAP_DATA/actions/cilium.yaml"
+  sudo sed -i 's;path: \(/var/run/cilium\);path: '"$SNAP_DATA"'\1;g' "$SNAP_DATA/actions/cilium.yaml"
+
+  microk8s.status --wait-ready >/dev/null
+  echo "Deploying $SNAP_DATA/actions/cilium.yaml. This may take several minutes."
+  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" apply -f "$SNAP_DATA/actions/cilium.yaml"
+  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" -n $NAMESPACE rollout status ds/cilium
+
+  # Fetch the Cilium CLI binary and install
+  CILIUM_POD=$("$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" -n $NAMESPACE get pod -l $CILIUM_LABELS -o jsonpath="{.items[0].metadata.name}")
+  CILIUM_BIN=$(mktemp)
+  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" -n $NAMESPACE cp $CILIUM_POD:/usr/bin/cilium $CILIUM_BIN >/dev/null
+  sudo mkdir -p "$SNAP_DATA/bin/"
+  sudo mv $CILIUM_BIN "$SNAP_DATA/bin/cilium-$CILIUM_ERSION"
+  sudo chmod +x "$SNAP_DATA/bin/"
+  sudo chmod +x "$SNAP_DATA/bin/cilium-$CILIUM_ERSION"
+  sudo ln -s $SNAP_DATA/bin/cilium-$CILIUM_ERSION $SNAP_DATA/bin/cilium
+
+  sudo rm -rf "$SNAP_DATA/tmp/cilium"
+fi
+
+echo "Cilium is enabled"

--- a/microk8s-resources/actions/enable.helm.sh
+++ b/microk8s-resources/actions/enable.helm.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Enabling Helm"
+
+if [ ! -f "${SNAP_DATA}/bin/helm" ]
+then
+  SOURCE_URI="https://get.helm.sh"
+  HELM_VERSION="v2.14.3"
+
+  echo "Fetching helm version $HELM_VERSION."
+  sudo mkdir -p "${SNAP_DATA}/tmp/helm"
+  (cd "${SNAP_DATA}/tmp/helm"
+  sudo "${SNAP}/usr/bin/curl" -L $SOURCE_URI/helm-$HELM_VERSION-linux-$(arch).tar.gz -o "$SNAP_DATA/tmp/helm/helm.tar.gz"
+  sudo gzip -f -d "$SNAP_DATA/tmp/helm/helm.tar.gz"
+  sudo tar -xf "$SNAP_DATA/tmp/helm/helm.tar")
+
+  sudo mkdir -p "$SNAP_DATA/bin/"
+  sudo mv "$SNAP_DATA/tmp/helm/linux-$(arch)/helm" "$SNAP_DATA/bin/helm"
+  sudo chmod +x "$SNAP_DATA/bin/"
+  sudo chmod +x "$SNAP_DATA/bin/helm"
+
+  sudo rm -rf "$SNAP_DATA/tmp/helm"
+fi
+
+echo "Helm is enabled"

--- a/microk8s-resources/wrappers/microk8s-cilium.wrapper
+++ b/microk8s-resources/wrappers/microk8s-cilium.wrapper
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu
+
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu"
+
+if [ ! -f "${SNAP_DATA}/bin/cilium" ]; then
+  echo "Cilium not available, try enabling it with 'microk8s.enable cilium'" >&2
+  exit 0
+fi
+
+source $SNAP/actions/common/utils.sh
+exit_if_stopped
+export CILIUM_MONITOR_SOCK="$SNAP_DATA/var/run/cilium/monitor1_2.sock"
+"${SNAP_DATA}/bin/cilium" -H "unix:///var/snap/microk8s/current/var/run/cilium/cilium.sock" "$@"

--- a/microk8s-resources/wrappers/microk8s-helm.wrapper
+++ b/microk8s-resources/wrappers/microk8s-helm.wrapper
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu"
+
+if [ ! -f "${SNAP_DATA}/bin/helm" ]; then
+  echo "Helm not available, try enabling it with 'microk8s.enable helm'" >&2
+  exit 0
+fi
+
+source $SNAP/actions/common/utils.sh
+"${SNAP_DATA}/bin/helm" --kubeconfig="${SNAP_DATA}"/credentials/client.config "$@"

--- a/microk8s-resources/wrappers/microk8s-status.wrapper
+++ b/microk8s-resources/wrappers/microk8s-status.wrapper
@@ -25,6 +25,7 @@ addon[prometheus]="pod/prometheus-k8s-0"
 addon[fluentd]="daemonset.apps/fluentd-es-v2.2.0"
 addon[jaeger]="pod/jaeger-operator"
 addon[linkerd]="pod/linkerd-controller"
+addon[cilium]="pod/cilium"
 
 
 function show_help() {

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -44,4 +44,7 @@ do
   sleep 6
 done
 
+# Set the path to the Cilium socket correctly for CNI
+export CILIUM_SOCK="${SNAP_DATA}/var/run/cilium/cilium.sock"
+
 exec "$SNAP/bin/$app" "${args[@]}"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,6 +64,8 @@ apps:
     command: microk8s-istioctl.wrapper
   linkerd:
     command: microk8s-linkerd.wrapper
+  helm:
+    command: microk8s-helm.wrapper
 
 parts:
   libnftnl:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -66,6 +66,8 @@ apps:
     command: microk8s-linkerd.wrapper
   helm:
     command: microk8s-helm.wrapper
+  cilium:
+    command: microk8s-cilium.wrapper
 
 parts:
   libnftnl:

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -17,6 +17,7 @@ from validators import (
     validate_jaeger,
     validate_linkerd,
     validate_rbac,
+    validate_cilium,
 )
 from utils import (
     microk8s_enable,
@@ -124,6 +125,26 @@ class TestAddons(object):
         microk8s_disable("knative")
         print("Disabling Istio")
         microk8s_disable("istio")
+
+    def test_cilium(self):
+        """
+        Sets up and validates Cilium.
+        """
+        if platform.machine() != 'x86_64':
+            print("Cilium tests are only relevant in x86 architectures")
+            return
+
+        if under_time_pressure != 'False':
+            print("Skipping cilium tests as we are under time pressure")
+            return
+
+        print("Enabling Cilium")
+        p = Popen("/snap/bin/microk8s.enable cilium".split(), stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+        p.communicate(input=b'N\n')[0]
+        print("Validating Cilium")
+        validate_cilium()
+        print("Disabling Cilium")
+        microk8s_disable("cilium")
 
     def test_metrics_server(self):
         """

--- a/tests/test-live-addons.py
+++ b/tests/test-live-addons.py
@@ -10,6 +10,7 @@ from validators import (
     validate_prometheus,
     validate_fluentd,
     validate_jaeger,
+    validate_cilium,
 )
 from utils import wait_for_pod_state
 
@@ -82,3 +83,9 @@ class TestLiveAddons(object):
 
         """
         validate_jaeger()
+
+    def test_cilium(self):
+        """
+        Validates Cilium works.
+        """
+        validate_cilium()

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -12,6 +12,7 @@ from validators import (
     validate_prometheus,
     validate_fluentd,
     validate_jaeger,
+    validate_cilium,
 )
 from subprocess import check_call, CalledProcessError, check_output
 from utils import (
@@ -138,6 +139,14 @@ class TestUpgrade(object):
                 test_matrix['jaeger'] = validate_jaeger
             except:
                 print('Will not test the jaeger addon')
+
+            try:
+                enable = microk8s_enable("cilium", timeout_insec=300)
+                assert "Nothing to do for" not in enable
+                validate_cilium()
+                test_matrix['cilium'] = validate_cilium
+            except:
+                print('Will not test the cilium addon')
 
         # Refresh the snap to the target
         if upgrade_to.endswith('.snap'):

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -11,6 +11,7 @@ from utils import (
     wait_for_installation,
     docker,
     update_yaml_with_arch,
+    run_until_success,
 )
 
 
@@ -337,3 +338,36 @@ def validate_rbac():
     assert "no" in output
     output = kubectl("auth can-i --as=admin --as-group=system:masters view pod")
     assert "yes" in output
+
+
+def cilium(cmd, timeout_insec=300, err_out=None):
+    """
+    Do a cilium <cmd>
+    Args:
+        cmd: left part of cilium <left_part> command
+        timeout_insec: timeout for this job
+        err_out: If command fails and this is the output, return.
+
+    Returns: the cilium response in a string
+    """
+    cmd = '/snap/bin/microk8s.cilium ' + cmd
+    return run_until_success(cmd, timeout_insec, err_out)
+
+def validate_cilium():
+    """
+    Validate cilium by deploying the bookinfo app.
+    """
+    if platform.machine() != 'x86_64':
+        print("Cilium tests are only relevant in x86 architectures")
+        return
+
+    wait_for_installation()
+    wait_for_pod_state("", "kube-system", "running", label="k8s-app=cilium")
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    manifest = os.path.join(here, "templates", "nginx-pod.yaml")
+    kubectl("apply -f {}".format(manifest))
+    wait_for_pod_state("", "default", "running", label="app=nginx")
+    output = cilium('endpoint list -o json')
+    assert "nginx" in output
+    kubectl("delete -f {}".format(manifest))


### PR DESCRIPTION
## Summary

Add support for enabling/disabling Cilium directly from microk8s. This should greatly simplify the instructions in the current [Cilium getting started guide](http://docs.cilium.io/en/latest/gettingstarted/microk8s/) to just:
1. `snap install microk8s --classic`
1. `microk8s.enable cilium`

This also provides a useful wrapper, `microk8s.cilium` which provides direct CLI access to Cilium without needing to open a shell into the Cilium container.

To install cilium, there are helm charts provided by the Cilium repository. So this PR also provides a way to install helm within the microk8s environment for use from Cilium.

## Testing

### Installing
```
$ sudo snap run --shell  microk8s.enable
# ./microk8s-resources/actions/enable.cilium.sh
Enabling Helm
Helm is enabled
Restarting kube-apiserver
Enabling Cilium
Fetching cilium version v1.6.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   119    0   119    0     0    339      0 --:--:-- --:--:-- --:--:--   338
100 21.8M    0 21.8M    0     0  1199k      0 --:--:--  0:00:18 --:--:-- 1264k
configmap/cilium-config created
serviceaccount/cilium created
serviceaccount/cilium-operator created
clusterrole.rbac.authorization.k8s.io/cilium created
clusterrole.rbac.authorization.k8s.io/cilium-operator created
clusterrolebinding.rbac.authorization.k8s.io/cilium created
clusterrolebinding.rbac.authorization.k8s.io/cilium-operator created
daemonset.apps/cilium created
deployment.apps/cilium-operator created
Waiting for daemon set "cilium" rollout to finish: 0 of 1 updated pods are available...
daemon set "cilium" successfully rolled out
Restarting kubelet
Restarting containerd
Cilium is enabled

```

### CLI usage

```
# ./microk8s-resources/wrappers/microk8s-cilium.wrapper status
KVStore:                Ok   Disabled                 
ContainerRuntime:       Ok   containerD events watcher: Ok; cri-containerd client: Ok - cri daemon: Ok
Kubernetes:             Ok   1.15 (v1.15.2) [linux/amd64]                             
Kubernetes APIs:        ["CustomResourceDefinition", "cilium/v2::CiliumEndpoint", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "core/v1::Endpoint", "core/v1::Namespace", "core/v1::Pods", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]
Cilium:                 Ok   OK                                                                       
NodeMonitor:            Disabled       
Cilium health daemon:   Ok                       
IPAM:                   IPv4: 11/255 allocated from 10.1.1.0/24,               
Controller Status:      53/53 healthy                                        
Proxy Status:           OK, ip 10.1.1.254, port-range 10000-20000                           
Cluster health:   1/1 reachable   (2019-08-13T21:22:50Z)
```

### Uninstalling
```
# ./microk8s-resources/actions/disable.cilium.sh
Disabling Cilium
configmap "cilium-config" deleted
serviceaccount "cilium" deleted
serviceaccount "cilium-operator" deleted
clusterrole.rbac.authorization.k8s.io "cilium" deleted
clusterrole.rbac.authorization.k8s.io "cilium-operator" deleted
clusterrolebinding.rbac.authorization.k8s.io "cilium" deleted
clusterrolebinding.rbac.authorization.k8s.io "cilium-operator" deleted
daemonset.apps "cilium" deleted
deployment.apps "cilium-operator" deleted
Restarting kubelet
Restarting containerd
Cilium is terminating
```

### Live testing

```
$ pytest -k cilium -s test-live-addons.py
============================================================ test session starts ============================================================
platform linux2 -- Python 2.7.16, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /home/joe/git/microk8s/tests, inifile:
collected 10 items / 9 deselected                                                                                                           

test-live-addons.py .

================================================== 1 passed, 9 deselected in 37.91 seconds ==================================================
```

### Upgrade

```
$ UPGRADE_MICROK8S_FROM=$PWD/microk8s_v1.15.2_amd64.snap UPGRADE_MICROK8S_TO=$PWD/microk8s_v1.15.2_amd64.snap py                                     
test -s ./tests/test-upgrade.py
==================================================================== test session starts =====================================================================                                     
platform linux2 -- Python 2.7.16, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /home/joe/git/microk8s, inifile:
collected 1 item                                                                                                                                                                                   

tests/test-upgrade.py Testing upgrade from /home/joe/git/microk8s/microk8s_v1.15.2_amd64.snap to /home/joe/git/microk8s/microk8s_v1.15.2_amd64.snap                                                
[sudo] password for joe:
The connection to the server 127.0.0.1:8080 was refused - did you specify the right host or port?
Retrying /snap/bin/microk8s.kubectl get -o yaml svc kubernetes
systemd-detect-virt did not detect a container
no indication of a container in /proc
Testing cilium
systemd-detect-virt did not detect a container
no indication of a container in /proc
```

## Remaining tasks
* [x] Check that Travis is happy
* [x] Write tests for addon integration
* [x] Fix version for full v1.6 release instead of master (Pulling from v1.6 branch)
* [x] Attempt installation in a fresh environment
* [x] Resolve `cilium-operator` API access issue (Cannot reproduce in fresh AWS Ubuntu VM)
* [ ] Resolve question about CLI tool permissions