### PR TITLE
Updates on manifests, depricated apiVersion, hostpath from 1.0.0

### DIFF
--- a/microk8s-resources/actions/dashboard.yaml
+++ b/microk8s-resources/actions/dashboard.yaml
@@ -207,7 +207,7 @@ spec:
 
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: monitoring-influxdb-grafana-v4
   namespace: kube-system
@@ -347,7 +347,7 @@ data:
     kind: NannyConfiguration
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster-v1.5.2

--- a/microk8s-resources/actions/dns.yaml
+++ b/microk8s-resources/actions/dns.yaml
@@ -55,7 +55,7 @@ data:
     ["8.8.8.8", "8.8.4.4"]
 # Why set upstream ns: https://github.com/kubernetes/minikube/issues/2027
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-dns

--- a/microk8s-resources/actions/gpu.yaml
+++ b/microk8s-resources/actions/gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nvidia-device-plugin-daemonset

--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: default-http-backend
@@ -162,7 +162,7 @@ kind: ConfigMap
 metadata:
   name: nginx-load-balancer-microk8s-conf
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nginx-ingress-microk8s-controller

--- a/microk8s-resources/actions/metrics-server.yaml
+++ b/microk8s-resources/actions/metrics-server.yaml
@@ -70,7 +70,7 @@ data:
     apiVersion: nannyconfig/v1alpha1
     kind: NannyConfiguration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server-v0.2.1

--- a/microk8s-resources/actions/prometheus/0prometheus-operator-deployment.yaml
+++ b/microk8s-resources/actions/prometheus/0prometheus-operator-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/microk8s-resources/actions/prometheus/grafana-deployment.yaml
+++ b/microk8s-resources/actions/prometheus/grafana-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/microk8s-resources/actions/prometheus/kube-state-metrics-deployment.yaml
+++ b/microk8s-resources/actions/prometheus/kube-state-metrics-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/microk8s-resources/actions/prometheus/node-exporter-daemonset.yaml
+++ b/microk8s-resources/actions/prometheus/node-exporter-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/microk8s-resources/actions/prometheus/prometheus-adapter-deployment.yaml
+++ b/microk8s-resources/actions/prometheus/prometheus-adapter-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-adapter

--- a/microk8s-resources/actions/registry.yaml
+++ b/microk8s-resources/actions/registry.yaml
@@ -17,7 +17,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/microk8s-resources/actions/registry.yaml
+++ b/microk8s-resources/actions/registry.yaml
@@ -28,7 +28,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      k8s-app: registry
+      app: registry
   template:
     metadata:
       labels:

--- a/microk8s-resources/actions/registry.yaml
+++ b/microk8s-resources/actions/registry.yaml
@@ -26,6 +26,9 @@ metadata:
   namespace: container-registry
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: registry
   template:
     metadata:
       labels:

--- a/microk8s-resources/actions/storage.yaml
+++ b/microk8s-resources/actions/storage.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hostpath-provisioner
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: microk8s-hostpath
       containers:
         - name: hostpath-provisioner
-          image: cdkbot/hostpath-provisioner-$ARCH:latest
+          image: cdkbot/hostpath-provisioner-$ARCH:1.0.0
           env:
             - name: NODE_NAME
               valueFrom:

--- a/tests/templates/bookinfo.yaml
+++ b/tests/templates/bookinfo.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     app: details
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: details-v1
@@ -63,7 +63,7 @@ spec:
   selector:
     app: ratings
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v1
@@ -98,7 +98,7 @@ spec:
   selector:
     app: reviews
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v1
@@ -117,7 +117,7 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
@@ -136,7 +136,7 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v3
@@ -171,7 +171,7 @@ spec:
   selector:
     app: productpage
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productpage-v1

--- a/tests/templates/emojivoto.yaml
+++ b/tests/templates/emojivoto.yaml
@@ -22,7 +22,7 @@ metadata:
   name: web
   namespace: emojivoto
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -143,7 +143,7 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -264,7 +264,7 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -391,7 +391,7 @@ spec:
     port: 80
     targetPort: 80
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/tests/templates/ingress.yaml
+++ b/tests/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -48,7 +48,7 @@ spec:
   selector:
     app: microbot
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
  name: microbot-ingress-xip
@@ -62,7 +62,7 @@ spec:
              serviceName: microbot
              servicePort: 80
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
  name: microbot-ingress-nip


### PR DESCRIPTION
- Address api version deprications: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
- Fixes: https://github.com/ubuntu/microk8s/issues/632