### PR TITLE
Wait for cluster to be up before we enable/disable addons

### DIFF
--- a/microk8s-resources/wrappers/microk8s-disable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-disable.wrapper
@@ -34,6 +34,8 @@ exit_if_no_permissions
 
 result=1
 for action in "$@"; do
+  # Making sure the cluster is up and running befor each addon
+  ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30 >/dev/null
   # If there is a script to execute for the action $1 run the script and ignore any yamls
   if [ -f "${SNAP}/actions/disable.$action.sh" ]; then
     if "${SNAP}/actions/disable.$action.sh"

--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -34,12 +34,13 @@ exit_if_no_permissions
 
 result=1
 for addon in "$@"; do
-
+  # Making sure the cluster is up and running befor each addon
+  ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30 >/dev/null
   action="$(addon_name $addon)"
   arguments="$(addon_arguments $addon)"
   # If there is a script to execute for the $action run the script and ignore any yamls
   if [ -f "${SNAP}/actions/enable.$action.sh" ]; then
-    
+
     "${SNAP}/actions/enable.$action.sh" "${arguments}"
     enable_result="$?"
     if [ "$enable_result" = "0" ]


### PR DESCRIPTION
This is most obvious when on a fresh install we do `microk8s.enable dns dashboard`. If the first addon restarts services the second addon may find the cluster in an unresponsive state. With this PR we make sure the cluster is up before enabling each addon. 

Fixes: https://github.com/ubuntu/microk8s/issues/674 and https://github.com/ubuntu/microk8s/issues/513

