### PR TITLE
Hacks to get knative 0.9.0 in 1.16 working

### DIFF
--- a/build-scripts/fetch-other-binaries.sh
+++ b/build-scripts/fetch-other-binaries.sh
@@ -24,5 +24,10 @@ mkdir -p $KUBE_SNAP_BINS
     curl -L https://github.com/knative/serving/releases/download/$KNATIVE_SERVING_VERSION/serving.yaml -o ./knative-yaml/serving.yaml
     curl -L https://github.com/knative/eventing/releases/download/$KNATIVE_EVENTING_VERSION/release.yaml  -o ./knative-yaml/release.yaml
     curl -L https://github.com/knative/serving/releases/download/$KNATIVE_SERVING_VERSION/monitoring.yaml  -o ./knative-yaml/monitoring.yaml
+
+    # This patch should be removed as soon as https://github.com/knative/serving/issues/5599 is fixed
+    sed -i 's@extensions/v1beta1@apps/v1@g'  ./knative-yaml/monitoring.yaml
+    sed -i '570 i \ \ selector:\n    matchLabels:\n      app: kube-state-metrics' ./knative-yaml/monitoring.yaml
+    sed -i '6985 i \ \ selector:\n    matchLabels:\n      app: node-exporter' ./knative-yaml/monitoring.yaml
   fi
 )

--- a/microk8s-resources/actions/enable.knative.sh
+++ b/microk8s-resources/actions/enable.knative.sh
@@ -4,12 +4,6 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-echo "Knative is not yet available in v1.16 MicroK8s. Please install the v1.15 release:"
-echo ""
-echo "sudo snap install microk8s --classic --channel=1.15/stable"
-echo ""
-exit 1
-
 echo "Enabling Knative"
 
 # Knative require istio

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -23,6 +23,7 @@ from validators import (
 from utils import (
     microk8s_enable,
     wait_for_pod_state,
+    wait_for_namespace_termination,
     microk8s_disable,
     microk8s_reset
 )
@@ -124,10 +125,9 @@ class TestAddons(object):
         validate_knative()
         print("Disabling Knative")
         microk8s_disable("knative")
-        time.sleep(60)
+        wait_for_namespace_termination("knative-serving", timeout_insec=600)
         print("Disabling Istio")
         microk8s_disable("istio")
-        time.sleep(60)
 
     def test_cilium(self):
         """

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import platform
+import time
 
 from validators import (
     validate_dns_dashboard,
@@ -115,17 +116,18 @@ class TestAddons(object):
             return
 
         print("Enabling Knative and Istio")
-        p = Popen("/snap/bin/microk8s.enable istio".split(), stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+        p = Popen("/snap/bin/microk8s.enable knative".split(), stdout=PIPE, stdin=PIPE, stderr=STDOUT)
         p.communicate(input=b'N\n')[0]
         print("Validating Istio")
         validate_istio()
-        ''' Disabling for 1.16 '''
-        # print("Validating Knative")
-        # validate_knative()
-        # print("Disabling Knative")
-        #microk8s_disable("knative")
+        print("Validating Knative")
+        validate_knative()
+        print("Disabling Knative")
+        microk8s_disable("knative")
+        time.sleep(60)
         print("Disabling Istio")
         microk8s_disable("istio")
+        time.sleep(60)
 
     def test_cilium(self):
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -154,13 +154,13 @@ def wait_for_namespace_termination(namespace, timeout_insec=360):
         try:
             cmd='/snap/bin/microk8s.kubectl get ns {}'.format(namespace)
             output = check_output(cmd.split()).strip().decode('utf8')
-            print('.', end='',flush=True)
+            print('Waiting...')
         except CalledProcessError as err:
             if datetime.datetime.now() > deadline:
                 raise
             else:
                 return
-        time.sleep(5)
+        time.sleep(10)
 
 
 def microk8s_enable(addon, timeout_insec=300):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -143,6 +143,26 @@ def wait_for_installation(cluster_nodes=1):
     time.sleep(30)
 
 
+def wait_for_namespace_termination(namespace, timeout_insec=360):
+    """
+    Wait for the termination of the provided namespace.
+    """
+
+    print("Waiting for namespace {} to be removed".format(namespace))
+    deadline = datetime.datetime.now() + datetime.timedelta(seconds=timeout_insec)
+    while True:
+        try:
+            cmd='/snap/bin/microk8s.kubectl get ns {}'.format(namespace)
+            output = check_output(cmd.split()).strip().decode('utf8')
+            print('.', end='',flush=True)
+        except CalledProcessError as err:
+            if datetime.datetime.now() > deadline:
+                raise
+            else:
+                return
+        time.sleep(5)
+
+
 def microk8s_enable(addon, timeout_insec=300):
     """
     Disable an addon
@@ -204,3 +224,4 @@ def update_yaml_with_arch(manifest_file):
     with open(manifest_file, 'w') as f:
         s = s.replace('$ARCH', arch)
         f.write(s)
+


### PR DESCRIPTION
Two hacks had to go in:
- patch the monitoring.yaml manifest after getting it from the official repo
- cleanup of the `knative-serving` namespace stays in terminating for too long so we introduced some delays.