### PR TITLE
Fixes on cilium

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -60,7 +60,7 @@ remove_vxlan_interfaces() {
   do
     if ! [ -z "$link" ] && $SNAP/sbin/ip link show ${link} &> /dev/null
     then
-      echo "Need to deleting old ${link} link"
+      echo "Deleting old ${link} link"
       sudo $SNAP/sbin/ip link delete ${link}
     fi
   done

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -60,7 +60,8 @@ remove_vxlan_interfaces() {
   do
     if ! [ -z "$link" ] && $SNAP/sbin/ip link show ${link} &> /dev/null
     then
-      $SNAP/sbin/ip link delete ${link}
+      echo "Need to deleting old ${link} link"
+      sudo $SNAP/sbin/ip link delete ${link}
     fi
   done
 }

--- a/microk8s-resources/actions/disable.cilium.sh
+++ b/microk8s-resources/actions/disable.cilium.sh
@@ -31,7 +31,7 @@ sudo rm -rf "$SNAP_DATA/sys/fs/bpf"
 
 if $SNAP/sbin/ip link show "cilium_vxlan"
 then
-  echo "Need to deleting old cilium_vxlan link"
+  echo "Deleting old cilium_vxlan link"
   sudo $SNAP/sbin/ip link delete "cilium_vxlan"
 fi
 

--- a/microk8s-resources/actions/disable.cilium.sh
+++ b/microk8s-resources/actions/disable.cilium.sh
@@ -31,7 +31,8 @@ sudo rm -rf "$SNAP_DATA/sys/fs/bpf"
 
 if $SNAP/sbin/ip link show "cilium_vxlan"
 then
-  $SNAP/sbin/ip link delete "cilium_vxlan"
+  echo "Need to deleting old cilium_vxlan link"
+  sudo $SNAP/sbin/ip link delete "cilium_vxlan"
 fi
 
 set_service_expected_to_start flanneld

--- a/microk8s-resources/actions/disable.cilium.sh
+++ b/microk8s-resources/actions/disable.cilium.sh
@@ -6,49 +6,46 @@ source $SNAP/actions/common/utils.sh
 
 echo "Disabling Cilium"
 
-if [ -L "${SNAP_DATA}/bin/cilium" ]
+"$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" delete -f "$SNAP_DATA/actions/cilium.yaml"
+
+# Give K8s some time to process the deletion request
+sleep 15
+cilium=$(wait_for_service_shutdown "kube-system" "k8s-app=cilium")
+if [[ $cilium == fail ]]
 then
-  "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" delete -f "$SNAP_DATA/actions/cilium.yaml"
-
-  # Give K8s some time to process the deletion request
-  sleep 15
-  cilium=$(wait_for_service_shutdown "kube-system" "k8s-app=cilium")
-  if [[ $cilium == fail ]]
-  then
-    echo "Cilium did not shut down on time. Proceeding."
-  fi
-
-  cilium=$(wait_for_service_shutdown "kube-system" "name=cilium-operator")
-  if [[ $cilium == fail ]]
-  then
-    echo "Cilium operator did not shut down on time. Proceeding."
-  fi
-  sudo rm -f "$SNAP_DATA/args/cni-network/05-cilium-cni.conf"
-  sudo rm -f "$SNAP_DATA/opt/cni/bin/cilium-cni"
-  sudo rm -rf $SNAP_DATA/bin/cilium*
-  sudo rm -f "$SNAP_DATA/actions/cilium.yaml"
-  sudo rm -rf "$SNAP_DATA/actions/cilium"
-  sudo rm -rf "$SNAP_DATA/var/run/cilium"
-  sudo rm -rf "$SNAP_DATA/sys/fs/bpf"
-
-  if $SNAP/sbin/ip link show "cilium_vxlan"
-  then
-    $SNAP/sbin/ip link delete "cilium_vxlan"
-  fi
-
-  set_service_expected_to_start flanneld
-
-  echo "Restarting kubelet"
-  refresh_opt_in_config "cni-bin-dir" "\${SNAP}/opt/cni/bin/" kubelet
-  sudo systemctl restart snap.${SNAP_NAME}.daemon-kubelet
-  echo "Restarting containerd"
-  if ! grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
-    sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  fi
-  sudo systemctl restart snap.${SNAP_NAME}.daemon-containerd
-
-  echo "Restarting flanneld"
-  sudo systemctl stop snap.${SNAP_NAME}.daemon-flanneld
-
-  echo "Cilium is terminating"
+  echo "Cilium did not shut down on time. Proceeding."
 fi
+
+cilium=$(wait_for_service_shutdown "kube-system" "name=cilium-operator")
+if [[ $cilium == fail ]]
+then
+  echo "Cilium operator did not shut down on time. Proceeding."
+fi
+sudo rm -f "$SNAP_DATA/args/cni-network/05-cilium-cni.conf"
+sudo rm -f "$SNAP_DATA/opt/cni/bin/cilium-cni"
+sudo rm -rf $SNAP_DATA/bin/cilium*
+sudo rm -f "$SNAP_DATA/actions/cilium.yaml"
+sudo rm -rf "$SNAP_DATA/actions/cilium"
+sudo rm -rf "$SNAP_DATA/var/run/cilium"
+sudo rm -rf "$SNAP_DATA/sys/fs/bpf"
+
+if $SNAP/sbin/ip link show "cilium_vxlan"
+then
+  $SNAP/sbin/ip link delete "cilium_vxlan"
+fi
+
+set_service_expected_to_start flanneld
+
+echo "Restarting kubelet"
+refresh_opt_in_config "cni-bin-dir" "\${SNAP}/opt/cni/bin/" kubelet
+sudo systemctl restart snap.${SNAP_NAME}.daemon-kubelet
+echo "Restarting containerd"
+if ! grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
+  sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
+fi
+sudo systemctl restart snap.${SNAP_NAME}.daemon-containerd
+
+echo "Restarting flanneld"
+sudo systemctl stop snap.${SNAP_NAME}.daemon-flanneld
+
+echo "Cilium is terminating"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -261,7 +261,7 @@ then
 fi
 
 # Securing important directories
-for dir in "${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/"
+for dir in "${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock"
 do
   chmod -R ug+rwX ${dir}
   chmod -R o-rwX ${dir}


### PR DESCRIPTION
Three fixes:
- Problem with cilium where a user in the microk8s group cannot enable it.
```
touch: cannot touch '/var/snap/microk8s/x1/var/lock/no-flanneld': Permission denied
```

- Cleans the cilium installation even if it half done. So we do not get into a broken state.

- sudo use when deleting vxlan links