### PR TITLE
Fix issue with enabling Kubeflow behind a proxy

### DIFF
--- a/microk8s-resources/actions/enable.kubeflow.sh
+++ b/microk8s-resources/actions/enable.kubeflow.sh
@@ -79,7 +79,7 @@ def main():
         sys.exit(1)
 
     print("Deploying Kubeflow...")
-    juju("bootstrap", "microk8s", "uk8s")
+    juju("bootstrap", "microk8s", "uk8s", "--config", "juju-no-proxy=10.0.0.1")
     juju("add-model", "kubeflow", "microk8s")
 
     with tempfile.NamedTemporaryFile("w+") as f:


### PR DESCRIPTION
When enabling Kubeflow behind some proxies, Juju attempts to use the proxy to connect to local addresses. Force Juju to ignore the proxy in this case.

Fixes #753 