### PR TITLE
Ask users to get ownership of their .kube when joining the microk8s group

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -7,6 +7,7 @@ exit_if_no_permissions() {
     echo "You can either try again with sudo or add the user $USER to the 'microk8s' group:" >&2
     echo "" >&2
     echo "    sudo usermod -a -G microk8s $USER" >&2
+    echo "    sudo chown -f -R $USER ~/.kube" >&2
     echo "" >&2
     echo "The new group will be available on the user's next login." >&2
     exit 1


### PR DESCRIPTION
When users start using MicroK8s with sudo ~/.kube is created with root permissions. If they later join the microk8s group accessing the ~/.kube directory is blocked and the interaction with the cli is is very slow to the point many report commands not working. With this PR we ask users to grant access to their user when switching to the microk8s group.

Fixes: https://github.com/ubuntu/microk8s/issues/1023