### PR TITLE
Fix privilege escalation of metallb on xenial

### DIFF
--- a/microk8s-resources/actions/enable.metallb.sh
+++ b/microk8s-resources/actions/enable.metallb.sh
@@ -14,6 +14,15 @@ fi
 
 echo "Enabling MetalLB"
 
+ALLOWESCALATION=false
+if grep  -e ubuntu /proc/version | grep 16.04 &> /dev/null
+then
+  ALLOWESCALATION=true
+fi
+declare -A map
+map[\$ALLOWESCALATION]="$ALLOWESCALATION"
+use_manifest metallb apply "$(declare -p map)"
+
 read -ra ARGUMENTS <<< "$1"
 if [ -z "${ARGUMENTS[@]}" ]
 then

--- a/microk8s-resources/actions/metallb.yaml
+++ b/microk8s-resources/actions/metallb.yaml
@@ -13,7 +13,7 @@ metadata:
   name: speaker
   namespace: metallb-system
 spec:
-  allowPrivilegeEscalation: false
+  allowPrivilegeEscalation: $ALLOWESCALATION
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
@@ -223,7 +223,7 @@ spec:
             cpu: 100m
             memory: 100Mi
         securityContext:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: $ALLOWESCALATION
           capabilities:
             add:
             - NET_ADMIN
@@ -279,7 +279,7 @@ spec:
             cpu: 100m
             memory: 100Mi
         securityContext:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: $ALLOWESCALATION
           capabilities:
             drop:
             - all


### PR DESCRIPTION
See https://github.com/ubuntu/microk8s/issues/1017 - metallb fails to enable correctly due to privilege escalation on Xenial.

Note that this fix is similar to https://github.com/ubuntu/microk8s/pull/551 which fixed a similar privilege escalation issue for coredns on Xenial.