### PR TITLE
Use helm3 instead of helm2 to enable cillium

### DIFF
--- a/microk8s-resources/actions/enable.cilium.sh
+++ b/microk8s-resources/actions/enable.cilium.sh
@@ -11,7 +11,7 @@ if ! [ "${ARCH}" = "amd64" ]; then
   exit 1
 fi
 
-"$SNAP/microk8s-enable.wrapper" helm
+"$SNAP/microk8s-enable.wrapper" helm3
 
 echo "Restarting kube-apiserver"
 refresh_opt_in_config "allow-privileged" "true" kube-apiserver
@@ -66,7 +66,7 @@ else
 
   # Generate the YAMLs for Cilium and apply them
   (cd "${SNAP_DATA}/tmp/cilium/$CILIUM_DIR/install/kubernetes"
-  ${SNAP_DATA}/bin/helm template cilium \
+  ${SNAP_DATA}/bin/helm3 template cilium \
       --namespace $NAMESPACE \
       --set global.cni.confPath="$SNAP_DATA/args/cni-network" \
       --set global.cni.binPath="$SNAP_DATA/opt/cni/bin" \


### PR DESCRIPTION
Cilium addon uses helm for inflating YAML. This PR updates dependency to new helm version (helm3).

```console
# snap run --shell microk8s.enable
# /tmp/enable.cillium.sh
Enabling Helm 3
Fetching helm version v3.0.2.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11.5M  100 11.5M    0     0  5241k      0  0:00:02  0:00:02 --:--:-- 5242k
Helm 3 is enabled
Restarting kube-apiserver
Restarting kubelet
Restarting containerd
Enabling Cilium
Fetching cilium version v1.6.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   119    0   119    0     0    237      0 --:--:-- --:--:-- --:--:--   237
100 22.6M    0 22.6M    0     0  5512k      0 --:--:--  0:00:04 --:--:-- 7473k
Deploying /var/snap/microk8s/1173/actions/cilium.yaml. This may take several minutes.
configmap/cilium-config created
serviceaccount/cilium created
serviceaccount/cilium-operator created
clusterrole.rbac.authorization.k8s.io/cilium created
clusterrole.rbac.authorization.k8s.io/cilium-operator created
clusterrolebinding.rbac.authorization.k8s.io/cilium created
clusterrolebinding.rbac.authorization.k8s.io/cilium-operator created
daemonset.apps/cilium created
deployment.apps/cilium-operator created
Waiting for daemon set "cilium" rollout to finish: 0 of 1 updated pods are available...
daemon set "cilium" successfully rolled out
Cilium is enabled
```