### PR TITLE
Updated Helm version to v2.16.0

### DIFF
--- a/microk8s-resources/actions/enable.helm.sh
+++ b/microk8s-resources/actions/enable.helm.sh
@@ -10,7 +10,7 @@ echo "Enabling Helm"
 if [ ! -f "${SNAP_DATA}/bin/helm" ]
 then
   SOURCE_URI="https://get.helm.sh"
-  HELM_VERSION="v2.15.1"
+  HELM_VERSION="v2.16.0"
 
   echo "Fetching helm version $HELM_VERSION."
   run_with_sudo mkdir -p "${SNAP_DATA}/tmp/helm"


### PR DESCRIPTION
Helm 2.x stable is now pinned to 2.16.0. The new version contains some
important fixes that were too large for a patch version bump.

Release notes: https://github.com/helm/helm/releases/tag/v2.16.0

Signed-off-by: Oleg Sidorov <me@whitebox.io>