### PR TITLE
feat: Add an option to customize the size of the container registry

### DIFF
--- a/microk8s-resources/actions/enable.registry.sh
+++ b/microk8s-resources/actions/enable.registry.sh
@@ -10,7 +10,8 @@ regex_args='([a-zA-Z]+=[a-zA-Z0-9]+(,|))'
 
 read -ra ARGUMENTS <<<"$1"
 if [ -z "${ARGUMENTS[@]}" ]; then
-  echo "Your pvc will be created with the default value of 20Gi. You can customize it with the following command eg: microk8s.enable registry:size=30Gi"
+  echo "The registry will be created with the default size of 20Gi."
+  echo "You can use the \"size\" argument while enabling the registry, eg microk8s.enable registry:size=30Gi"
   declare -A map
   map[\$DISKSIZE]="20Gi"
   "$SNAP/microk8s-enable.wrapper" storage
@@ -21,14 +22,13 @@ elif [[ ${ARGUMENTS[@]} =~ $regex_args ]]; then
 	IFS=',' read -ra args <<< ${ARGUMENTS[@]}
   REGEX_DISK_SIZE='(^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)'
 	for arg in "${args[@]}"; do
-		read -r key value <<<$(echo $arg | awk -F "=" '{print $1 ,$2}')
+		read -r key value <<<$(echo $arg | gawk -F "=" '{print $1 ,$2}')
     if [ "$key" != "size" ]; then
-      echo "WARNING: The only authorized argument is \"size\" and it work as follow: microk8s.enable registry:size=30Gi"
-      echo "WARNING: The arguments should match the following regex: ([a-zA-Z]+=[a-zA-Z0-9]+(,|))"
-      echo "WARNING: Ignoring the key: $key and value $value"    
+      echo "WARNING: The only authorized argument is \"size\", eg  microk8s.enable registry:size=30Gi"
+      echo "WARNING: The \"size\" value should match the regex: ([a-zA-Z]+=[a-zA-Z0-9]+(,|))"
+      echo "WARNING: Ignoring the key: $key and value $value"
     elif [ "$key" = "size"  ] && [[ ! $value =~ $REGEX_DISK_SIZE ]]; then
-      echo "The size of the registry should be higher or equal to 20Gi"
-      echo "The size should match this regex : (^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)"
+      echo "The size of the registry should be higher or equal to 20Gi and match the regex: (^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)"
 		elif [ "$key" = "size" ] && [[ $value =~ $REGEX_DISK_SIZE ]]; then
       "$SNAP/microk8s-enable.wrapper" storage
       echo "Applying registry manifest"

--- a/microk8s-resources/actions/enable.registry.sh
+++ b/microk8s-resources/actions/enable.registry.sh
@@ -4,8 +4,6 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-echo "Enabling the private registry"
-
 regex_args='([a-zA-Z]+=[a-zA-Z0-9]+(,|))'
 
 read -ra ARGUMENTS <<<"$1"
@@ -24,23 +22,25 @@ elif [[ ${ARGUMENTS[@]} =~ $regex_args ]]; then
 	for arg in "${args[@]}"; do
 		read -r key value <<<$(echo $arg | gawk -F "=" '{print $1 ,$2}')
     if [ "$key" != "size" ]; then
-      echo "WARNING: The only authorized argument is \"size\", eg  microk8s.enable registry:size=30Gi"
-      echo "WARNING: The \"size\" value should match the regex: ([a-zA-Z]+=[a-zA-Z0-9]+(,|))"
-      echo "WARNING: Ignoring the key: $key and value $value"
+      echo "The only authorized argument is \"size\", eg  microk8s.enable registry:size=30Gi"
+      echo "The \"size\" value should match the regex: ([a-zA-Z]+=[a-zA-Z0-9]+(,|))"
+      exit 1
     elif [ "$key" = "size"  ] && [[ ! $value =~ $REGEX_DISK_SIZE ]]; then
       echo "The size of the registry should be higher or equal to 20Gi and match the regex: (^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)"
+      exit 1
 		elif [ "$key" = "size" ] && [[ $value =~ $REGEX_DISK_SIZE ]]; then
       "$SNAP/microk8s-enable.wrapper" storage
-      echo "Applying registry manifest"
       declare -A map
       map[\$DISKSIZE]=$value
-      use_manifest registry apply "$(declare -p map)"
-      echo "The registry is enabled"
-      echo "The size of the persistent volume is $value"          
     fi
   done
+  echo "Enabling the private registry"
+  echo "Applying registry manifest"
+  use_manifest registry apply "$(declare -p map)"
+  echo "The registry is enabled"
+  echo "The size of the persistent volume is $value"
 else
-  echo "The only authorized argument is \"size\" and it work as follow: microk8s.enable registry:size=30Gi"
-  echo "The arguments should match the following regex ([a-zA-Z]+=[a-zA-Z0-9]+(,|))"
+  echo "The only authorized argument is \"size\", eg  microk8s.enable registry:size=30Gi"
+  echo "The \"size\" value should match the regex: ([a-zA-Z]+=[a-zA-Z0-9]+(,|))"
   exit 1
 fi

--- a/microk8s-resources/actions/enable.registry.sh
+++ b/microk8s-resources/actions/enable.registry.sh
@@ -8,7 +8,23 @@ echo "Enabling the private registry"
 
 "$SNAP/microk8s-enable.wrapper" storage
 
-echo "Applying registry manifest"
-use_manifest registry apply
-
-echo "The registry is enabled"
+read -ra ARGUMENTS <<<"$1"
+if [ -z "${ARGUMENTS[@]}" ]; then
+  echo "Your pvc will be created with the default value of 20Gi. You can customize it with the following command eg: microk8s.enable registry:30Gi"
+  declare -A map
+  map[\$DISKSIZE]="20Gi"
+  use_manifest registry apply "$(declare -p map)"
+else
+  disk_size="${ARGUMENTS[@]}"
+  REGEX_DISK_SIZE='(^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)'
+  if [[ $disk_size =~ $REGEX_DISK_SIZE ]]; then
+    echo "Applying registry manifest"
+    declare -A map
+    map[\$DISKSIZE]=$disk_size
+    use_manifest registry apply "$(declare -p map)"
+    echo "The registry is enabled"
+  else
+    echo "You input value ($disk_size) is not a valid value"
+    exit 1
+  fi
+fi

--- a/microk8s-resources/actions/enable.registry.sh
+++ b/microk8s-resources/actions/enable.registry.sh
@@ -13,7 +13,9 @@ if [ -z "${ARGUMENTS[@]}" ]; then
   echo "Your pvc will be created with the default value of 20Gi. You can customize it with the following command eg: microk8s.enable registry:30Gi"
   declare -A map
   map[\$DISKSIZE]="20Gi"
+  echo "Applying registry manifest"
   use_manifest registry apply "$(declare -p map)"
+  echo "The registry is enabled"
 else
   disk_size="${ARGUMENTS[@]}"
   REGEX_DISK_SIZE='(^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)'
@@ -25,6 +27,7 @@ else
     echo "The registry is enabled"
   else
     echo "You input value ($disk_size) is not a valid value"
+    echo "The value should be Higher or equal to 20Gi"
     exit 1
   fi
 fi

--- a/microk8s-resources/actions/enable.registry.sh
+++ b/microk8s-resources/actions/enable.registry.sh
@@ -6,28 +6,41 @@ source $SNAP/actions/common/utils.sh
 
 echo "Enabling the private registry"
 
-"$SNAP/microk8s-enable.wrapper" storage
+regex_args='([a-zA-Z]+=[a-zA-Z0-9]+(,|))'
 
 read -ra ARGUMENTS <<<"$1"
 if [ -z "${ARGUMENTS[@]}" ]; then
-  echo "Your pvc will be created with the default value of 20Gi. You can customize it with the following command eg: microk8s.enable registry:30Gi"
+  echo "Your pvc will be created with the default value of 20Gi. You can customize it with the following command eg: microk8s.enable registry:size=30Gi"
   declare -A map
   map[\$DISKSIZE]="20Gi"
+  "$SNAP/microk8s-enable.wrapper" storage
   echo "Applying registry manifest"
   use_manifest registry apply "$(declare -p map)"
   echo "The registry is enabled"
-else
-  disk_size="${ARGUMENTS[@]}"
+elif [[ ${ARGUMENTS[@]} =~ $regex_args ]]; then
+	IFS=',' read -ra args <<< ${ARGUMENTS[@]}
   REGEX_DISK_SIZE='(^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)'
-  if [[ $disk_size =~ $REGEX_DISK_SIZE ]]; then
-    echo "Applying registry manifest"
-    declare -A map
-    map[\$DISKSIZE]=$disk_size
-    use_manifest registry apply "$(declare -p map)"
-    echo "The registry is enabled"
-  else
-    echo "You input value ($disk_size) is not a valid value"
-    echo "The value should be Higher or equal to 20Gi"
-    exit 1
-  fi
+	for arg in "${args[@]}"; do
+		read -r key value <<<$(echo $arg | awk -F "=" '{print $1 ,$2}')
+    if [ "$key" != "size" ]; then
+      echo "WARNING: The only authorized argument is \"size\" and it work as follow: microk8s.enable registry:size=30Gi"
+      echo "WARNING: The arguments should match the following regex: ([a-zA-Z]+=[a-zA-Z0-9]+(,|))"
+      echo "WARNING: Ignoring the key: $key and value $value"    
+    elif [ "$key" = "size"  ] && [[ ! $value =~ $REGEX_DISK_SIZE ]]; then
+      echo "The size of the registry should be higher or equal to 20Gi"
+      echo "The size should match this regex : (^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)"
+		elif [ "$key" = "size" ] && [[ $value =~ $REGEX_DISK_SIZE ]]; then
+      "$SNAP/microk8s-enable.wrapper" storage
+      echo "Applying registry manifest"
+      declare -A map
+      map[\$DISKSIZE]=$value
+      use_manifest registry apply "$(declare -p map)"
+      echo "The registry is enabled"
+      echo "The size of the persistent volume is $value"          
+    fi
+  done
+else
+  echo "The only authorized argument is \"size\" and it work as follow: microk8s.enable registry:size=30Gi"
+  echo "The arguments should match the following regex ([a-zA-Z]+=[a-zA-Z0-9]+(,|))"
+  exit 1
 fi

--- a/microk8s-resources/actions/registry.yaml
+++ b/microk8s-resources/actions/registry.yaml
@@ -15,7 +15,7 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 20Gi
+      storage: $DISKSIZE
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -4,7 +4,6 @@ import re
 import requests
 import platform
 import yaml
-import pprint
 
 from utils import (
     kubectl,

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -3,6 +3,8 @@ import os
 import re
 import requests
 import platform
+import yaml
+import pprint
 
 from utils import (
     kubectl,
@@ -217,7 +219,12 @@ def validate_registry():
     """
     Validate the private registry.
     """
+    
     wait_for_pod_state("", "container-registry", "running", label="app=registry")
+    pvc_stdout = kubectl("get pvc registry-claim -n container-registry -o yaml")
+    pvc_yaml = yaml.safe_load(pvc_stdout)
+    storage = pvc_yaml['spec']['resources']['requests']['storage']
+    assert re.match("(^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)",storage)
     docker("pull busybox")
     docker("tag busybox localhost:32000/my-busybox")
     docker("push localhost:32000/my-busybox")


### PR DESCRIPTION
fixes #926 
Description

feat: 
Add an option to the `microk8s.enable registry` command to customize the size of the container registry the default value is still set to 20Gi and the pvc cannot be lower than 20Gi
Add a test to assert that the value is equal or higher to 20Gi


