### PR TITLE
Revert "Add content interface slot for Juju to plug to;"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -394,9 +394,3 @@ parts:
         echo "Skipped"
       fi
 
-slots:
-  microk8s-info:
-    interface: content
-    content: microk8s
-    source:
-      read: [$SNAP/.microk8s-info/microk8s]


### PR DESCRIPTION
Reverts ubuntu/microk8s#795

We need to wait for the snapstore to accept slots in classic snaps.