### PR TITLE
Include charm store in bundle name

### DIFF
--- a/microk8s-resources/actions/enable.kubeflow.sh
+++ b/microk8s-resources/actions/enable.kubeflow.sh
@@ -93,7 +93,7 @@ def main():
         json.dump(password_overlay, f)
         f.flush()
 
-        juju("deploy", "kubeflow", "--channel", channel, "--overlay", f.name)
+        juju("deploy", "cs:kubeflow", "--channel", channel, "--overlay", f.name)
 
     print("Kubeflow deployed.")
     print("Waiting for operator pods to become ready.")


### PR DESCRIPTION
To prevent issues when someone has a folder named `kubeflow` in their working directory.

Fixes #859 