### PR TITLE
add helm to microk8s.status command

### DIFF
--- a/microk8s-resources/wrappers/microk8s-status.wrapper
+++ b/microk8s-resources/wrappers/microk8s-status.wrapper
@@ -98,6 +98,12 @@ function format_output() {
           addon["$a"]="disabled"
         fi
       done
+      if [ -f "${SNAP_DATA}/bin/helm" ]
+        then
+          addon["helm"]="enabled"
+        else
+          addon["helm"]="disabled"
+      fi
     fi
 
     if ! [ -z ${yaml} ]

--- a/microk8s-resources/wrappers/microk8s-status.wrapper
+++ b/microk8s-resources/wrappers/microk8s-status.wrapper
@@ -32,6 +32,7 @@ addon[fluentd]="daemonset.apps/fluentd-es-v2.2.0"
 addon[jaeger]="pod/jaeger-operator"
 addon[linkerd]="pod/linkerd-controller"
 addon[cilium]="pod/cilium"
+addon[helm]="${SNAP_DATA}/bin/helm"
 
 
 function show_help() {
@@ -91,19 +92,14 @@ function format_output() {
       get_all="$get_all\n$($KUBECTL get clusterroles --show-kind --no-headers 2>&1)"
       for a in "${!addon[@]}"
       do
-        if echo "$get_all" | grep "${addon[$a]}" &> /dev/null
+        if (echo "$get_all" | grep "${addon[$a]}" &> /dev/null) ||
+            [ -f "${addon[$a]}" ]
         then
           addon["$a"]="enabled"
         else
           addon["$a"]="disabled"
         fi
       done
-      if [ -f "${SNAP_DATA}/bin/helm" ]
-        then
-          addon["helm"]="enabled"
-        else
-          addon["helm"]="disabled"
-      fi
     fi
 
     if ! [ -z ${yaml} ]


### PR DESCRIPTION
Hi, this is a fix for #699 so helm shows up the the `.status` command. I built a development snap using the contribution instructions and it was working as expected.

![helm status added](https://user-images.githubusercontent.com/3979926/66711100-f7119c00-ed4a-11e9-871a-18c01dd7896a.png)


I held off adding it to the addon array on L:34 because it wasn't possible to determine the helm install status by keying off the namespaces or clusterroles. There may be another `kubectl` command that shows the status that I'm not aware of though.