### PR TITLE
Allow for some time slack between dns and linkerd

### DIFF
--- a/microk8s-resources/actions/enable.linkerd.sh
+++ b/microk8s-resources/actions/enable.linkerd.sh
@@ -22,5 +22,8 @@ echo "Enabling Linkerd2"
 # pod/servicegraph will start failing without dns
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 "$SNAP/microk8s-enable.wrapper" dns
+# Allow some time for the apiserver to start
+sleep 5
+
 "$SNAP_DATA/bin/linkerd" "--kubeconfig=$SNAP_DATA/credentials/client.config" install "${argz[@]}" | $KUBECTL apply -f -
 echo "Linkerd is starting"


### PR DESCRIPTION
Some times enabling linkerd fails with: 
```
Enabling Linkerd2
Enabling DNS
Applying manifest
serviceaccount/coredns created
configmap/coredns created
deployment.apps/coredns created
service/kube-dns created
clusterrole.rbac.authorization.k8s.io/coredns created
clusterrolebinding.rbac.authorization.k8s.io/coredns created
Restarting kubelet
DNS is enabled
Unable to install the Linkerd control plane. It appears that there is an existing installation:

Get https://127.0.0.1:16443/apis/rbac.authorization.k8s.io/v1/clusterroles?labelSelector=linkerd.io%2Fcontrol-plane-ns: http2: server sent GOAWAY and closed the connection; LastStreamID=3, ErrCode=NO_ERROR, debug=""
Get https://127.0.0.1:16443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?labelSelector=linkerd.io%2Fcontrol-plane-ns: dial tcp 127.0.0.1:16443: connect: connection refused
Get https://127.0.0.1:16443/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions?labelSelector=linkerd.io%2Fcontrol-plane-ns: dial tcp 127.0.0.1:16443: connect: connection refused
Get https://127.0.0.1:16443/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations?labelSelector=linkerd.io%2Fcontrol-plane-ns: dial tcp 127.0.0.1:16443: connect: connection refused
Get https://127.0.0.1:16443/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations?labelSelector=linkerd.io%2Fcontrol-plane-ns: dial tcp 127.0.0.1:16443: connect: connection refused
Get https://127.0.0.1:16443/apis/policy/v1beta1/podsecuritypolicies?labelSelector=linkerd.io%2Fcontrol-plane-ns: dial tcp 127.0.0.1:16443: connect: connection refused

If you are sure you'd like to have a fresh install, remove these resources with:

    linkerd install --ignore-cluster | kubectl delete -f -

Otherwise, you can use the --ignore-cluster flag to overwrite the existing global resources.
error: no objects passed to apply
Failed to enable linkerd
```