### PR TITLE
Rename microk8s-info slot for juju

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -489,7 +489,7 @@ parts:
       - bin/juju
 
 slots:
-  microk8s-info:
+  microk8s:
     interface: content
     content: microk8s
     source:


### PR DESCRIPTION
This is was requested for the juju integration.