### PR TITLE
Fix privilege escalation of metallb on xenial

### DIFF
--- a/microk8s-resources/actions/enable.metallb.sh
+++ b/microk8s-resources/actions/enable.metallb.sh
@@ -14,6 +14,12 @@ fi
 
 echo "Enabling MetalLB"
 
+ALLOWESCALATION=false
+if grep  -e ubuntu /proc/version | grep 16.04 &> /dev/null
+then
+  ALLOWESCALATION=true
+fi
+
 read -ra ARGUMENTS <<< "$1"
 if [ -z "${ARGUMENTS[@]}" ]
 then
@@ -32,7 +38,7 @@ REGEX_IP_RANGE='^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*\
 if [[ $ip_range =~ $REGEX_IP_RANGE ]]
 then
   echo "Applying registry manifest"
-  cat $SNAP/actions/metallb.yaml | $SNAP/bin/sed "s/{{ip_range}}/$ip_range/g" | $KUBECTL apply -f -
+  cat $SNAP/actions/metallb.yaml | $SNAP/bin/sed "s/{{allow_escalation}}/$ALLOWESCALATION/g" | $SNAP/bin/sed "s/{{ip_range}}/$ip_range/g" | $KUBECTL apply -f -
   echo "MetalLB is enabled"
 else
   echo "You input value ($ip_range) is not a valid IP Range"

--- a/microk8s-resources/actions/metallb.yaml
+++ b/microk8s-resources/actions/metallb.yaml
@@ -13,7 +13,7 @@ metadata:
   name: speaker
   namespace: metallb-system
 spec:
-  allowPrivilegeEscalation: false
+  allowPrivilegeEscalation: {{allow_escalation}}
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
@@ -223,7 +223,7 @@ spec:
             cpu: 100m
             memory: 100Mi
         securityContext:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: {{allow_escalation}}
           capabilities:
             add:
             - NET_ADMIN
@@ -279,7 +279,7 @@ spec:
             cpu: 100m
             memory: 100Mi
         securityContext:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: {{allow_escalation}}
           capabilities:
             drop:
             - all


### PR DESCRIPTION
See #1017 - metallb fails to enable correctly due to privilege escalation on Xenial.

Note that this fix is similar to #551 which fixed a similar privilege escalation issue for coredns on Xenial.