### PR TITLE
Fix configuring addons

### DIFF
--- a/microk8s-resources/wrappers/run-cluster-agent-with-args
+++ b/microk8s-resources/wrappers/run-cluster-agent-with-args
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ -z "$HOME" ]
+then
+  mkdir -p $SNAP_DATA/var/tmp/
+  export HOME=$SNAP_DATA/var/tmp/
+fi
+
 set -eu
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"


### PR DESCRIPTION
When using the /configure REST endpoint of cluster-agent, the subprocess for calling the microk8s-enable-wrapper command was timing out due to $HOME env var not being injected. By setting the HOME env var in run-cluster-agent-with-args script, the issue is fixed.

Testing

Set the callback-token:
`sudo echo "xyztoken" > /var/snap/microk8s/current/credentials/callback-token.txt`

and test with curl:
`curl -k -v -d '{"callback":"xyztoken","addon":[{"name":"dns", "enable":true}]}' -H "Content-Type: application/json" -X POST https://127.0.0.1:25000/cluster/api/v1.0/configure`

Fixes: https://github.com/ubuntu/microk8s/issues/937
