### PR TITLE
Return single IP from get_default_ip().

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -155,7 +155,7 @@ wait_for_service_shutdown() {
 get_default_ip() {
     # Get the IP of the default interface
     local DEFAULT_INTERFACE="$($SNAP/bin/netstat -rn | $SNAP/bin/grep '^0.0.0.0' | $SNAP/usr/bin/gawk '{print $NF}' | head -1)"
-    local IP_ADDR="$($SNAP/sbin/ip -o -4 addr list "$DEFAULT_INTERFACE" | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1)"
+    local IP_ADDR="$($SNAP/sbin/ip -o -4 addr list "$DEFAULT_INTERFACE" | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
     if [[ -z "$IP_ADDR" ]]
     then
         echo "none"


### PR DESCRIPTION
Multiple IP addresses causes etcd failed to start.

Some logs

```bash
sudo journalctl -u snap.microk8s.daemon-etcd.service -l --no-pager| tail -n 100
```

Replaced ip address to 555.555.555.555 & 10.10.10.10

> Sep 07 00:33:59 test-server systemd[1]: Started Service for snap application microk8s.daemon-etcd.
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + export PATH=/snap/microk8s/825/usr/sbin:/snap/microk8s/825/usr/bin:/snap/microk8s/825/sbin:/snap/microk8s/825/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + PATH=/snap/microk8s/825/usr/sbin:/snap/microk8s/825/usr/bin:/snap/microk8s/825/sbin:/snap/microk8s/825/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + export LD_LIBRARY_PATH=:/snap/microk8s/825/lib:/snap/microk8s/825/usr/lib:/snap/microk8s/825/lib/x86_64-linux-gnu:/snap/microk8s/825/usr/lib/x86_64-linux-gnu
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + LD_LIBRARY_PATH=:/snap/microk8s/825/lib:/snap/microk8s/825/usr/lib:/snap/microk8s/825/lib/x86_64-linux-gnu:/snap/microk8s/825/usr/lib/x86_64-linux-gnu
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + export LD_LIBRARY_PATH=/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void::/snap/microk8s/825/lib:/snap/microk8s/825/usr/lib:/snap/microk8s/825/lib/x86_64-linux-gnu:/snap/microk8s/825/usr/lib/x86_64-linux-gnu
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + LD_LIBRARY_PATH=/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void::/snap/microk8s/825/lib:/snap/microk8s/825/usr/lib:/snap/microk8s/825/lib/x86_64-linux-gnu:/snap/microk8s/825/usr/lib/x86_64-linux-gnu
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + source /snap/microk8s/825/actions/common/utils.sh
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + '[' -S /var/snap/microk8s/current/etcd.socket:2379 ']'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: ++ arch
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: ++ echo amd64
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + ARCH=amd64
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + '[' amd64 = amd64 ']'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: ++ get_default_ip
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: +++ /snap/microk8s/825/usr/bin/gawk '{print $NF}'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: +++ /snap/microk8s/825/bin/grep '^0.0.0.0'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: +++ /snap/microk8s/825/bin/netstat -rn
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: +++ head -1
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: ++ local DEFAULT_INTERFACE=eth0
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: +++ /snap/microk8s/825/sbin/ip -o -4 addr list eth0
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: +++ /snap/microk8s/825/usr/bin/cut -d/ -f1
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: +++ /snap/microk8s/825/usr/bin/gawk '{print $4}'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: ++ local 'IP_ADDR=555.555.555.555
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: 10.10.10.10'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: ++ [[ -z 555.555.555.555
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: 10.10.10.10 ]]
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: ++ echo '555.555.555.555
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: 10.10.10.10'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + export 'DEFAULT_INTERFACE_IP_ADDR=555.555.555.555
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: 10.10.10.10'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + DEFAULT_INTERFACE_IP_ADDR='555.555.555.555
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: 10.10.10.10'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: ++ cat /var/snap/microk8s/825/args/etcd
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + declare -a 'args=(--data-dir=${SNAP_COMMON}/var/run/etcd
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: --advertise-client-urls="https://${DEFAULT_INTERFACE_IP_ADDR}:12379"
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: --listen-client-urls=https://0.0.0.0:12379
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: --client-cert-auth=true
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: --trusted-ca-file=${SNAP_DATA}/certs/ca.crt
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: --cert-file=${SNAP_DATA}/certs/server.crt
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: --key-file=${SNAP_DATA}/certs/server.key)'
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: + exec /snap/microk8s/825/etcd --data-dir=/var/snap/microk8s/common/var/run/etcd '--advertise-client-urls=https://555.555.555.555
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: 10.10.10.10:12379' --listen-client-urls=https://0.0.0.0:12379 --client-cert-auth=true --trusted-ca-file=/var/snap/microk8s/825/certs/ca.crt --cert-file=/var/snap/microk8s/825/certs/server.crt --key-file=/var/snap/microk8s/825/certs/server.key
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: invalid value "https://555.555.555.555\n10.10.10.10:12379" for flag -advertise-client-urls: parse https://555.555.555.555
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: 10.10.10.10:12379: invalid character "\n" in host name
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]: usage: etcd [flags]
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        start an etcd server
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        etcd --version
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        show the version of etcd
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        etcd -h | --help
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        show the help information about etcd
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        etcd --config-file
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        path to the server configuration file
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        etcd gateway
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        run the stateless pass-through etcd TCP connection forwarding proxy
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        etcd grpc-proxy
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:        run the stateless etcd v3 gRPC L7 reverse proxy
> Sep 07 00:33:59 test-server microk8s.daemon-etcd[17830]:         
> Sep 07 00:33:59 test-server systemd[1]: snap.microk8s.daemon-etcd.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
> Sep 07 00:33:59 test-server systemd[1]: snap.microk8s.daemon-etcd.service: Failed with result 'exit-code'.
> Sep 07 00:34:00 test-server systemd[1]: snap.microk8s.daemon-etcd.service: Service hold-off time over, scheduling restart.
> Sep 07 00:34:00 test-server systemd[1]: snap.microk8s.daemon-etcd.service: Scheduled restart job, restart counter is at 5.
> Sep 07 00:34:00 test-server systemd[1]: Stopped Service for snap application microk8s.daemon-etcd.
> Sep 07 00:34:00 test-server systemd[1]: snap.microk8s.daemon-etcd.service: Start request repeated too quickly.
> Sep 07 00:34:00 test-server systemd[1]: snap.microk8s.daemon-etcd.service: Failed with result 'exit-code'.
> Sep 07 00:34:00 test-server systemd[1]: Failed to start Service for snap application microk8s.daemon-etcd.


This also fix #440 .