### PR TITLE
Have dqlite node gracefully depart a cluster

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -413,6 +413,9 @@ get_node() {
     fi
 }
 
+wait_for_node() {
+  get_node
+}
 
 drain_node() {
     # Drain node
@@ -479,5 +482,6 @@ init_cluster() {
   $SNAP/bin/sed -i 's/HOSTNAME/'"${DNS}"'/g' $SNAP_DATA/var/tmp/csr-dqlite.conf
   $SNAP/bin/sed -i 's/HOSTIP/'"${IP}"'/g' $SNAP_DATA/var/tmp/csr-dqlite.conf
   ${SNAP}/usr/bin/openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout ${SNAP_DATA}/var/kubernetes/backend/cluster.key -out ${SNAP_DATA}/var/kubernetes/backend/cluster.crt -subj "/CN=k8s" -config $SNAP_DATA/var/tmp/csr-dqlite.conf -extensions v3_ext
+  chmod -R o-rwX ${SNAP_DATA}/var/kubernetes/backend/
 }
 

--- a/microk8s-resources/wrappers/microk8s-leave.wrapper
+++ b/microk8s-resources/wrappers/microk8s-leave.wrapper
@@ -20,7 +20,8 @@ fi
 exit_if_stopped
 exit_if_no_permissions
 
-if ! [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
+if ! [ -e ${SNAP_DATA}/var/lock/clustered.lock ] &&
+   ! grep "^\-\-storage\-backend.dqlite" "$SNAP_DATA/args/kube-apiserver" &> /dev/null
 then
   echo "This MicroK8s deployment is not acting as a node in a cluster."
   exit 1

--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -47,5 +47,4 @@ else
   fi
 fi
 
-echo "Enabling pod scheduling"
-uncordon_node
+wait_for_node

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -266,6 +266,7 @@ parts:
     python-packages:
     - flask
     - PyYAML
+    - netifaces
     stage-packages:
     - python3-openssl
     - openssl


### PR DESCRIPTION
With this PR:
- We inform the dqlite cluster of a departing node.
- Start does not uncordon the node as this was causing only the first node to uncordon
- Fix credential permissions of the dqlite backend