### PR TITLE
Automatically setup and tear down MicroK8s VM in Windows installer

### DIFF
--- a/installer/windows/microk8s.iss
+++ b/installer/windows/microk8s.iss
@@ -57,4 +57,4 @@ end;
 Filename: "{app}\microk8s.exe"; Parameters: "install --assume-yes"; StatusMsg: "Setting up MicroK8s for the first time"; Description: "Setup and start MicroK8s?"; Flags: postinstall
 
 [UninstallRun]
-Filename: "{app}\microk8s.exe"; Parameters: "uninstall"; StatusMsg: "Removing the MicroK8s VM"; Description: "Stop and remove the MicroK8s VM?"
+Filename: "{app}\microk8s.exe"; Parameters: "uninstall"

--- a/installer/windows/microk8s.iss
+++ b/installer/windows/microk8s.iss
@@ -55,3 +55,6 @@ end;
 
 [Run]
 Filename: "{app}\microk8s.exe"; Parameters: "install --assume-yes"; StatusMsg: "Setting up MicroK8s for the first time"; Description: "Setup and start MicroK8s?"; Flags: postinstall
+
+[UninstallRun]
+Filename: "{app}\microk8s.exe"; Parameters: "uninstall"; StatusMsg: "Removing the MicroK8s VM"; Description: "Stop and remove the MicroK8s VM?"

--- a/installer/windows/microk8s.iss
+++ b/installer/windows/microk8s.iss
@@ -54,4 +54,4 @@ begin
 end;
 
 [Run]
-Filename: "{app}\microk8s.exe"; Parameters: "install --assume-yes"; StatusMsg: "Setting up MicroK8s for the first time"; Description: "Setup and start MicroK8s?"; Flags: StatusMsg
+Filename: "{app}\microk8s.exe"; Parameters: "install --assume-yes"; StatusMsg: "Setting up MicroK8s for the first time"; Description: "Setup and start MicroK8s?"; Flags: postinstall

--- a/installer/windows/microk8s.iss
+++ b/installer/windows/microk8s.iss
@@ -52,3 +52,6 @@ begin
       ModPath();
   end;
 end;
+
+[Run]
+Filename: "{app}\microk8s.exe"; Parameters: "install --assume-yes"; StatusMsg: "Setting up MicroK8s for the first time"; Description: "Setup and start MicroK8s?"; Flags: StatusMsg


### PR DESCRIPTION
Tested on the laptop.  We now offer a tick box to setup (i.e. `microk8s install`), after install.  Then also automatically clean up at uninstall. 