### PR TITLE
Upgrade Helm to v2.15.1

### DIFF
--- a/microk8s-resources/actions/enable.helm.sh
+++ b/microk8s-resources/actions/enable.helm.sh
@@ -10,7 +10,7 @@ echo "Enabling Helm"
 if [ ! -f "${SNAP_DATA}/bin/helm" ]
 then
   SOURCE_URI="https://get.helm.sh"
-  HELM_VERSION="v2.15.0"
+  HELM_VERSION="v2.15.1"
 
   echo "Fetching helm version $HELM_VERSION."
   sudo mkdir -p "${SNAP_DATA}/tmp/helm"


### PR DESCRIPTION
2.15.1 fixes a regression (https://github.com/helm/helm/issues/6708)  that broke various charts, e.g. stable/redis (https://github.com/helm/charts/issues/18141)

