### PR TITLE
Upgrading cilium while it is already enabled

### DIFF
--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -36,7 +36,7 @@ result=1
 for addon in "$@"; do
   # Making sure the cluster is up and running befor each addon
   STATUS=$(${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30)
-  if echo $STATUS | grep "$addon: enabled"
+  if echo $STATUS | grep "$addon: enabled" >/dev/null
   then
     echo "$addon is already enabled"
     result=0

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -342,7 +342,7 @@ if [ -L "${SNAP_DATA}/bin/cilium" ]
 then
   echo "Cilium is enabled we need to reconfigure it."
   rm -rf $SNAP_DATA/bin/cilium*
-  ${SNAP}/microk8s-enable.wrapper cilium
+  ${SNAP}/actions/enable.cilium.sh
 fi
 
 # modify the containerd localhost:32000 mirror registry


### PR DESCRIPTION
We cannot call microk8s.enable on an already enabled addon. Cilium needs to be re-enabled every time we upgrade.