### PR TITLE
Fixes to allow refresh from 1.13

### DIFF
--- a/microk8s-resources/wrappers/run-flanneld-with-args
+++ b/microk8s-resources/wrappers/run-flanneld-with-args
@@ -8,6 +8,9 @@ source $SNAP/actions/common/utils.sh
 
 exit_if_service_not_expected_to_start flanneld
 
+# Allow some slack for containerd and etcd to start
+sleep 5
+
 # TODO rewrite for snaps
 etcd_endpoints="$(cat $SNAP_DATA/args/flanneld | grep "etcd-endpoints" | tr "=" " "| awk '{print $2}')"
 cert_file="$(cat $SNAP_DATA/args/flanneld | grep "etcd-certfile" | tr "=" " "| awk '{print $2}')"
@@ -26,7 +29,6 @@ if ! "${SNAP}/etcdctl" --endpoint "${etcd_endpoints}" --cert-file "${cert_file}"
 fi
 
 "${SNAP}/etcdctl" --endpoint "${etcd_endpoints}"  --cert-file "${cert_file}" --key-file "${key_file}" --ca-file "${ca_file}" set "/coreos.com/network/config" "$data"
-
 
 # This is really the only way I could find to get the args passed in correctly. WTF
 declare -a args="($(cat $SNAP_DATA/args/flanneld))"

--- a/microk8s-resources/wrappers/run-flanneld-with-args
+++ b/microk8s-resources/wrappers/run-flanneld-with-args
@@ -9,7 +9,17 @@ source $SNAP/actions/common/utils.sh
 exit_if_service_not_expected_to_start flanneld
 
 # Allow some slack for containerd and etcd to start
+# so we avoid this edge case: https://forum.snapcraft.io/t/restarting-services-from-configure-hook-race-condition/2513/13
 sleep 5
+
+n=0
+until [ $n -ge 10 ]
+do
+  test -e "$SNAP_DATA/args/flannel-network-mgr-config" && "$SNAP_DATA/args/flanneld" && break
+  echo "Waiting for flannled configuration to appear. (attempt $n)"
+  n=$[$n+1]
+  sleep 2
+done
 
 # TODO rewrite for snaps
 etcd_endpoints="$(cat $SNAP_DATA/args/flanneld | grep "etcd-endpoints" | tr "=" " "| awk '{print $2}')"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -20,8 +20,8 @@ then
   "$SNAP/bin/sed" -i 's@\${SNAP}/certs/serviceaccount.key@\${SNAP_DATA}/certs/serviceaccount.key@g' ${SNAP_DATA}/args/kube-apiserver
   "$SNAP/bin/sed" -i 's@\${SNAP}/certs/ca.crt@\${SNAP_DATA}/certs/ca.crt@g' ${SNAP_DATA}/args/kube-controller-manager
   "$SNAP/bin/sed" -i 's@\${SNAP}/certs/serviceaccount.key@\${SNAP_DATA}/certs/serviceaccount.key@g' ${SNAP_DATA}/args/kube-controller-manager
-  snapctl restart snap.${SNAP_NAME}.daemon-apiserver
-  snapctl restart snap.${SNAP_NAME}.daemon-controller-manager
+  snapctl restart ${SNAP_NAME}.daemon-apiserver
+  snapctl restart ${SNAP_NAME}.daemon-controller-manager
 fi
 
 #Allow the ability to add external IPs to the csr, by moving the csr.conf.template to SNAP_DATA 
@@ -37,7 +37,7 @@ then
   # Add a new line at the end
   echo "" >> ${SNAP_DATA}/args/kube-apiserver
   echo "--requestheader-client-ca-file=\${SNAP_DATA}/certs/ca.crt" >> ${SNAP_DATA}/args/kube-apiserver
-  snapctl restart snap.${SNAP_NAME}.daemon-apiserver
+  snapctl restart ${SNAP_NAME}.daemon-apiserver
 fi
 
 # Enable the aggregation layer (continue)
@@ -51,7 +51,7 @@ then
   echo '--requestheader-username-headers=X-Remote-User' >> ${SNAP_DATA}/args/kube-apiserver
   echo '--proxy-client-cert-file=${SNAP_DATA}/certs/front-proxy-client.crt' >> ${SNAP_DATA}/args/kube-apiserver
   echo '--proxy-client-key-file=${SNAP_DATA}/certs/front-proxy-client.key' >> ${SNAP_DATA}/args/kube-apiserver
-  snapctl restart snap.${SNAP_NAME}.daemon-apiserver
+  snapctl restart ${SNAP_NAME}.daemon-apiserver
 fi
 
 # Patch for issue: https://github.com/ubuntu/microk8s/issues/121
@@ -98,8 +98,8 @@ then
   skip_opt_in_config docker kubelet
   skip_opt_in_config docker-endpoint kubelet
 
-  snapctl restart snap.${SNAP_NAME}.daemon-containerd
-  snapctl restart snap.${SNAP_NAME}.daemon-kubelet
+  snapctl restart ${SNAP_NAME}.daemon-containerd
+  snapctl restart ${SNAP_NAME}.daemon-kubelet
 
   if [ -e ${SNAP_DATA}/args/dockerd ] && grep -e "default-runtime=nvidia" ${SNAP_DATA}/args/dockerd
   then
@@ -115,8 +115,8 @@ fi
 if [ "$(produce_certs)" == "1" ]
 then
     rm -rf .srl
-    snapctl restart snap.${SNAP_NAME}.daemon-apiserver.service
-    snapctl restart snap.${SNAP_NAME}.daemon-proxy.service
+    snapctl restart ${SNAP_NAME}.daemon-apiserver
+    snapctl restart ${SNAP_NAME}.daemon-proxy
 fi
 
 # Make containerd stream server listen to localhost
@@ -127,8 +127,8 @@ then
     then
         "$SNAP/bin/sed" -i 's@stream_server_port = "10010"@stream_server_port = "0"@g' ${SNAP_DATA}/args/containerd-template.toml
     fi
-    snapctl restart snap.${SNAP_NAME}.daemon-containerd
-    snapctl restart snap.${SNAP_NAME}.daemon-kubelet
+    snapctl restart ${SNAP_NAME}.daemon-containerd
+    snapctl restart ${SNAP_NAME}.daemon-kubelet
 fi
 
 # With v1.15 allow-privileged is removed from kubelet
@@ -136,7 +136,7 @@ if grep -e "\-\-allow-privileged" ${SNAP_DATA}/args/kubelet
 then
   echo "Patching 1.15 allow-privileged"
   sudo "${SNAP}/bin/sed" -i '/allow-privileged/d' ${SNAP_DATA}/args/kubelet
-  snapctl restart snap.${SNAP_NAME}.daemon-kubelet
+  snapctl restart ${SNAP_NAME}.daemon-kubelet
 fi
 
 if ([ -f "$SNAP_USER_COMMON/istio-auth.lock" ] || [ -f "$SNAP_USER_COMMON/istio-auth.lock" ]) && ! [ -f "$SNAP_DATA/bin/istioctl" ]
@@ -181,7 +181,7 @@ then
   refresh_opt_in_config kubeconfig \${SNAP_DATA}/credentials/kubelet.config kubelet
   refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
 
-  snapctl restart snap.${SNAP_NAME}.daemon-kubelet
+  snapctl restart ${SNAP_NAME}.daemon-kubelet
   need_api_restart=true
 fi
 
@@ -206,7 +206,7 @@ then
   skip_opt_in_config master kube-proxy
   refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
 
-  snapctl restart snap.${SNAP_NAME}.daemon-proxy
+  snapctl restart ${SNAP_NAME}.daemon-proxy
   need_api_restart=true
 fi
 
@@ -231,7 +231,7 @@ then
   skip_opt_in_config master kube-scheduler
   refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
 
-  snapctl restart snap.${SNAP_NAME}.daemon-scheduler
+  snapctl restart ${SNAP_NAME}.daemon-scheduler
   need_api_restart=true
 fi
 
@@ -257,7 +257,7 @@ then
   refresh_opt_in_config use-service-account-credentials true kube-controller-manager
 
   refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
-  snapctl restart snap.${SNAP_NAME}.daemon-controller-manager
+  snapctl restart ${SNAP_NAME}.daemon-controller-manager
 fi
 
 # Securing important directories
@@ -285,7 +285,7 @@ then
   cp ${SNAP}/default-args/flanneld ${SNAP_DATA}/args/
   cp ${SNAP}/default-args/flannel-template.conflist ${SNAP_DATA}/args/
   cp ${SNAP}/default-args/flannel-network-mgr-config ${SNAP_DATA}/args/
-  snapctl restart snap.${SNAP_NAME}.daemon-flanneld
+  snapctl restart ${SNAP_NAME}.daemon-flanneld
 fi
 
 if grep -e "etcd.socket:2379" ${SNAP_DATA}/args/etcd
@@ -309,7 +309,7 @@ fi
 
 if [ "${need_api_restart}" ]
 then
-  snapctl restart snap.${SNAP_NAME}.daemon-apiserver
+  snapctl restart ${SNAP_NAME}.daemon-apiserver
 fi
 
 if [ -L "${SNAP_DATA}/bin/cilium" ]

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -20,8 +20,8 @@ then
   "$SNAP/bin/sed" -i 's@\${SNAP}/certs/serviceaccount.key@\${SNAP_DATA}/certs/serviceaccount.key@g' ${SNAP_DATA}/args/kube-apiserver
   "$SNAP/bin/sed" -i 's@\${SNAP}/certs/ca.crt@\${SNAP_DATA}/certs/ca.crt@g' ${SNAP_DATA}/args/kube-controller-manager
   "$SNAP/bin/sed" -i 's@\${SNAP}/certs/serviceaccount.key@\${SNAP_DATA}/certs/serviceaccount.key@g' ${SNAP_DATA}/args/kube-controller-manager
-  systemctl restart snap.${SNAP_NAME}.daemon-apiserver
-  systemctl restart snap.${SNAP_NAME}.daemon-controller-manager
+  snapctl restart snap.${SNAP_NAME}.daemon-apiserver
+  snapctl restart snap.${SNAP_NAME}.daemon-controller-manager
 fi
 
 #Allow the ability to add external IPs to the csr, by moving the csr.conf.template to SNAP_DATA 
@@ -37,7 +37,7 @@ then
   # Add a new line at the end
   echo "" >> ${SNAP_DATA}/args/kube-apiserver
   echo "--requestheader-client-ca-file=\${SNAP_DATA}/certs/ca.crt" >> ${SNAP_DATA}/args/kube-apiserver
-  systemctl restart snap.${SNAP_NAME}.daemon-apiserver
+  snapctl restart snap.${SNAP_NAME}.daemon-apiserver
 fi
 
 # Enable the aggregation layer (continue)
@@ -51,7 +51,7 @@ then
   echo '--requestheader-username-headers=X-Remote-User' >> ${SNAP_DATA}/args/kube-apiserver
   echo '--proxy-client-cert-file=${SNAP_DATA}/certs/front-proxy-client.crt' >> ${SNAP_DATA}/args/kube-apiserver
   echo '--proxy-client-key-file=${SNAP_DATA}/certs/front-proxy-client.key' >> ${SNAP_DATA}/args/kube-apiserver
-  systemctl restart snap.${SNAP_NAME}.daemon-apiserver
+  snapctl restart snap.${SNAP_NAME}.daemon-apiserver
 fi
 
 # Patch for issue: https://github.com/ubuntu/microk8s/issues/121
@@ -98,8 +98,8 @@ then
   skip_opt_in_config docker kubelet
   skip_opt_in_config docker-endpoint kubelet
 
-  systemctl restart snap.${SNAP_NAME}.daemon-containerd
-  systemctl restart snap.${SNAP_NAME}.daemon-kubelet
+  snapctl restart snap.${SNAP_NAME}.daemon-containerd
+  snapctl restart snap.${SNAP_NAME}.daemon-kubelet
 
   if [ -e ${SNAP_DATA}/args/dockerd ] && grep -e "default-runtime=nvidia" ${SNAP_DATA}/args/dockerd
   then
@@ -115,8 +115,8 @@ fi
 if [ "$(produce_certs)" == "1" ]
 then
     rm -rf .srl
-    systemctl restart snap.${SNAP_NAME}.daemon-apiserver.service
-    systemctl restart snap.${SNAP_NAME}.daemon-proxy.service
+    snapctl restart snap.${SNAP_NAME}.daemon-apiserver.service
+    snapctl restart snap.${SNAP_NAME}.daemon-proxy.service
 fi
 
 # Make containerd stream server listen to localhost
@@ -127,8 +127,8 @@ then
     then
         "$SNAP/bin/sed" -i 's@stream_server_port = "10010"@stream_server_port = "0"@g' ${SNAP_DATA}/args/containerd-template.toml
     fi
-    systemctl restart snap.${SNAP_NAME}.daemon-containerd
-    systemctl restart snap.${SNAP_NAME}.daemon-kubelet
+    snapctl restart snap.${SNAP_NAME}.daemon-containerd
+    snapctl restart snap.${SNAP_NAME}.daemon-kubelet
 fi
 
 # With v1.15 allow-privileged is removed from kubelet
@@ -136,7 +136,7 @@ if grep -e "\-\-allow-privileged" ${SNAP_DATA}/args/kubelet
 then
   echo "Patching 1.15 allow-privileged"
   sudo "${SNAP}/bin/sed" -i '/allow-privileged/d' ${SNAP_DATA}/args/kubelet
-  systemctl restart snap.${SNAP_NAME}.daemon-kubelet
+  snapctl restart snap.${SNAP_NAME}.daemon-kubelet
 fi
 
 if ([ -f "$SNAP_USER_COMMON/istio-auth.lock" ] || [ -f "$SNAP_USER_COMMON/istio-auth.lock" ]) && ! [ -f "$SNAP_DATA/bin/istioctl" ]
@@ -181,7 +181,7 @@ then
   refresh_opt_in_config kubeconfig \${SNAP_DATA}/credentials/kubelet.config kubelet
   refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
 
-  systemctl restart snap.${SNAP_NAME}.daemon-kubelet
+  snapctl restart snap.${SNAP_NAME}.daemon-kubelet
   need_api_restart=true
 fi
 
@@ -206,7 +206,7 @@ then
   skip_opt_in_config master kube-proxy
   refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
 
-  systemctl restart snap.${SNAP_NAME}.daemon-proxy
+  snapctl restart snap.${SNAP_NAME}.daemon-proxy
   need_api_restart=true
 fi
 
@@ -231,7 +231,7 @@ then
   skip_opt_in_config master kube-scheduler
   refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
 
-  systemctl restart snap.${SNAP_NAME}.daemon-scheduler
+  snapctl restart snap.${SNAP_NAME}.daemon-scheduler
   need_api_restart=true
 fi
 
@@ -257,7 +257,7 @@ then
   refresh_opt_in_config use-service-account-credentials true kube-controller-manager
 
   refresh_opt_in_config token-auth-file \${SNAP_DATA}/credentials/known_tokens.csv kube-apiserver
-  systemctl restart snap.${SNAP_NAME}.daemon-controller-manager
+  snapctl restart snap.${SNAP_NAME}.daemon-controller-manager
 fi
 
 # Securing important directories
@@ -285,7 +285,7 @@ then
   cp ${SNAP}/default-args/flanneld ${SNAP_DATA}/args/
   cp ${SNAP}/default-args/flannel-template.conflist ${SNAP_DATA}/args/
   cp ${SNAP}/default-args/flannel-network-mgr-config ${SNAP_DATA}/args/
-  systemctl restart snap.${SNAP_NAME}.daemon-flanneld
+  snapctl restart snap.${SNAP_NAME}.daemon-flanneld
 fi
 
 if grep -e "etcd.socket:2379" ${SNAP_DATA}/args/etcd
@@ -298,7 +298,7 @@ then
   refresh_opt_in_config trusted-ca-file \${SNAP_DATA}/certs/ca.crt etcd
   refresh_opt_in_config cert-file \${SNAP_DATA}/certs/server.crt etcd
   refresh_opt_in_config key-file \${SNAP_DATA}/certs/server.key etcd
-  systemctl restart snap.${SNAP_NAME}.daemon-etcd
+  snapctl restart snap.${SNAP_NAME}.daemon-etcd
 
   refresh_opt_in_config etcd-servers https://127.0.0.1:12379 kube-apiserver
   refresh_opt_in_config etcd-cafile \${SNAP_DATA}/certs/ca.crt kube-apiserver
@@ -309,7 +309,7 @@ fi
 
 if [ "${need_api_restart}" ]
 then
-  systemctl restart snap.${SNAP_NAME}.daemon-apiserver
+  snapctl restart snap.${SNAP_NAME}.daemon-apiserver
 fi
 
 if [ -L "${SNAP_DATA}/bin/cilium" ]

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -298,7 +298,7 @@ then
   refresh_opt_in_config trusted-ca-file \${SNAP_DATA}/certs/ca.crt etcd
   refresh_opt_in_config cert-file \${SNAP_DATA}/certs/server.crt etcd
   refresh_opt_in_config key-file \${SNAP_DATA}/certs/server.key etcd
-  snapctl restart snap.${SNAP_NAME}.daemon-etcd
+  snapctl restart ${SNAP_NAME}.daemon-etcd
 
   refresh_opt_in_config etcd-servers https://127.0.0.1:12379 kube-apiserver
   refresh_opt_in_config etcd-cafile \${SNAP_DATA}/certs/ca.crt kube-apiserver

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -280,6 +280,7 @@ fi
 
 if ! [ -f "${SNAP_DATA}/args/flanneld" ]
 then
+  mkdir -p ${SNAP_DATA}/args/cni-network/
   cp -r ${SNAP}/default-args/cni-network/flannel.conflist ${SNAP_DATA}/args/cni-network/
   cp ${SNAP}/default-args/flanneld ${SNAP_DATA}/args/
   cp ${SNAP}/default-args/flannel-template.conflist ${SNAP_DATA}/args/

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -285,6 +285,8 @@ then
   cp ${SNAP}/default-args/flanneld ${SNAP_DATA}/args/
   cp ${SNAP}/default-args/flannel-template.conflist ${SNAP_DATA}/args/
   cp ${SNAP}/default-args/flannel-network-mgr-config ${SNAP_DATA}/args/
+  snapctl restart ${SNAP_NAME}.daemon-etcd
+  snapctl restart ${SNAP_NAME}.daemon-containerd
   snapctl restart ${SNAP_NAME}.daemon-flanneld
 fi
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -80,11 +80,15 @@ then
 fi
 
 # Upgrading to containerd
-if [ ! -e ${SNAP_DATA}/args/containerd ]
+if [ ! -e ${SNAP_DATA}/args/containerd ] ||
+   grep -e "\-\-docker unix://\${SNAP_DATA}/docker.sock" ${SNAP_DATA}/args/kubelet
 then
   echo "Making sure we have containerd file"
+  cp ${SNAP_DATA}/args/containerd ${SNAP_DATA}/args/containerd.backup || true
   cp ${SNAP}/default-args/containerd ${SNAP_DATA}/args/containerd
+  cp ${SNAP_DATA}/args/containerd-template.toml ${SNAP_DATA}/args/containerd-template.toml.backup || true
   cp ${SNAP}/default-args/containerd-template.toml ${SNAP_DATA}/args/containerd-template.toml
+  cp ${SNAP_DATA}/args/containerd-env ${SNAP_DATA}/args/containerd-env.backup || true
   cp ${SNAP}/default-args/containerd-env ${SNAP_DATA}/args/containerd-env
 
   cp -r ${SNAP}/default-args/cni-network ${SNAP_DATA}/args/


### PR DESCRIPTION
Fixes https://github.com/ubuntu/microk8s/issues/641

Upgrading from 1.13 to 1.16 is failing with: 
```
+ cp -r /snap/microk8s/860/default-args/cni-network/flannel.conflist /var/snap/microk8s/860/args/cni-network/
cp: cannot create regular file '/var/snap/microk8s/860/args/cni-network/': Not a directory
-----)
```
Although this upgrade is not recommended (see https://github.com/ubuntu/microk8s/issues/641) it has to work.

Other fixes
- Use snapctl to restart services in configure hook.
- Flanneld wait for config files before starting.