### PR TITLE
Check if metallb is already enabled when enabling it

### DIFF
--- a/microk8s-resources/actions/enable.metallb.sh
+++ b/microk8s-resources/actions/enable.metallb.sh
@@ -4,6 +4,14 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
+KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+
+if $KUBECTL get ns metallb-system >/dev/null 2>&1
+then
+  echo "MetalLB already enabled."
+  exit 0
+fi
+
 echo "Enabling MetalLB"
 
 read -ra ARGUMENTS <<< "$1"
@@ -12,7 +20,7 @@ then
   read -p "Enter the IP address range (e.g., 10.64.140.43-10.64.140.49): " ip_range
   if [ -z "${ip_range}" ]
   then
-    echo "You have to input an IP Range value when asked, or provide it as an argument to the enable commang, eg:"
+    echo "You have to input an IP Range value when asked, or provide it as an argument to the enable command, eg:"
     echo "  microk8s.enable metallb:10.64.140.43-10.64.140.49"
     exit 1
   fi
@@ -23,7 +31,6 @@ fi
 REGEX_IP_RANGE='^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$'
 if [[ $ip_range =~ $REGEX_IP_RANGE ]]
 then
-  KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
   echo "Applying registry manifest"
   cat $SNAP/actions/metallb.yaml | $SNAP/bin/sed "s/{{ip_range}}/$ip_range/g" | $KUBECTL apply -f -
   echo "MetalLB is enabled"


### PR DESCRIPTION
Allows other scripts such as kubeflow to lazily ensure it's enabled.