### PR TITLE
Fix cilium health cluster status check

### DIFF
--- a/microk8s-resources/wrappers/microk8s-cilium.wrapper
+++ b/microk8s-resources/wrappers/microk8s-cilium.wrapper
@@ -13,4 +13,5 @@ fi
 source $SNAP/actions/common/utils.sh
 exit_if_stopped
 export CILIUM_MONITOR_SOCK="$SNAP_DATA/var/run/cilium/monitor1_2.sock"
+export CILIUM_HEALTH_SOCK="$SNAP_DATA/var/run/cilium/health.sock"
 "${SNAP_DATA}/bin/cilium" -H "unix:///var/snap/microk8s/current/var/run/cilium/cilium.sock" "$@"


### PR DESCRIPTION
This defines the correct `cilium-health` socket for contacting the
`cilium-health` cluster connectivity API for the output of `cilium status`.

Previously:
```
$ cilium status
KVStore:                Ok   Disabled
ContainerRuntime:       Ok   containerD events watcher: Ok; cri-containerd client: Ok - cri daemon: Ok
Kubernetes:             Ok   1.15 (v1.15.2) [linux/amd64]
Kubernetes APIs:        ["CustomResourceDefinition", "cilium/v2::CiliumEndpoint", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "core/v1::Endpoint", "core/v1::Namespace", "core/v1::Pods", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]
Cilium:                 Ok   OK
NodeMonitor:            Disabled
Cilium health daemon:   Ok
IPAM:                   IPv4: 2/65535 allocated from 10.244.0.0/16,
Controller Status:      12/12 healthy
Proxy Status:           OK, ip 10.244.215.6, port-range 10000-20000
Cluster health:         Warning   cilium-health daemon unreachable
```

Now:
```
# microk8s-resources/wrappers/microk8s-cilium.wrapper status
KVStore:                Ok   Disabled
ContainerRuntime:       Ok   containerD events watcher: Ok; cri-containerd client: Ok - cri daemon: Ok
Kubernetes:             Ok   1.15 (v1.15.2) [linux/amd64]
Kubernetes APIs:        ["CustomResourceDefinition", "cilium/v2::CiliumEndpoint", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "core/v1::Endpoint", "core/v1::Namespace", "core/v1::Pods", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]
Cilium:                 Ok   OK
NodeMonitor:            Disabled
Cilium health daemon:   Ok   
IPAM:                   IPv4: 2/65535 allocated from 10.244.0.0/16, 
Controller Status:      12/12 healthy
Proxy Status:           OK, ip 10.244.215.6, port-range 10000-20000
Cluster health:   1/1 reachable   (2019-08-20T19:59:09Z)
```