### PR TITLE
Switch snapcraft.yml to base: core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 dist: xenial
 language: bash
 sudo: required
-services: [docker]
+
+addons:
+  snaps:
+   - name: snapcraft
+     channel: stable
+     confinement: classic
+   - name: lxd
+     channel: stable
 
 script:
-  - docker run --network=host -v $(pwd):$(pwd) -w $(pwd) snapcore/snapcraft:beta sh -c "apt update && snapcraft"
+  - sudo /snap/bin/lxd.migrate -yes
+  - sudo /snap/bin/lxd waitready
+  - sudo /snap/bin/lxd init --auto
+  - sudo snapcraft --use-lxd
   - sudo apt update
   - sudo snap install *.snap --classic --dangerous
   - sudo pip install -U pytest

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,8 +1,12 @@
 # Building the snap from source
 
-Snapcraft and LXD are needed to build the snap. Both are available as snaps:
+[Building a snap](https://snapcraft.io/docs/snapcraft-overview) is done by running `snapcraft` on the root of the project.
+A VM managed by Multipass is spawned to contain the build process. If you don’t have Multipass installed,
+snapcraft will first prompt for its automatic installation.
+
+Alternatively, you can build the snap in an LXC container.
+LXD is needed in this case:
 ```
-sudo snap install snapcraft --classic
 sudo snap install lxd
 sudo apt-get remove lxd* -y
 sudo apt-get remove lxc* -y
@@ -13,12 +17,14 @@ Build the snap with:
 ```
 git clone http://github.com/ubuntu/microk8s
 cd ./microk8s/
-snapcraft cleanbuild
+snapcraft --use-lxd
 ```
 
 ## Building a custom MicroK8s package
 
-To produce a custom build with specific component versions we need to prepare an LXC container with Ubuntu 16:04 and snapcraft:
+To produce a custom build with specific component versions we need to
+[prepare an LXC](https://forum.snapcraft.io/t/how-to-create-a-lxd-container-for-snap-development/4658)
+container with Ubuntu 16:04 and snapcraft:
 ```
 lxc launch ubuntu:16.04 --ephemeral test-build
 lxc exec test-build -- snap install snapcraft --classic
@@ -40,9 +46,9 @@ We can then set the following environment variables prior to building:
  - KUBERNETES_COMMIT: commit to be used from KUBERNETES_REPOSITORY for building the kubernetes banaries
 
 
-For building we use `snapcraft` (not `snapcraft cleanbuild`) and we prepend and variables we need. For example to build the MicroK8s snap for Kubernetes v1.9.6 we:
+For building we prepend the variables we need as well as `SNAPCRAFT_BUILD_ENVIRONMENT=host` so the current LXC container is used. For example to build the MicroK8s snap for Kubernetes v1.9.6 we:
 ```
-lxc exec test-build -- sh -c "cd microk8s && KUBE_VERSION=v1.9.6 snapcraft"
+lxc exec test-build -- sh -c "cd microk8s && SNAPCRAFT_BUILD_ENVIRONMENT=host KUBE_VERSION=v1.9.6 snapcraft"
 ```
 
 The produced snap is inside the ephemeral LXC container, we need to copy it to the host:
@@ -54,3 +60,8 @@ lxc file pull test-build/root/microk8s/microk8s_v1.9.6_amd64.snap .
 ```
 snap install microk8s_latest_amd64.snap --classic --dangerous
 ```
+
+## References
+
+- https://snapcraft.io/docs/snapcraft-overview
+- https://forum.snapcraft.io/t/how-to-create-a-lxd-container-for-snap-development/4658

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,6 +13,7 @@ description: |-
 
 grade: stable
 confinement: classic
+base: core
 
 apps:
   daemon-etcd:
@@ -106,10 +107,9 @@ parts:
     - "--disable-shared"
     - "--enable-static"
     prime: [ -bin/iptables-xml ]
-  go:
-    source-tag: go1.12.7
   containerd:
-    after: [go, iptables]
+    build-snaps: [go]
+    after: [iptables]
     source: https://github.com/containerd/containerd
     source-type: git
     plugin: go
@@ -119,7 +119,7 @@ parts:
     - libseccomp-dev
     override-build: |
       set -eu
-      . ../../../build-scripts/set-env-variables.sh
+      . ../../../project/build-scripts/set-env-variables.sh
 
       go version
       export GOPATH=$(realpath ../go)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -192,6 +192,7 @@ parts:
     - file
     - dpkg
     stage-packages:
+    - libatm1
     - net-tools
     - util-linux
     - zfsutils-linux

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -119,7 +119,7 @@ parts:
     - libseccomp-dev
     override-build: |
       set -eu
-      . ../../../project/build-scripts/set-env-variables.sh
+      . $SNAPCRAFT_PROJECT_DIR/build-scripts/set-env-variables.sh
 
       go version
       export GOPATH=$(realpath ../go)


### PR DESCRIPTION
Allows building on non-xenial hosts without having to run cleanbuild. Cuts rebuild times significantly.