### PR TITLE
upgrade containerd to 1.3.0

### DIFF
--- a/build-scripts/set-env-variables.sh
+++ b/build-scripts/set-env-variables.sh
@@ -16,10 +16,10 @@ export CNI_VERSION="${CNI_VERSION:-v0.7.1}"
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v0.9.0}"
 export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v0.9.0}"
 # RUNC commit matching the containerd release commit
-# Tag 1.2.5
-export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-bb71b10fd8f58240ca47fbb579b9d1028eea7c84}"
-# Release v1.0.0~rc6 with CVE-2019-5736 fix
-export RUNC_COMMIT="${RUNC_COMMIT:-2b18fe1d885ee5083ef9f0838fee39b62d653e30}"
+# Tag 1.3.0
+export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-36cf5b690dcc00ff0f34ff7799209050c3d0c59a}"
+# Release v1.0.0~rc8+ with CVE-2019-16884 fix
+export RUNC_COMMIT="${RUNC_COMMIT:-3e425f80a8c931f88e6d94a8c831b9d5aa481657}"
 # Set this to the kubernetes fork you want to build binaries from
 export KUBERNETES_REPOSITORY="${KUBERNETES_REPOSITORY:-}"
 export KUBERNETES_COMMIT="${KUBERNETES_COMMIT:-}"

--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -49,7 +49,7 @@ oom_score = 0
       [plugins.cri.registry.mirrors]
         [plugins.cri.registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io"]
-        [plugins.cri.registry.mirrors."local.insecure-registry.io"]
+        [plugins.cri.registry.mirrors."localhost:32000"]
           endpoint = ["http://localhost:32000"]
   [plugins.diff-service]
     default = ["walking"]

--- a/microk8s-resources/default-args/flannel-template.conflist
+++ b/microk8s-resources/default-args/flannel-template.conflist
@@ -1,5 +1,6 @@
 {
     "name": "microk8s-flannel-network",
+    "cniVersion": "0.3.1",
     "plugins": [
       {
         "type": "flannel",

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -141,16 +141,6 @@ then
     snapctl restart ${SNAP_NAME}.daemon-kubelet
 fi
 
-# modify the containerd localhost:32000 mirror registry
-if [ -e ${SNAP_DATA}/args/containerd-template.toml ] && grep -e "plugins.cri.registry.mirrors.\"local.insecure-registry.io\"" ${SNAP_DATA}/args/containerd-template.toml
-then
-    "$SNAP/bin/sed" -i 's@plugins.cri.registry.mirrors."local.insecure-registry.io"@plugins.cri.registry.mirrors."localhost:32000"@g' ${SNAP_DATA}/args/containerd-template.toml
-    snapctl restart ${SNAP_NAME}.daemon-containerd
-    sleep 10
-    KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
-    $KUBECTL delete pod --all --all-namespaces
-fi
-
 # With v1.15 allow-privileged is removed from kubelet
 if grep -e "\-\-allow-privileged" ${SNAP_DATA}/args/kubelet
 then
@@ -339,4 +329,19 @@ then
   echo "Cilium is enabled we need to reconfigure it."
   sudo rm -rf $SNAP_DATA/bin/cilium*
   ${SNAP}/microk8s-enable.wrapper cilium
+fi
+
+# modify the containerd localhost:32000 mirror registry
+if [ -e ${SNAP_DATA}/args/containerd-template.toml ] && grep -e "plugins.cri.registry.mirrors.\"local.insecure-registry.io\"" ${SNAP_DATA}/args/containerd-template.toml
+then
+    "$SNAP/bin/sed" -i 's@plugins.cri.registry.mirrors."local.insecure-registry.io"@plugins.cri.registry.mirrors."localhost:32000"@g' ${SNAP_DATA}/args/containerd-template.toml
+    snapctl restart ${SNAP_NAME}.daemon-containerd
+fi
+
+# This patches flanneld conf template by adding cniversion if it doesnt exist.
+if [ -e ${SNAP_DATA}/args/flannel-template.conflist ] && ! grep -e "cniVersion" ${SNAP_DATA}/args/flannel-template.conflist
+then
+    "$SNAP/bin/sed" -i 's@"name": "microk8s-flannel-network",@"name": "microk8s-flannel-network",\n    "cniVersion": "0.3.1",@g' ${SNAP_DATA}/args/flannel-template.conflist
+    snapctl restart ${SNAP_NAME}.daemon-flanneld
+    snapctl restart ${SNAP_NAME}.daemon-containerd
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -147,7 +147,8 @@ then
     "$SNAP/bin/sed" -i 's@plugins.cri.registry.mirrors."local.insecure-registry.io"@plugins.cri.registry.mirrors."localhost:32000"@g' ${SNAP_DATA}/args/containerd-template.toml
     snapctl restart ${SNAP_NAME}.daemon-containerd
     sleep 10
-    "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" "delete pod --all --all-namespaces"
+    KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+    $KUBECTL delete pod --all --all-namespaces
 fi
 
 # With v1.15 allow-privileged is removed from kubelet

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -141,6 +141,15 @@ then
     snapctl restart ${SNAP_NAME}.daemon-kubelet
 fi
 
+# modify the containerd localhost:32000 mirror registry
+if [ -e ${SNAP_DATA}/args/containerd-template.toml ] && grep -e "plugins.cri.registry.mirrors.\"local.insecure-registry.io\"" ${SNAP_DATA}/args/containerd-template.toml
+then
+    "$SNAP/bin/sed" -i 's@plugins.cri.registry.mirrors."local.insecure-registry.io"@plugins.cri.registry.mirrors."localhost:32000"@g' ${SNAP_DATA}/args/containerd-template.toml
+    snapctl restart ${SNAP_NAME}.daemon-containerd
+    sleep 10
+    "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" "delete pod --all --all-namespaces"
+fi
+
 # With v1.15 allow-privileged is removed from kubelet
 if grep -e "\-\-allow-privileged" ${SNAP_DATA}/args/kubelet
 then

--- a/tests/templates/ingress.yaml
+++ b/tests/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
         app: microbot
     spec:
       containers:
-      - image: cdkbot/microbot-$ARCH
+      - image: cdkbot/microbot-amd64
         imagePullPolicy: ""
         name: microbot
         ports:

--- a/tests/templates/ingress.yaml
+++ b/tests/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
         app: microbot
     spec:
       containers:
-      - image: cdkbot/microbot-amd64
+      - image: cdkbot/microbot-$ARCH
         imagePullPolicy: ""
         name: microbot
         ports:


### PR DESCRIPTION
Take note of the change in the `containerd-template.toml`.  This new containerd-cri requires that the name must match the image name.

For example:
```
image: 192.169.1.12:32000/my-busybox:1.0
```
In the `containerd-template.toml` the mirror definition must match the registry mirror.
```
        [plugins.cri.registry.mirrors."192.168.1.12:32000"]
          endpoint = ["http://192.168.1.12:32000"]
```

Addresses issue https://github.com/ubuntu/microk8s/issues/702