### PR TITLE
Improve build caching

### DIFF
--- a/build-scripts/set-env-variables.sh
+++ b/build-scripts/set-env-variables.sh
@@ -28,7 +28,9 @@ export KUBE_TRACK="${KUBE_TRACK:-}"
 
 export KUBE_VERSION="${KUBE_VERSION:-}"
 export KUBE_SNAP_BINS="${KUBE_SNAP_BINS:-}"
-if [ -z "$KUBE_SNAP_BINS" ]; then
+if [ -e "$KUBE_SNAP_BINS/version" ]; then
+  export KUBE_VERSION=`cat $KUBE_SNAP_BINS/version`
+else
   # KUBE_SNAP_BINS is not set meaning we will either build the binaries OR fetch them from upstream
   # eitherway the k8s binaries should land at build/kube_bins/$KUBE_VERSION
   if [ -z "$KUBE_VERSION" ]; then
@@ -40,8 +42,6 @@ if [ -z "$KUBE_SNAP_BINS" ]; then
       export KUBE_VERSION="${KUBE_VERSION:-`curl -L https://dl.k8s.io/release/stable-${KUBE_TRACK}.txt`}"
     fi
   fi
-else
-  export KUBE_VERSION=`cat $KUBE_SNAP_BINS/version`
 fi
 
 export KUBE_SNAP_ROOT="$(readlink -f .)"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -92,7 +92,8 @@ parts:
     source-tag: go1.12.7
   containerd:
     after: [go, iptables]
-    source: .
+    source: https://github.com/containerd/containerd
+    source-type: git
     plugin: go
     go-importpath: github.com/containerd/containerd
     build-packages:
@@ -100,7 +101,7 @@ parts:
     - libseccomp-dev
     override-build: |
       set -eu
-      . build-scripts/set-env-variables.sh
+      . ../../../build-scripts/set-env-variables.sh
 
       go version
       export GOPATH=$(realpath ../go)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -179,10 +179,12 @@ parts:
 
       REMOVE_KUBE_SNAP_BINS=false
       echo "Reached here"
-      if [ -z "${KUBE_SNAP_BINS}" ]; then
-        REMOVE_KUBE_SNAP_BINS=true
+      if [ ! -e "${KUBE_SNAP_BINS}" ]; then
+        if [ -z "${KUBE_SNAP_BINS}" ]; then
+          REMOVE_KUBE_SNAP_BINS=true
+          . build-scripts/set-env-binaries-location.sh
+        fi
         echo "Downloading binaries"
-        . build-scripts/set-env-binaries-location.sh
         . build-scripts/fetch-other-binaries.sh
         if [ -z "${KUBERNETES_COMMIT}" ]; then
           echo "Downloading k8s binaries from upstream"


### PR DESCRIPTION
These commits improve build caching:
* Don't depend on the microk8s tree for the containerd build, so the part can be cached
* Support specifying `KUBE_SNAP_BINS` to a non-existent directory, in which case the build will create the directory and cache k8s artifacts there. Previously a developer would first have to come up with the cached artifacts somehow, and ensure they weren't deleted, then keep them somewhere safe and specify `KUBE_SNAP_BINS`. This makes the process a bit easier for new developers.