### PR TITLE
Fix transition to calico permissions

### DIFF
--- a/upgrade-scripts/000-switch-to-calico/commit-master.sh
+++ b/upgrade-scripts/000-switch-to-calico/commit-master.sh
@@ -21,28 +21,28 @@ cp -R "$SNAP"/opt/cni/bin/* "$SNAP_DATA"/opt/cni/bin/
 echo "Restarting services"
 cp "$SNAP_DATA"/args/kube-apiserver "$BACKUP_DIR/args"
 refresh_opt_in_config "allow-privileged" "true" kube-apiserver
-run_with_sudo preserve_env snapctl restart ${SNAP_NAME}.daemon-apiserver
+snapctl restart ${SNAP_NAME}.daemon-apiserver
 
 # Reconfigure kubelet/containerd to pick up the new CNI config and binary.
 cp "$SNAP_DATA"/args/kubelet "$BACKUP_DIR/args"
 echo "Restarting kubelet"
 refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
-run_with_sudo preserve_env snapctl restart ${SNAP_NAME}.daemon-kubelet
+snapctl restart ${SNAP_NAME}.daemon-kubelet
 
 cp "$SNAP_DATA"/args/kube-proxy "$BACKUP_DIR/args"
 echo "Restarting kube proxy"
 refresh_opt_in_config "cluster-cidr" "10.1.0.0/16" kube-proxy
-run_with_sudo preserve_env snapctl restart ${SNAP_NAME}.daemon-proxy
+snapctl restart ${SNAP_NAME}.daemon-proxy
 
 set_service_not_expected_to_start flanneld
-run_with_sudo preserve_env snapctl stop ${SNAP_NAME}.daemon-flanneld
+snapctl stop ${SNAP_NAME}.daemon-flanneld
 remove_vxlan_interfaces
 
 cp "$SNAP_DATA"/args/containerd-template.toml "$BACKUP_DIR/args"
 if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
   echo "Restarting containerd"
-  run_with_sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  run_with_sudo preserve_env snapctl restart ${SNAP_NAME}.daemon-containerd
+  "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
+  snapctl restart ${SNAP_NAME}.daemon-containerd
 fi
 
 # Allow for services to restart

--- a/upgrade-scripts/000-switch-to-calico/commit-node.sh
+++ b/upgrade-scripts/000-switch-to-calico/commit-node.sh
@@ -26,22 +26,22 @@ refresh_opt_in_config "allow-privileged" "true" kube-apiserver
 cp "$SNAP_DATA"/args/kubelet "$BACKUP_DIR/args"
 echo "Restarting kubelet"
 refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
-run_with_sudo preserve_env snapctl restart ${SNAP_NAME}.daemon-kubelet
+snapctl restart ${SNAP_NAME}.daemon-kubelet
 
 cp "$SNAP_DATA"/args/kube-proxy "$BACKUP_DIR/args"
 echo "Restarting kube proxy"
 refresh_opt_in_config "cluster-cidr" "10.1.0.0/16" kube-proxy
-run_with_sudo preserve_env snapctl restart ${SNAP_NAME}.daemon-proxy
+snapctl restart ${SNAP_NAME}.daemon-proxy
 
 set_service_not_expected_to_start flanneld
-run_with_sudo preserve_env snapctl stop ${SNAP_NAME}.daemon-flanneld
+snapctl stop ${SNAP_NAME}.daemon-flanneld
 remove_vxlan_interfaces
 
 cp "$SNAP_DATA"/args/containerd-template.toml "$BACKUP_DIR/args"
 if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
   echo "Restarting containerd"
-  run_with_sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  run_with_sudo preserve_env snapctl restart ${SNAP_NAME}.daemon-containerd
+  "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
+  snapctl restart ${SNAP_NAME}.daemon-containerd
 fi
 
 echo "Calico is enabled"

--- a/upgrade-scripts/000-switch-to-calico/rollback-master.sh
+++ b/upgrade-scripts/000-switch-to-calico/rollback-master.sh
@@ -42,13 +42,13 @@ ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30
 echo "Restarting flannel"
 set_service_expected_to_start flanneld
 remove_vxlan_interfaces
-run_with_sudo snapctl start ${SNAP_NAME}.daemon-flanneld
+snapctl start ${SNAP_NAME}.daemon-flanneld
 
 echo "Restarting kubelet"
 if grep -qE "bin_dir.*SNAP_DATA}\/" $SNAP_DATA/args/containerd-template.toml; then
   echo "Restarting containerd"
-  run_with_sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  run_with_sudo snapctl restart ${SNAP_NAME}.daemon-containerd
+  "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
+  snapctl restart ${SNAP_NAME}.daemon-containerd
 fi
 
 echo "Calico rolledback"

--- a/upgrade-scripts/000-switch-to-calico/rollback-node.sh
+++ b/upgrade-scripts/000-switch-to-calico/rollback-node.sh
@@ -34,13 +34,13 @@ fi
 echo "Restarting flannel"
 set_service_expected_to_start flanneld
 remove_vxlan_interfaces
-run_with_sudo snapctl start ${SNAP_NAME}.daemon-flanneld
+snapctl start ${SNAP_NAME}.daemon-flanneld
 
 echo "Restarting kubelet"
 if grep -qE "bin_dir.*SNAP_DATA}\/" $SNAP_DATA/args/containerd-template.toml; then
   echo "Restarting containerd"
-  run_with_sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  run_with_sudo snapctl restart ${SNAP_NAME}.daemon-containerd
+  "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
+  snapctl restart ${SNAP_NAME}.daemon-containerd
 fi
 
 echo "Calico rolledback"


### PR DESCRIPTION
Until we decide on how the UX would look like I cannot be sure what the context of the transition scripts would be. With this PR all scripts assume they run within a microk8s context and as root.