### PR TITLE
Filter out coredns from the list of addons

### DIFF
--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -21,7 +21,7 @@ if echo "$*" | grep -q -- '--help'; then
     echo
     echo "Available addons:"
     echo
-    actions="$(find "${SNAP}/actions" -maxdepth 1 -name '*.yaml' -or -name 'enable.*.sh')"
+    actions="$(find "${SNAP}/actions" -maxdepth 1 ! -name 'coredns.yaml' -name '*.yaml' -or -name 'enable.*.sh')"
     actions="$(echo "$actions" | sed -e 's/.*[/.]\([^.]*\)\..*/\1/' | sort | uniq)"
     for action in $actions; do
         echo "  $action"


### PR DESCRIPTION
coredns.yaml is not an addon, it is used as template by the dns addon. We should not be showing it in the list of addons.

Fixes: https://github.com/ubuntu/microk8s/issues/675

