### PR TITLE
Set up magic IP for API services to bind to

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -271,15 +271,7 @@ wait_for_service_shutdown() {
 }
 
 get_default_ip() {
-    # Get the IP of the default interface
-    local DEFAULT_INTERFACE="$($SNAP/bin/netstat -rn | $SNAP/bin/grep '^0.0.0.0' | $SNAP/usr/bin/gawk '{print $NF}' | head -1)"
-    local IP_ADDR="$($SNAP/sbin/ip -o -4 addr list "$DEFAULT_INTERFACE" | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
-    if [[ -z "$IP_ADDR" ]]
-    then
-        echo "none"
-    else
-        echo "${IP_ADDR}"
-    fi
+    echo "$(snapctl get api.ip)"
 }
 
 get_ips() {

--- a/microk8s-resources/actions/enable.kubeflow.sh
+++ b/microk8s-resources/actions/enable.kubeflow.sh
@@ -130,7 +130,7 @@ def main():
         "--all",
     )
 
-    juju("config", "ambassador", "juju-external-hostname=localhost")
+    juju("config", "ambassador", "juju-external-hostname=microk8s.local")
     juju("expose", "ambassador")
 
     # Workaround for https://bugs.launchpad.net/juju/+bug/1849725.
@@ -166,7 +166,7 @@ def main():
         textwrap.dedent(
             """
     Congratulations, Kubeflow is now available.
-    The dashboard is available at https://localhost/
+    The dashboard is available at https://microk8s.local/
 
         Username: admin
         Password: %s

--- a/microk8s-resources/client.config.template
+++ b/microk8s-resources/client.config.template
@@ -2,7 +2,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: CADATA
-    server: https://127.0.0.1:16443
+    server: https://IP:16443
   name: microk8s-cluster
 contexts:
 - context:

--- a/microk8s-resources/wrappers/microk8s-config.wrapper
+++ b/microk8s-resources/wrappers/microk8s-config.wrapper
@@ -45,10 +45,10 @@ done
 exit_if_no_permissions
 
 if [[ "$USE_LOOPBACK" == "true" ]]; then
-    cat "$SNAP_DATA/credentials/client.config"
+    IP_ADDR="$(get_default_ip)"
+    "$SNAP/bin/sed" -e "s/$IP_ADDR/127.0.0.1/" "$SNAP_DATA/credentials/client.config"
     "$SNAP/bin/echo"
 else
-    IP_ADDR="$(get_default_ip)"
-    "$SNAP/bin/sed" -e "s/127.0.0.1/$IP_ADDR/" "$SNAP_DATA/credentials/client.config"
+    cat "$SNAP_DATA/credentials/client.config"
     "$SNAP/bin/echo"
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -4,6 +4,7 @@ set -eux
 
 source $SNAP/actions/common/utils.sh
 
+
 # This is a one-off patch. It will allow us to refresh the beta snap without breaking the user's deployment.
 # We make sure the certificates used by the deployment from beta do not change. We copy them to SNAP_DATA
 # and make sure the respective services use them.
@@ -371,4 +372,39 @@ then
     then
         chgrp microk8s -R "$SNAP_DATA/juju" "$SNAP_DATA/juju-home" || true
     fi
+fi
+
+# Set up a bridge with a known IP address that services can bind to instead of
+# whatever IP gets handed out by their router. Doesn't affect services that bind
+# to 127.0.0.1.
+API_IP="$(snapctl get api.ip)"
+if [[ "$API_IP" == "" ]]
+then
+  API_IP="10.5.2.1"
+  snapctl set api.ip="${API_IP}"
+fi
+
+if ADDR_INFO="$(sudo ip -j a show uk8s0 2>/dev/null)"; then
+  CURRENT_IP="$(echo $ADDR_INFO | jq -r '.[0].addr_info[] | select(.family == "inet").local')"
+
+  if [[ "$API_IP" != "$CURRENT_IP" ]]; then
+    $SNAP/sbin/ip link delete uk8s0
+    $SNAP/sbin/ip link add uk8s0 type bridge
+    $SNAP/sbin/ip address add $API_IP/24 dev uk8s0
+    $SNAP/sbin/ip link set uk8s0 up
+
+    for conf in client controller kubelet proxy scheduler; do
+      $SNAP/bin/sed -i 's/IP/'"${API_IP}"'/g' ${SNAP_DATA}/credentials/${conf}.config
+      $SNAP/bin/sed -i 's|server: .*|server: https://'"${API_IP}"':16443|g' ${SNAP_DATA}/credentials/${conf}.config
+    done
+
+    $SNAP/bin/sed -i "s/.*microk8s.local/${API_IP}\tmicrok8s.local/g" /etc/hosts
+
+    snapctl restart ${SNAP_NAME}
+  fi
+else
+  $SNAP/sbin/ip link add uk8s0 type bridge
+  $SNAP/sbin/ip address add $API_IP/24 dev uk8s0
+  $SNAP/sbin/ip link set uk8s0 up
+  $SNAP/bin/echo "${API_IP}\tmicrok8s.local" >> /etc/hosts
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -23,11 +23,13 @@ mkdir ${SNAP_DATA}/credentials
 admin_token=$(openssl rand -base64 32 | ${SNAP}/usr/bin/base64)
 echo "${admin_token},admin,admin,\"system:masters\"" > ${SNAP_DATA}/credentials/basic_auth.csv
 ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
+API_IP="10.5.2.1"
 
 # Create the client kubeconfig
 cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/client.config
 $SNAP/bin/sed -i 's/PASSWORD/'"${admin_token}"'/g' ${SNAP_DATA}/credentials/client.config
 $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/client.config
+$SNAP/bin/sed -i 's/IP/'"${API_IP}"'/g' ${SNAP_DATA}/credentials/client.config
 $SNAP/bin/sed -i 's/NAME/admin/g' ${SNAP_DATA}/credentials/client.config
 $SNAP/bin/sed -i 's/AUTHTYPE/password/g' ${SNAP_DATA}/credentials/client.config
 $SNAP/bin/sed -i 's/PASSWORD/'"${admin_token}"'/g' ${SNAP_DATA}/credentials/client.config
@@ -47,6 +49,7 @@ echo "${scheduler_token},system:kube-scheduler,scheduler" >> ${SNAP_DATA}/creden
 # Create the client kubeconfig for the controller
 cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/controller.config
 $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/controller.config
+$SNAP/bin/sed -i 's/IP/'"${API_IP}"'/g' ${SNAP_DATA}/credentials/controller.config
 $SNAP/bin/sed -i 's/NAME/controller/g' ${SNAP_DATA}/credentials/controller.config
 $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/controller.config
 $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/controller.config
@@ -55,6 +58,7 @@ $SNAP/bin/sed -i 's/PASSWORD/'"${controller_token}"'/g' ${SNAP_DATA}/credentials
 # Create the client kubeconfig for the scheduler
 cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/scheduler.config
 $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/scheduler.config
+$SNAP/bin/sed -i 's/IP/'"${API_IP}"'/g' ${SNAP_DATA}/credentials/scheduler.config
 $SNAP/bin/sed -i 's/NAME/scheduler/g' ${SNAP_DATA}/credentials/scheduler.config
 $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/scheduler.config
 $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/scheduler.config
@@ -64,6 +68,7 @@ $SNAP/bin/sed -i 's/PASSWORD/'"${scheduler_token}"'/g' ${SNAP_DATA}/credentials/
 cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/kubelet.config
 $SNAP/bin/sed -i 's/NAME/kubelet/g' ${SNAP_DATA}/credentials/kubelet.config
 $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/kubelet.config
+$SNAP/bin/sed -i 's/IP/'"${API_IP}"'/g' ${SNAP_DATA}/credentials/kubelet.config
 $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/kubelet.config
 $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/kubelet.config
 $SNAP/bin/sed -i 's/PASSWORD/'"${kubelet_token}"'/g' ${SNAP_DATA}/credentials/kubelet.config
@@ -71,6 +76,7 @@ $SNAP/bin/sed -i 's/PASSWORD/'"${kubelet_token}"'/g' ${SNAP_DATA}/credentials/ku
 cp ${SNAP}/client.config.template ${SNAP_DATA}/credentials/proxy.config
 $SNAP/bin/sed -i 's/NAME/kubeproxy/g' ${SNAP_DATA}/credentials/proxy.config
 $SNAP/bin/sed -i 's/CADATA/'"${ca_data}"'/g' ${SNAP_DATA}/credentials/proxy.config
+$SNAP/bin/sed -i 's/IP/'"${API_IP}"'/g' ${SNAP_DATA}/credentials/proxy.config
 $SNAP/bin/sed -i '/username/d' ${SNAP_DATA}/credentials/proxy.config
 $SNAP/bin/sed -i 's/AUTHTYPE/token/g' ${SNAP_DATA}/credentials/proxy.config
 $SNAP/bin/sed -i 's/PASSWORD/'"${proxy_token}"'/g' ${SNAP_DATA}/credentials/proxy.config

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -34,7 +34,11 @@ rm -rf ${SNAP_COMMON}/run/containerd/* || true
 (cat /proc/mounts | grep ${SNAP_COMMON}/var/lib/docker | cut -d ' ' -f 2 | xargs umount -l) || true
 (cat /proc/mounts | grep ${SNAP_COMMON}/var/run/docker | cut -d ' ' -f 2 | xargs umount) || true
 
-if $SNAP/sbin/ip link show cni0
-then
-  $SNAP/sbin/ip link delete cni0
-fi
+for link in cni0 uk8s0; do
+  if $SNAP/sbin/ip link show $link
+  then
+    $SNAP/sbin/ip link delete $link
+  fi
+done
+
+$SNAP/bin/sed -i '/microk8s.local/d' /etc/hosts


### PR DESCRIPTION
Sets up a user-configurable IP that is stable between network changes. Defaults to 10.5.2.1, and allows configuring a different IP in case of conflicts.

Also adds microk8s.local to /etc/hosts, since K8s Ingresses don't allow straight IP addresses.

Fixes #351 