### PR TITLE
Improve distributions tests

### DIFF
--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -53,8 +53,15 @@ then
   PROXY=$4
 fi
 
+# Test addons upgrade
+# TODO Handle local in the upgrade
+create_machine $NAME $PROXY
+# use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
+lxc exec $NAME -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /var/tmp/tests/test-upgrade.py"
+lxc delete $NAME --force
 
 # Test addons
+NAME=machine-$RANDOM
 create_machine $NAME $PROXY
 if [ ${TO_CHANNEL} == "local" ]
 then
@@ -67,12 +74,4 @@ lxc exec $NAME -- /var/tmp/tests/patch-kube-proxy.sh
 # use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
 lxc exec $NAME -- script -e -c "pytest -s /var/tmp/tests/test-addons.py"
 lxc exec $NAME -- microk8s reset
-lxc delete $NAME --force
-
-# Test addons upgrade
-# TODO Handle local in the upgrade
-NAME=machine-$RANDOM
-create_machine $NAME $PROXY
-# use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
-lxc exec $NAME -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /var/tmp/tests/test-upgrade.py"
 lxc delete $NAME --force

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -76,24 +76,3 @@ create_machine $NAME $PROXY
 # use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
 lxc exec $NAME -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /var/tmp/tests/test-upgrade.py"
 lxc delete $NAME --force
-
-# Test cluster
-VM1_NAME=machine-$RANDOM
-VM2_NAME=machine-$RANDOM
-create_machine $VM1_NAME $PROXY
-create_machine $VM2_NAME $PROXY
-if [ ${TO_CHANNEL} == "local" ]
-then
-  lxc file push ./microk8s_latest_amd64.snap $VM1_NAME/tmp/
-  lxc file push ./microk8s_latest_amd64.snap $VM2_NAME/tmp/
-  lxc exec $VM1_NAME -- snap install /tmp/microk8s_latest_amd64.snap --dangerous --classic
-  lxc exec $VM2_NAME -- snap install /tmp/microk8s_latest_amd64.snap --dangerous --classic
-else
-  lxc exec $VM1_NAME -- snap install microk8s --channel=${TO_CHANNEL} --classic
-  lxc exec $VM2_NAME -- snap install microk8s --channel=${TO_CHANNEL} --classic
-fi
-lxc exec $VM1_NAME -- /var/tmp/tests/patch-kube-proxy.sh
-lxc exec $VM2_NAME -- /var/tmp/tests/patch-kube-proxy.sh
-
-lxc delete $VM1_NAME --force
-lxc delete $VM2_NAME --force


### PR DESCRIPTION
Two things we improve:

- Do the upgrade test before the testing of addons. The upgrade test fails more often so we try to fail fast.
- The clusters test part was a place holder for future tests but it was not providing an value. We remove it. Proper cluster testing is in https://github.com/ubuntu/microk8s/tree/feature/cluster-test and needs multipass.