### PR TITLE
Mocking up a 30 day auto sync

### DIFF
--- a/installer/cli/checkpoint.py
+++ b/installer/cli/checkpoint.py
@@ -1,0 +1,84 @@
+import os
+import pickle
+from datetime import datetime
+from vm_providers.factory import get_provider_for
+
+
+CHECKPOINT_FILE = '.microk8s.checkpoint'
+CHECKPOINT_PATH = os.path.join(os.path.expanduser('~'), CHECKPOINT_FILE)
+ALIAS_FILE = '.microk8s.rc'
+ALIAS_PATH = os.path.join(os.path.expanduser('~'), ALIAS_FILE)
+
+
+def sync(force: bool = False) -> None:
+    """
+    Synchronise the alias file with the available commands.
+
+    :return: None
+    """
+    if not _check_checkpoint() or force:
+        _sync_commands()
+        _make_checkpoint()
+
+
+def _sync_commands() -> None:
+    """
+    Rewrite the alias file.
+
+    :return: None
+    """
+    if platform in ['linux', 'darwin']:
+        with open(ALIAS_PATH, 'w') as f:
+            for i in _get_microk8s_commands():
+                f.write('alias microk8s.{0}="microk8s {0}"'.format(i))
+    elif platform in ['win32']:
+        with open(ALIAS_PATH, 'w') as f:
+            for i in _get_microk8s_commands():
+                f.write('doskey microk8s.{0}=microk8s {0}'.format(i))
+
+
+def _make_checkpoint() -> None:
+    """
+    Stamp a current timestamp into the checkpoint file.
+
+    :return: None
+    """
+    with open(CHECKPOINT_PATH, 'w') as f:
+        pickle.dump(datetime.now(), f)
+
+
+def _check_checkpoint() -> bool:
+    """
+    Run this every time.  We're trying to keep the aliases in sync with the underlying CLI.
+
+    :return: Boolean true if okay false if outdated.
+    """
+    if os.path.isfile(CHECKPOINT_PATH):
+        with open(CHECKPOINT_PATH) as f:
+            previous = pickle.load(f)
+    
+        if (datetime.now() - previous).days > 30:
+            return False
+        
+        return True
+
+    return False
+
+
+def get_microk8s_commands() -> List:
+    """
+    Pull the MicroK8s commands from the VM.
+
+    :return: List String
+    """
+    vm_provider_name = "multipass"
+    vm_provider_class = get_provider_for(vm_provider_name)
+    echo = Echo()
+    try:
+        vm_provider_class.ensure_provider()
+        instance = vm_provider_class(echoer=echo)
+        instance_info = instance.get_instance_info()
+        if instance_info.is_running():
+            commands = instance.run('ls -1 /snap/bin/'.split(), hide_output=True)
+            mk8s = [c.decode().replace('microk8s.', '') for c in commands.split() if c.decode().startswith('microk8s')]
+            return mk8s

--- a/installer/cli/checkpoint.py
+++ b/installer/cli/checkpoint.py
@@ -35,6 +35,7 @@ def _sync_commands() -> None:
         with open(ALIAS_PATH, 'w') as f:
             for i in _get_microk8s_commands():
                 f.write('doskey microk8s.{0}=microk8s {0}'.format(i))
+        os.system('attrib +h {}'.format(ALIAS_PATH))
 
 
 def _make_checkpoint() -> None:

--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -123,7 +123,10 @@ def install(args) -> None:
                     ])
 
     elif platform in ['win32']:
-        pass  # TODO: Set Windows registry to source this file: https://superuser.com/questions/144347/is-there-windows-equivalent-to-the-bashrc-file-in-linux
+        import winreg  # Will raise ImportError if called outside of Windows.
+        cmd = winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE, r'SOFTWARE\Microsoft\Command Processor', access=winreg.KEY_WRITE)
+        winreg.SetValueEx(cmd, 'AutoRun', 0, winreg.REG_SZ, ALIAS_PATH)
 
 
     parser = argparse.ArgumentParser("microk8s install")


### PR DESCRIPTION
Trying to address the issue of MicroK8sVM and the wrapper becoming out of sync.

The way this works currently is:

1. Upon install, we write to the user's `bashrc` and `zshenv` or Windows registry to source the aliases file (https://github.com/ubuntu/microk8s/pull/1048/files#diff-f2062a194b762346d37aeb4feb960c87R111).

2. After install, we enforce a sync.  This writes a checkpoint file and generates the alias file that step 1 will source (https://github.com/ubuntu/microk8s/pull/1048/files#diff-fb29bc3034a18e0c18302bb7f6fb756bR13).

3. Every time the CLI is called, the checkpoint file is checked https://github.com/ubuntu/microk8s/pull/1048/files#diff-fb29bc3034a18e0c18302bb7f6fb756bR50

4. If outdated, go to step 2.
