### PR TITLE
Add ulimit -l 16384 to containerd-env

### DIFF
--- a/microk8s-resources/default-args/containerd-env
+++ b/microk8s-resources/default-args/containerd-env
@@ -16,3 +16,8 @@
 # this get inherited to the running containers
 #
 ulimit -n 65536 || true
+
+# Attempt to change the maximum locked memory limit
+# this get inherited to the running containers
+#
+ulimit -l 16384 || true


### PR DESCRIPTION
Juju controllers need a higher memlock limit.
Setting to 16384 (from a default of 64) fixes the issue.