### PR TITLE
Re-enable cilium when upgrading

### DIFF
--- a/microk8s-resources/actions/enable.cilium.sh
+++ b/microk8s-resources/actions/enable.cilium.sh
@@ -74,7 +74,7 @@ else
   sudo cp "$SNAP_DATA/tmp/cilium/$CILIUM_DIR/install/kubernetes/cilium.yaml" "$SNAP_DATA/actions/cilium.yaml"
   sudo sed -i 's;path: \(/var/run/cilium\);path: '"$SNAP_DATA"'\1;g' "$SNAP_DATA/actions/cilium.yaml"
 
-  microk8s.status --wait-ready >/dev/null
+  ${SNAP}/microk8s-status.wrapper --wait-ready >/dev/null
   echo "Deploying $SNAP_DATA/actions/cilium.yaml. This may take several minutes."
   "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" apply -f "$SNAP_DATA/actions/cilium.yaml"
   "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" -n $NAMESPACE rollout status ds/cilium

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -302,3 +302,9 @@ then
   systemctl restart snap.${SNAP_NAME}.daemon-apiserver
 fi
 
+if [ -f "${SNAP_DATA}/bin/cilium" ]
+then
+  echo "Cilium is enabled we need to reconfigure it."
+  sudo rm -rf $SNAP_DATA/bin/cilium*
+  ${SNAP}/microk8s-enable.wrapper cilium
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -302,7 +302,7 @@ then
   systemctl restart snap.${SNAP_NAME}.daemon-apiserver
 fi
 
-if [ -f "${SNAP_DATA}/bin/cilium" ]
+if [ -L "${SNAP_DATA}/bin/cilium" ]
 then
   echo "Cilium is enabled we need to reconfigure it."
   sudo rm -rf $SNAP_DATA/bin/cilium*


### PR DESCRIPTION
@joestringer the cilium addon will not upgrade as expected. To see what happens deploy microk8s from beta enable some addons and cilium and then upgrade refresh to edge:
```
sudo snap install microk8s --classic --beta
sudo microk8s.status --wait-ready
sudo microk8s.enable dns dashboard
sudo microk8s.enable cilium
# simulate an upgrade
sudo snap refresh microk8s --channel edge
```
The cilium socket seems to be missing, but I was not able to revive it in an "elegant" way.

This PR will detect if cilium is enabled and and then force a re-enabling/re-installation. Not that pretty but I believe it works.

As this blocks our release cycle (failing upgrades will stop any new releases) I would like to merge it soon and perhaps do a proper fix at a later stage based on your feedback. Many thanks. 
