### PR TITLE
Fix default namespace for ctr

### DIFF
--- a/microk8s-resources/default-args/ctr
+++ b/microk8s-resources/default-args/ctr
@@ -1,1 +1,2 @@
 --address=${SNAP_COMMON}/run/containerd.sock
+--namespace k8s.io


### PR DESCRIPTION
Without this patch, `microk8s.ctr` is unable to list any containers on the system because it's looking in the wrong namespace. With this patch, the containers show up when running commands like `microk8s.ctr containers list`.

Fixes: #738 