### PR TITLE
Accept --channel in microk8s install

### DIFF
--- a/installer/build-linux.sh
+++ b/installer/build-linux.sh
@@ -2,7 +2,7 @@
 
 
 virtualenv -p python3 .venv
-source ./bin/activate
+source ./.venv/bin/activate
 pip install -r requirements.txt
 pyinstaller ./microk8s.spec
 deactivate

--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -71,7 +71,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  install         Installs MicroK8s. Use --cpu, --mem, --disk to appoint resources.
+  install         Installs MicroK8s. Use --cpu, --mem, --disk and --channel to configure your setup. 
   uninstall       Removes MicroK8s"""
     click.echo(msg)
     commands = _get_microk8s_commands()
@@ -89,12 +89,16 @@ def _show_install_help():
     msg = """Usage: microk8s install OPTIONS
 
     Options:
-      --help  Show this message and exit.
-      --cpu   Cores used by MicroK8s (default={})
-      --mem   RAM in GB used by MicroK8s (default={})
-      --disk  Maximum volume in GB of the dynamicaly expandable hard disk to be used (default={})
+      --help     Show this message and exit.
+      --cpu      Cores used by MicroK8s (default={})
+      --mem      RAM in GB used by MicroK8s (default={})
+      --disk     Maximum volume in GB of the dynamically expandable hard disk to be used (default={})
+      --channel  Kubernetes version to install (default={})
        -y, --assume-yes  Automatic yes to prompts"""
-    Echo.info(msg.format(definitions.DEFAULT_CORES, definitions.DEFAULT_MEMORY, definitions.DEFAULT_DISK))
+    Echo.info(msg.format(definitions.DEFAULT_CORES,
+                         definitions.DEFAULT_MEMORY,
+                         definitions.DEFAULT_DISK,
+                         definitions.DEFAULT_CHANNEL))
 
 
 def install(args) -> None:
@@ -105,6 +109,7 @@ def install(args) -> None:
     parser.add_argument('--cpu', default=definitions.DEFAULT_CORES, type=int)
     parser.add_argument('--mem', default=definitions.DEFAULT_MEMORY, type=int)
     parser.add_argument('--disk', default=definitions.DEFAULT_DISK, type=int)
+    parser.add_argument('--channel', default=definitions.DEFAULT_CHANNEL, type=str)
     parser.add_argument('-y', '--assume-yes', action='store_true', default=definitions.DEFAULT_ASSUME)
     args = parser.parse_args(args)
     vm_provider_name: str = 'multipass'

--- a/installer/common/definitions.py
+++ b/installer/common/definitions.py
@@ -24,3 +24,4 @@ DEFAULT_CORES: int = 2
 DEFAULT_MEMORY: int = 4
 DEFAULT_DISK: int = 256
 DEFAULT_ASSUME: bool = False
+DEFAULT_CHANNEL: str = "latest/stable"

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -135,10 +135,10 @@ class Provider(abc.ABC):
         except errors.ProviderInstanceNotFoundError:
             self._launch(specs)
             # We need to setup MicroK8s and scan for cli commands
-            self._setup_microk8s()
+            self._setup_microk8s(specs)
 
-    def _setup_microk8s(self) -> None:
-        self.run("snap install microk8s --classic".split())
+    def _setup_microk8s(self, specs: Dict) -> None:
+        self.run("snap install microk8s --classic --channel {}".format(specs['channel']).split())
 
     def _get_env_command(self) -> Sequence[str]:
         """Get command sequence for `env` with configured flags."""


### PR DESCRIPTION
This PR adds the `--channel` option to `microk8s install` eg
```
microk8s install --cpu 2 --mem 4 --channel 1.18/stable
```

Fixes: https://github.com/ubuntu/microk8s/issues/1072