### PR TITLE
Add  --containerd flag to work cAdvisor correctly

### DIFF
--- a/microk8s-resources/default-args/kubelet
+++ b/microk8s-resources/default-args/kubelet
@@ -11,4 +11,5 @@
 --eviction-hard="memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi"
 --container-runtime=remote
 --container-runtime-endpoint=${SNAP_COMMON}/run/containerd.sock
+--containerd=${SNAP_COMMON}/run/containerd.sock
 --node-labels="microk8s.io/cluster=true"


### PR DESCRIPTION
This flag is deprecated [at least since 2017 Dec](https://github.com/kubernetes/kubernetes/commit/8ec1958667e66fb3da2a1f1428998f59f8b027f2#diff-48b7d75949f67a9adceea2ba834c8e35), but is still needed to tell cAdvisor the containerd socket path. As things stand, with cAdvisor enabled, we can get more memory stats about containers (e.g. `/stats/summary` endpoint).

## Before

```json
$ curl http://localhost:10255/stats/summary
{
  ...
  "pods": [
    ...
    {
      "podRef": {
        "name": "nginx-deployment-7f5f4c6d4b-vh764",
        ...
      },
      "startTime": "2020-01-30T18:22:04Z",
      "containers": [
        {
          "name": "nginx",
          "startTime": "2020-01-30T18:22:05Z",
          "memory": {
            "time": "2020-01-30T18:27:21Z",
            "workingSetBytes": 2183168
          },
        },
        ...
      ],
      ...
    }
  ]
}
```


## After

```json
$ curl http://localhost:10255/stats/summary
{
  ...
  "pods": [
    ...
    {
      "podRef": {
        "name": "nginx-deployment-7f5f4c6d4b-vh764",
        ...
      },
      "startTime": "2020-01-30T17:59:15Z",
      "containers": [
        {
          "name": "nginx",
          "startTime": "2020-01-30T17:59:15Z",
          "memory": {
            "time": "2020-01-30T18:16:46Z",
            "usageBytes": 2383872,
            "workingSetBytes": 2375680,
            "rssBytes": 1433600,
            "pageFaults": 2791,
            "majorPageFaults": 0
          },
          ...
        },
      ],
      ...
    }
  ]
}
```