### PR TITLE
Create flanneld config file with using SNAP_DATA env variables (#797)

### DIFF
--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -19,10 +19,11 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 CLUSTER_API = "cluster/api/v1.0"
 snapdata_path = os.environ.get('SNAP_DATA')
 snap_path = os.environ.get('SNAP')
+ca_cert_file_via_env = "${SNAP_DATA}/certs/ca.remote.crt"
 ca_cert_file = "{}/certs/ca.remote.crt".format(snapdata_path)
 callback_token_file = "{}/credentials/callback-token.txt".format(snapdata_path)
 callback_tokens_file = "{}/credentials/callback-tokens.txt".format(snapdata_path)
-callback_tokens_file = "{}/credentials/callback-tokens.txt".format(snapdata_path)
+server_cert_file_via_env = "${SNAP_DATA}/certs/server.remote.crt"
 server_cert_file = "{}/certs/server.remote.crt".format(snapdata_path)
 
 
@@ -126,8 +127,8 @@ def update_flannel(etcd, master_ip, master_port, token):
     get_etcd_client_cert(master_ip, master_port, token)
     etcd = etcd.replace("0.0.0.0", master_ip)
     set_arg("--etcd-endpoints", etcd, "flanneld")
-    set_arg("--etcd-cafile", ca_cert_file, "flanneld")
-    set_arg("--etcd-certfile", server_cert_file, "flanneld")
+    set_arg("--etcd-cafile", ca_cert_file_via_env, "flanneld")
+    set_arg("--etcd-certfile", server_cert_file_via_env, "flanneld")
     set_arg("--etcd-keyfile", "${SNAP_DATA}/certs/server.key", "flanneld")
 
     subprocess.check_call("systemctl restart snap.microk8s.daemon-flanneld.service".split())

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -330,3 +330,18 @@ then
   rm -rf $SNAP_DATA/bin/cilium*
   ${SNAP}/microk8s-enable.wrapper cilium
 fi
+
+if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
+then
+  if grep -e "\-\-etcd-cafile /var/snap/microk8s/.*/ca.remote.crt" ${SNAP_DATA}/args/flanneld
+  then
+    skip_opt_in_config etcd-cafile flanneld
+    refresh_opt_in_config etcd-cafile \${SNAP_DATA}/certs/ca.remote.crt flanneld
+  fi
+
+  if grep -e "\-\-etcd-certfile /var/snap/microk8s/.*/server.remote.crt" ${SNAP_DATA}/args/flanneld
+  then
+    skip_opt_in_config etcd-certfile flanneld
+    refresh_opt_in_config etcd-certfile \${SNAP_DATA}/certs/server.remote.crt flanneld
+  fi
+fi


### PR DESCRIPTION
* Create flanneld config file with using SNAP_DATA env variables as to not
break during snap upgrades.

* Handle upgrade of clustered flannel

* Remove old config before adding it again