### PR TITLE
Keep only one if-condition for checking when an addon is enabled

### DIFF
--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -28,7 +28,7 @@ for addon in "$@"; do
   action="$(addon_name $addon)"
   arguments="$(addon_arguments $addon)"
   # Check if the addon is already enabled, then skip.
-  if ${SNAP}/microk8s-status.wrapper --addon $action | grep "enabled" >/dev/null; then
+  if ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30 --addon $action | grep "enabled" >/dev/null; then
     echo "Addon $action is already enabled."
     result=0
     continue

--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -24,15 +24,7 @@ exit_if_no_permissions
 
 result=1
 for addon in "$@"; do
-  # Making sure the cluster is up and running befor each addon
-  STATUS=$(${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30)
-  if echo $STATUS | grep "$addon: enabled" >/dev/null
-  then
-    echo "$addon is already enabled"
-    result=0
-    continue
-  fi
-
+  # Making sure the cluster is up and running before each addon
   action="$(addon_name $addon)"
   arguments="$(addon_arguments $addon)"
   # Check if the addon is already enabled, then skip.


### PR DESCRIPTION
In microk8s-enable-wrapper script, two if conditions we checking for same thing: "if an addon is already enabled"

Kept the latest one committed.

Screenshot from testing local build:
![keep-one-if](https://user-images.githubusercontent.com/1267871/77436944-c3a06680-6dec-11ea-88af-02e838d17697.png)
