### PR TITLE
Use the default front-proxy-client cert in linkerd

### DIFF
--- a/microk8s-resources/actions/disable.linkerd.sh
+++ b/microk8s-resources/actions/disable.linkerd.sh
@@ -5,9 +5,6 @@ set -e
 source $SNAP/actions/common/utils.sh
 
 echo "Disabling Linkerd"
-refresh_opt_in_config "requestheader-allowed-names" "front-proxy-client" kube-apiserver
-sudo systemctl restart snap.${SNAP_NAME}.daemon-apiserver
-sleep 5
 ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30 >/dev/null
 
 echo "Removing linkerd control plane"

--- a/microk8s-resources/actions/enable.linkerd.sh
+++ b/microk8s-resources/actions/enable.linkerd.sh
@@ -20,11 +20,6 @@ if [ ! -f "${SNAP_DATA}/bin/linkerd" ]; then
 fi
 
 echo "Enabling Linkerd2"
-
-refresh_opt_in_config "requestheader-allowed-names" "127.0.0.1" kube-apiserver
-sudo systemctl restart snap.${SNAP_NAME}.daemon-apiserver
-sleep 5
-
 # enable dns service
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 "$SNAP/microk8s-enable.wrapper" dns


### PR DESCRIPTION
@balchua, now that we have a separate CA for front-proxy certs and 2.6.0 linkerd. Do you think we could remove the hack of requestheader-allowed-names set to 127.0.0.1.

Thanks.