### PR TITLE
Change VM name of installers to lowercase

### DIFF
--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -40,7 +40,7 @@ class Provider(abc.ABC):
         self.echoer = echoer
         self._is_ephemeral = is_ephemeral
 
-        self.instance_name = "MicroK8sVM"
+        self.instance_name = "microk8s-vm"
 
         if build_provider_flags is None:
             build_provider_flags = dict()


### PR DESCRIPTION
This PR sets the VM name created by the installers to `microk8s-vm`. There are two reasons:
- When RBAC is enabled the capital letters of `MicroK8sVM` render the k8s node inaccessible. The error reported by kubelet is:
```
Apr 18 13:17:23 MicroK8sVM microk8s.daemon-kubelet[3556]: E0418 13:17:23.302029    3556 reflector.go:178] object-"kube-system"/"default-token-zdmcr": Failed to list *v1.Secret: secrets "default-token-zdmcr" is forbidden: User "system:node:MicroK8sVM" cannot list resource "secrets" in API group "" in the namespace "kube-system": no relationship found between node "MicroK8sVM" and this object
```  
See https://github.com/ubuntu/microk8s/issues/902
- Stay consistent with the current instructions. See issue https://github.com/ubuntu/microk8s/issues/1085
