### PR TITLE
Fixes in --help in installer

### DIFF
--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -192,7 +192,7 @@ def _get_microk8s_commands() -> List:
         instance_info = instance.get_instance_info()
         if instance_info.is_running():
             commands = instance.run('ls -1 /snap/bin/'.split(), hide_output=True)
-            mk8s = [c.decode().replace('microk8s.', '') for c in commands.split() if c.decode().startswith('microk8s')]
+            mk8s = [c.decode().replace('microk8s.', '') for c in commands.split() if c.decode().startswith('microk8s.')]
             return mk8s
         else:
             return ["start", "stop"]

--- a/installer/common/definitions.py
+++ b/installer/common/definitions.py
@@ -7,6 +7,7 @@ command_descriptions = {
   'disable':         "Disables running add-ons",
   'enable':          "Enables  useful add-ons",
   'helm':            "The helm client",
+  'helm3':            "The helm3 client",
   'inspect':         "Checks the cluster and gathers logs",
   'istioctl':        "The istio client",
   'join':            "Joins this instance as a node to a cluster",


### PR DESCRIPTION
Two minor fixes in the output of `microk8s --help`:
1. Added the description of helm3
1. Filtered out the `microk8s` command 