### PR TITLE
Check machine architecture before enabling Kubeflow

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -315,6 +315,12 @@ parts:
         # Linkerd support
         rm "actions/enable.linkerd.sh"
         rm "actions/disable.linkerd.sh"
+        # Juju support
+        rm "actions/enable.juju.sh"
+        rm "actions/disable.juju.sh"
+        # Kubeflow support
+        rm "actions/enable.kubeflow.sh"
+        rm "actions/disable.kubeflow.sh"
       else
         # Knative support
         echo "Preparing knative"


### PR DESCRIPTION
Fails fast instead of waiting for a Juju bootstrap to fail without a great error message.

Fixes #943 