### PR TITLE
miscellaneous updates for strict mode

### DIFF
--- a/microk8s-resources/default-args/etcd
+++ b/microk8s-resources/default-args/etcd
@@ -1,3 +1,3 @@
 --data-dir=${SNAP_COMMON}/var/run/etcd
---advertise-client-urls=unix://etcd.socket:2379
---listen-client-urls=unix://etcd.socket:2379
+--advertise-client-urls=http://localhost:2379
+--listen-client-urls=http://localhost:2379

--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -1,6 +1,6 @@
 --insecure-bind-address=127.0.0.1
 --cert-dir=${SNAP_DATA}/certs
---etcd-servers='unix://etcd.socket:2379'
+--etcd-servers='http://localhost:2379'
 --service-cluster-ip-range=10.152.183.0/24
 --authorization-mode=AlwaysAllow
 --basic-auth-file=${SNAP_DATA}/credentials/basic_auth.csv

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -22,7 +22,7 @@ do
     if [ -f "${SNAP_DATA}/external_ip.txt" ] &&
        ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
        ip route | grep default &> /dev/null &&
-       systemctl is-active --quiet snap.microk8s.daemon-apiserver.service
+       snapctl services | grep "microk8s.daemon-apiserver *enabled *active"
     then
         IP_ADDR="$(get_ips)"
         USED_IP_ADDR="$(cat "${SNAP_DATA}"/external_ip.txt)"
@@ -32,8 +32,8 @@ do
             produce_server_cert $IP_ADDR
             rm -rf .srl
 
-            systemctl restart snap.microk8s.daemon-apiserver.service
-            systemctl restart snap.microk8s.daemon-proxy.service
+	    snapctl restart microk8s.daemon-apiserver
+	    snapctl restart microk8s.daemon-proxy
             restart_attempt=$[$restart_attempt+1]
         else
             restart_attempt=0

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -8,14 +8,10 @@ export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 export XDG_RUNTIME_DIR="${SNAP_COMMON}/run"
 mkdir -p "${XDG_RUNTIME_DIR}"
 
-if [ -d "/etc/apparmor.d" ]; then
-  echo "Using a default profile template"
-  cp ${SNAP}/containerd-profile /etc/apparmor.d/cri-containerd.apparmor.d
-  echo "Reloading AppArmor profiles"
-  if ! service apparmor reload
-  then
-    echo "AppArmor profiles loading failed. AppArmor may be unavailable on this host."
-  fi
+apparmor_parser -r ${SNAP}/containerd-profile
+
+if [ ! -d "$SNAP_COMMON/run/containerd" ]; then
+  mkdir -p "$SNAP_COMMON/run/containerd"
 fi
 
 app=containerd

--- a/microk8s-resources/wrappers/run-with-config-args
+++ b/microk8s-resources/wrappers/run-with-config-args
@@ -6,6 +6,12 @@ export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
 source $SNAP/actions/common/utils.sh
 
+for d in "$SNAP_COMMON/var/lib/cni" "$SNAP_COMMON/usr/libexec" "$SNAP_COMMON/var/log/pods" "$SNAP_COMMON/var/log/containers" "$SNAP_COMMON/var/lib/kubelet/pod-resources"; do
+  if [ ! -d "$d" ]; then
+    mkdir -p "$d" || true
+  fi
+done
+
 app=$1
 
 if [ "${app}" = "kubelet" ]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: microk8s
 version-script: |
   . build-scripts/prepare-env.sh > /dev/null
   echo $KUBE_VERSION
-version: "latest"
+version: "latest-strict"
 summary: Kubernetes for workstations and appliances
 description: |-
  MicroK8s is a small, fast, secure, single node Kubernetes that installs on
@@ -13,6 +13,16 @@ description: |-
 
 grade: devel
 confinement: strict
+
+hooks:
+  configure:
+    plugs: []
+  install:
+    plugs: []
+  remove:
+    plugs:
+    - k8s-kubelet
+    - mount-observe
 
 plugs:
   docker-privileged:
@@ -46,16 +56,23 @@ apps:
     daemon: simple
     plugs:
     - network-bind
+    - network-observe
   daemon-apiserver-kicker:
     command: apiservice-kicker
     daemon: simple
     plugs:
     - network-bind
+    - network-observe
   daemon-controller-manager:
     command: run-with-config-args kube-controller-manager
     daemon: simple
     plugs:
     - network-bind
+    - docker-support
+    - docker-privileged
+    - firewall-control
+    - kernel-module-control
+    - network-control
   daemon-scheduler:
     command: run-with-config-args kube-scheduler
     daemon: simple
@@ -82,13 +99,21 @@ apps:
     - k8s-kubeproxy
     - kernel-module-observe
     - mount-observe
+    - network-observe
     - system-observe
     - kernel-module-control
   kubectl:
     command: microk8s-kubectl.wrapper
     completer: kubectl.bash
     plugs:
-    - network
+    - firewall-control
+    - network-bind
+    - k8s-kubelet
+    - hardware-observe
+    - mount-observe
+    - network-control
+    - process-control
+    - system-observe
   ctr:
     command: microk8s-ctr.wrapper
   inspect:
@@ -99,17 +124,36 @@ apps:
     command: microk8s-disable.wrapper
   start:
     command: microk8s-start.wrapper
+    plugs:
+    - network
   stop:
     command: microk8s-stop.wrapper
+    plugs:
+    - network
   status:
     command: microk8s-status.wrapper
+    plugs:
+    - network
   config:
     command: microk8s-config.wrapper
   reset:
     command: microk8s-reset.wrapper
+    plugs:
+    - network
   istioctl:
     command: microk8s-istioctl.wrapper
     completer: istioctl.bash
+
+passthrough:
+  layout:
+    /usr/libexec:
+      symlink: $SNAP_COMMON/usr/libexec
+    /var/lib/cni:
+      symlink: $SNAP_COMMON/var/lib/cni
+    /var/log/pods:
+      symlink: $SNAP_COMMON/var/log/pods
+    /var/log/containers:
+      symlink: $SNAP_COMMON/var/log/containers
 
 parts:
   libnftnl:


### PR DESCRIPTION
This is a first pass at getting the microk8s basic services to work in strict mode. As of this time, there are several TODOs to make various snap commands work under strict mode:

* stop use of sudo (grep -r sudo ./microk8s-resources/). Eg, check for root uid and exit if non-root
* stop use of systemctl (grep -r systemctl ./microk8s-resources/, but also meta/hooks). use snapctl instead
* don't run /snap/bin/... commands. Use $SNAP/path/to/thing instead

There are likely other things that should be done. Eg, you may also want to update to not require the use of layouts.

That said, with these changes, I was able to install microk8s in strict mode, create, use and delete a pod (see https://people.canonical.com/~jamie/microk8s/README) and have it all work after reboot. Testing was performed on an Ubuntu 18.04 server install with the 2.41 snapd in edge (snap refresh core --edge; several updates were made in 2.41 to make microk8s work with containerd, etc).

* default-args/kube-apiserver: listen on localhost:2379
* default-args/etcd: listen on localhost:2379
* wrappers/apiservice-kicker: use snapctl instead of systemctl
* run-containerd-with-args: load apparmor profile directly and create dir
* run-with-config-args: create various directories used in layouts
* snapcraft.yaml: add explicit hooks, layouts and misc interfaces


