### PR TITLE
Allow users to be in a group instead of using sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sudo microk8s.kubectl config view --raw > $HOME/.kube/config
 ```
 
 #### User access without sudo
-If the *microk8s* user group exist at MicroK8s `snap install` time, users on that group
+If the *microk8s* user group exists at MicroK8s `snap install` time, users in that group
 will be granted access to `microk8s` commands.
 
 At any point you grant access to a specific group with:

--- a/README.md
+++ b/README.md
@@ -73,20 +73,13 @@ sudo microk8s.kubectl config view --raw > $HOME/.kube/config
 If the *microk8s* user group exists at MicroK8s `snap install` time, users in that group
 will be granted access to `microk8s` commands.
 
-At any point you grant access to a specific group with:
-```
-sudo snap set microk8s user.group=<GROUP_NAME>
-```
-
-For example, to create the `microk8s` group and add a user to it:
+If the *microk8s* is not available during installation you can add it later with:
 ```
 # Create the group
-sudo addgroup microk8s
-# Add a user to the group. The new group will be available on the user's next login.
-sudo usermod -a -G microk8s myuser
+sudo groupadd --system microk8s
 
 # Let MicroK8s know which user group to trust
-sudo snap set microk8s user.group=microk8s
+cd /var/snap/microk8s/current; sudo chgrp -R microk8s ./credentials ./certs ./args
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -70,16 +70,10 @@ sudo microk8s.kubectl config view --raw > $HOME/.kube/config
 ```
 
 #### User access without sudo
-If the *microk8s* user group exists at MicroK8s `snap install` time, users in that group
-will be granted access to `microk8s` commands.
-
-If the *microk8s* is not available during installation you can add it later with:
+The *microk8s* user group is created during the snap installation. Users in that group
+are granted access to `microk8s` commands. To add a user to that group:
 ```
-# Create the group
-sudo groupadd --system microk8s
-
-# Let MicroK8s know which user group to trust
-cd /var/snap/microk8s/current; sudo chgrp -R microk8s ./credentials ./certs ./args
+sudo usermod -a -G microk8s <username>"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -59,22 +59,43 @@ snap install microk8s --classic
 MicroK8s includes a `microk8s.kubectl` command:
 
 ```
-microk8s.kubectl get nodes
-microk8s.kubectl get services
+sudo microk8s.kubectl get nodes
+sudo microk8s.kubectl get services
 ```
 
 To use MicroK8s with your existing kubectl:
 
 ```
-microk8s.kubectl config view --raw > $HOME/.kube/config
+sudo microk8s.kubectl config view --raw > $HOME/.kube/config
 ```
+
+#### User access without sudo
+If the *microk8s* user group exist at MicroK8s `snap install` time, users on that group
+will be granted access to `microk8s` commands.
+
+At any point you grant access to a specific group with:
+```
+sudo snap set microk8s user.group=<GROUP_NAME>
+```
+
+For example, to create the `microk8s` group and add a user to it:
+```
+# Create the group
+sudo addgroup microk8s
+# Add a user to the group. The new group will be available on the user's next login.
+sudo usermod -a -G microk8s myuser
+
+# Let MicroK8s know which user group to trust
+sudo snap set microk8s user.group=microk8s
+```
+
 
 #### Kubernetes add-ons
 
 MicroK8s installs a barebones upstream Kubernetes. Additional services like dns and the Kubernetes dashboard can be enabled using the `microk8s.enable` command.
 
 ```
-microk8s.enable dns dashboard
+sudo microk8s.enable dns dashboard
 ```
 
 Use `microk8s.status` to see a list of enabled and available addons. You can find the addon manifests and/or scripts under `${SNAP}/actions/`, with `${SNAP}` pointing by default to `/snap/microk8s/current`.

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -4,15 +4,13 @@ exit_if_no_permissions() {
   # test if we can access the default kubeconfig
   if [ ! -r $SNAP_DATA/credentials/client.config ]; then
     echo "Insufficient permissions to access MicroK8s."
-    echo "You can either try again with sudo or grant access to a specific user group with:"
-    echo "    sudo snap set microk8s user.group=<GROUP_NAME>"
-    echo ""
+    echo "You can either try again with sudo or grant access to the 'microk8s' group:"
     echo ""
     echo "Example: create and configure a 'microk8s' group and add a user to it:"
     echo ""
     echo "    sudo addgroup microk8s"
-    echo "    sudo snap set microk8s user.group=microk8s"
-    echo "    sudo usermod -a -G microk8s myuser"
+    echo "    cd /var/snap/microk8s/current; sudo chgrp -R microk8s ./credentials ./certs ./args"
+    echo "    sudo usermod -a -G microk8s $USER"
     echo ""
     echo "The new group will be available on the user's next login."
     exit 1

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -6,6 +6,15 @@ exit_if_no_permissions() {
     echo "Not enough permissions to access MicroK8s."
     echo "You can either try again with sudo or grant access to a specific user group with:"
     echo "    sudo snap set microk8s user.group=<GROUP_NAME>"
+    echo ""
+    echo ""
+    echo "Example: create and configure a 'microk8s' group and add a user to it:"
+    echo ""
+    echo "    sudo addgroup microk8s"
+    echo "    sudo snap set microk8s user.group=microk8s"
+    echo "    sudo usermod -a -G microk8s myuser"
+    echo ""
+    echo "The new group will be available on the user's next login."
     exit 1
   fi
 }

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -4,12 +4,8 @@ exit_if_no_permissions() {
   # test if we can access the default kubeconfig
   if [ ! -r $SNAP_DATA/credentials/client.config ]; then
     echo "Insufficient permissions to access MicroK8s."
-    echo "You can either try again with sudo or grant access to the 'microk8s' group:"
+    echo "You can either try again with sudo or add the user $USER to the 'microk8s' group:"
     echo ""
-    echo "Example: create and configure a 'microk8s' group and add a user to it:"
-    echo ""
-    echo "    sudo addgroup microk8s"
-    echo "    cd /var/snap/microk8s/current; sudo chgrp -R microk8s ./credentials ./certs ./args"
     echo "    sudo usermod -a -G microk8s $USER"
     echo ""
     echo "The new group will be available on the user's next login."

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -3,7 +3,9 @@
 exit_if_no_permissions() {
   # test if we can access the default kubeconfig
   if [ ! -r $SNAP_DATA/credentials/client.config ]; then
-    echo "You do not have enough permissions to access MicroK8s. Please try again with sudo."
+    echo "Not enough permissions to access MicroK8s."
+    echo "You can either try again with sudo or grant access to a specific user group with:"
+    echo "    sudo snap set microk8s user.group=<GROUP_NAME>"
     exit 1
   fi
 }

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -3,7 +3,7 @@
 exit_if_no_permissions() {
   # test if we can access the default kubeconfig
   if [ ! -r $SNAP_DATA/credentials/client.config ]; then
-    echo "Not enough permissions to access MicroK8s."
+    echo "Insufficient permissions to access MicroK8s."
     echo "You can either try again with sudo or grant access to a specific user group with:"
     echo "    sudo snap set microk8s user.group=<GROUP_NAME>"
     echo ""

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -261,9 +261,11 @@ then
 fi
 
 # Securing important directories
-chmod 660 -R ${SNAP_DATA}/credentials/
-chmod 660 -R ${SNAP_DATA}/certs/
-chmod 660 -R ${SNAP_DATA}/args/
+for dir in "${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/"
+do
+  chmod -R ug+rwX ${dir}
+  chmod -R o-rwX ${dir}
+done
 
 user_group=$(snapctl get user.group)
 if [ ! -z "${user_group}" ]

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -265,6 +265,19 @@ chmod 660 -R ${SNAP_DATA}/credentials/
 chmod 660 -R ${SNAP_DATA}/certs/
 chmod 660 -R ${SNAP_DATA}/args/
 
+user_group=$(snapctl get user.group)
+if [ ! -z "${user_group}" ]
+then
+  chgrp "${user_group}" -R ${SNAP_DATA}/credentials/
+  chgrp "${user_group}" -R ${SNAP_DATA}/certs/
+  chgrp "${user_group}" -R ${SNAP_DATA}/args/
+elif getent group microk8s >/dev/null 2>&1
+then
+  chgrp microk8s -R ${SNAP_DATA}/credentials/
+  chgrp microk8s -R ${SNAP_DATA}/certs/
+  chgrp microk8s -R ${SNAP_DATA}/args/
+fi
+
 if grep -e "etcd.socket:2379" ${SNAP_DATA}/args/etcd
 then
   echo "Using a port for etcd"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -267,9 +267,15 @@ do
   chmod -R o-rwX ${dir}
 done
 
+# Try to greate the microk8s group. DO not fail the installation if something goes wrong
+if ! getent group microk8s >/dev/null 2>&1
+then
+  groupadd --system microk8s || true
+fi
+
 if getent group microk8s >/dev/null 2>&1
 then
-  chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/
+  chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ || true
 fi
 
 if grep -e "etcd.socket:2379" ${SNAP_DATA}/args/etcd

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -267,17 +267,9 @@ do
   chmod -R o-rwX ${dir}
 done
 
-user_group=$(snapctl get user.group)
-if [ ! -z "${user_group}" ]
+if getent group microk8s >/dev/null 2>&1
 then
-  chgrp "${user_group}" -R ${SNAP_DATA}/credentials/
-  chgrp "${user_group}" -R ${SNAP_DATA}/certs/
-  chgrp "${user_group}" -R ${SNAP_DATA}/args/
-elif getent group microk8s >/dev/null 2>&1
-then
-  chgrp microk8s -R ${SNAP_DATA}/credentials/
-  chgrp microk8s -R ${SNAP_DATA}/certs/
-  chgrp microk8s -R ${SNAP_DATA}/args/
+  chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/
 fi
 
 if grep -e "etcd.socket:2379" ${SNAP_DATA}/args/etcd

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -73,6 +73,8 @@ $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/proxy.config
 $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/proxy.config
 $SNAP/bin/sed -i 's/PASSWORD/'"${proxy_token}"'/g' ${SNAP_DATA}/credentials/proxy.config
 
-chmod 660 -R ${SNAP_DATA}/credentials/
-chmod 660 -R ${SNAP_DATA}/certs/
-chmod 660 -R ${SNAP_DATA}/args/
+for dir in "${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/"
+do
+  chmod -R ug+rwX ${dir}
+  chmod -R o-rwX ${dir}
+done


### PR DESCRIPTION
This PR is based on your feedback @balchua (on slack), @amozoss (on https://github.com/ubuntu/microk8s/issues/606) and @alexmurray. Thank you all.

~~If the *microk8s* group is present at installation time users of that group will be granted access to `microk8s.*` commands.
If the *microk8s* group is not present at installation time, the administrator can later set a group with trusted users with: `sudo snap set microk8s user.group=<GROUP_NAME>`.~~ 
(Updated due to the strict confinement we want to ultimately reach)

The *microk8s* group is created during installation or upgrade of the snap. Users in that group have access to `microks.*` commands. To add users you normally do a `sudo usermod -a -G microk8s $USER`.

Sudo users are always allowed to access MicroK8s.

Let me know what you think.