### PR TITLE
Fix ctr using overlayfs on zfs

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -172,6 +172,17 @@ arch() {
 }
 
 
+snapshotter() {
+  # Determine the underlying filesystem that containerd will be running on
+  FSTYPE=$(stat -f -c %T "${SNAP_COMMON}")
+  # ZFS is supported through the native snapshotter
+  if [ "$FSTYPE" = "zfs" ]; then
+    echo "native"
+  else
+    echo "overlayfs"
+  fi
+}
+
 use_manifest() {
     # Perform an action (apply or delete) on a manifest.
     # Optionally replace strings in the manifest

--- a/microk8s-resources/wrappers/microk8s-ctr.wrapper
+++ b/microk8s-resources/wrappers/microk8s-ctr.wrapper
@@ -6,5 +6,14 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 
+# Determine the underlying filesystem that ctr will be running on
+FSTYPE=$(stat -f -c %T "${SNAP_COMMON}")
+# ZFS is supported through the native snapshotter
+if [ "$FSTYPE" = "zfs" ]; then
+  SNAPSHOTTER="native"
+else
+  SNAPSHOTTER="overlayfs"
+fi
+
 declare -a args="($(cat $SNAP_DATA/args/ctr))"
-sudo -E LD_LIBRARY_PATH="$IN_SNAP_LD_LIBRARY_PATH" "${SNAP}/bin/ctr" "${args[@]}" "$@"
+sudo -E LD_LIBRARY_PATH="$IN_SNAP_LD_LIBRARY_PATH" CONTAINERD_SNAPSHOTTER="$SNAPSHOTTER" "${SNAP}/bin/ctr" "${args[@]}" "$@"

--- a/microk8s-resources/wrappers/microk8s-ctr.wrapper
+++ b/microk8s-resources/wrappers/microk8s-ctr.wrapper
@@ -6,14 +6,9 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 
-# Determine the underlying filesystem that ctr will be running on
-FSTYPE=$(stat -f -c %T "${SNAP_COMMON}")
-# ZFS is supported through the native snapshotter
-if [ "$FSTYPE" = "zfs" ]; then
-  SNAPSHOTTER="native"
-else
-  SNAPSHOTTER="overlayfs"
-fi
+source $SNAP/actions/common/utils.sh
+
+SNAPSHOTTER=$(snapshotter)
 
 declare -a args="($(cat $SNAP_DATA/args/ctr))"
 sudo -E LD_LIBRARY_PATH="$IN_SNAP_LD_LIBRARY_PATH" CONTAINERD_SNAPSHOTTER="$SNAPSHOTTER" "${SNAP}/bin/ctr" "${args[@]}" "$@"

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -29,14 +29,7 @@ else
   RUNTIME="runc"
 fi
 
-# Determine the underlying filesystem that containerd will be running on
-FSTYPE=$(stat -f -c %T "${SNAP_COMMON}")
-# ZFS is supported through the native snapshotter
-if [ "$FSTYPE" = "zfs" ]; then
-  SNAPSHOTTER="native"
-else
-  SNAPSHOTTER="overlayfs"
-fi
+SNAPSHOTTER=$(snapshotter)
 
 sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g;s@${SNAPSHOTTER}@'"${SNAPSHOTTER}"'@g;s@${RUNTIME}@'"${RUNTIME}"'@g' $SNAP_DATA/args/containerd-template.toml > $SNAP_DATA/args/containerd.toml
 

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -31,7 +31,7 @@ fi
 
 # Determine the underlying filesystem that containerd will be running on
 FSTYPE=$(stat -f -c %T "${SNAP_COMMON}")
-# ZFS is supported throught the native snapshotter
+# ZFS is supported through the native snapshotter
 if [ "$FSTYPE" = "zfs" ]; then
   SNAPSHOTTER="native"
 else


### PR DESCRIPTION
Some ctr commands use a snapshotter locally. By default this is `overlayfs`, but when using zfs we need to use `native` (or `zfs`) snapshotter.

#1000 fixes this issue for containerd, but ctr doesn't use the containerd config.

Commands affected by this are:
- ctr containers create
- ctr images check
- ctr images import
- ctr images pull
- ctr run
- ctr snapshots

Snapshotter selection should probably be consolidated into one place.