### PR TITLE
Use native containerd snapshotter if ZFS is detected

### DIFF
--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -31,7 +31,7 @@ oom_score = 0
     enable_tls_streaming = false
     max_container_log_line_size = 16384
     [plugins.cri.containerd]
-      snapshotter = "overlayfs"
+      snapshotter = "${SNAPSHOTTER}"
       no_pivot = false
       [plugins.cri.containerd.default_runtime]
         runtime_type = "io.containerd.runtime.v1.linux"

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -28,7 +28,17 @@ if [ -e "${SNAP_DATA}/var/lock/gpu" ]; then
 else
   RUNTIME="runc"
 fi
-sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g;s@${RUNTIME}@'"${RUNTIME}"'@g' $SNAP_DATA/args/containerd-template.toml > $SNAP_DATA/args/containerd.toml
+
+# Determine the underlying filesystem that containerd will be running on
+FSTYPE=$(stat -f -c %T "${SNAP_COMMON}")
+# ZFS is supported throught the native snapshotter
+if [ "$FSTYPE" = "zfs" ]; then
+  SNAPSHOTTER="native"
+else
+  SNAPSHOTTER="overlayfs"
+fi
+
+sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g;s@${SNAPSHOTTER}@'"${SNAPSHOTTER}"'@g;s@${RUNTIME}@'"${RUNTIME}"'@g' $SNAP_DATA/args/containerd-template.toml > $SNAP_DATA/args/containerd.toml
 
 run_flanneld="$(is_service_expected_to_start flanneld)"
 if [ "${run_flanneld}" == "1" ]


### PR DESCRIPTION
This is a workaround to allow microk8s to run on ZFS systems.
See issue: #401

Using the zfs snapshotter would be another option, but currently
it seems that the zfs snapshotter requires it's own dedicated filesystem
and is still missing features such as Usage().

https://github.com/containerd/zfs/issues/17