### PR TITLE
Add content interface slot for Juju to plug to;

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -394,3 +394,9 @@ parts:
         echo "Skipped"
       fi
 
+slots:
+  microk8s-info:
+    interface: content
+    content: microk8s
+    source:
+      read: [$SNAP/.microk8s-info/microk8s]


### PR DESCRIPTION
Reapply the PR https://github.com/ubuntu/microk8s/pull/795 now that the snapstore allows interfaces for classic snaps. 