### PR TITLE
Upgrade and cleanup dashboard

### DIFF
--- a/microk8s-resources/actions/dashboard.yaml
+++ b/microk8s-resources/actions/dashboard.yaml
@@ -167,7 +167,7 @@ spec:
     spec:
       containers:
         - name: kubernetes-dashboard
-          image: kubernetesui/dashboard:v2.0.0-rc5
+          image: kubernetesui/dashboard:v2.0.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8443
@@ -188,6 +188,11 @@ spec:
               port: 8443
             initialDelaySeconds: 30
             timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001            
       volumes:
         - name: kubernetes-dashboard-certs
           secret:
@@ -238,7 +243,7 @@ spec:
     spec:
       containers:
         - name: dashboard-metrics-scraper
-          image: kubernetesui/metrics-scraper:v1.0.2
+          image: kubernetesui/metrics-scraper:v1.0.4
           ports:
             - containerPort: 8000
               protocol: TCP
@@ -252,6 +257,11 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: tmp-volume
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001            
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
@@ -262,324 +272,3 @@ spec:
           emptyDir: {}
 
 ---    
-# ------------------ Monitoring (heapster,influxdb, grafana) ----------- #
-apiVersion: v1
-kind: Service
-metadata:
-  name: monitoring-grafana
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "Grafana"
-spec:
-  # On production clusters, consider setting up auth for grafana, and
-  # exposing Grafana either using a LoadBalancer or a public IP.
-  # type: LoadBalancer
-  ports:
-    - port: 80
-      protocol: TCP
-      targetPort: ui
-  selector:
-    k8s-app: influxGrafana
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: monitoring-influxdb
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "InfluxDB"
-spec:
-  ports:
-    - name: http
-      port: 8083
-      targetPort: 8083
-    - name: api
-      port: 8086
-      targetPort: 8086
-  selector:
-    k8s-app: influxGrafana
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: heapster
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "Heapster"
-spec:
-  ports:
-    - port: 80
-      targetPort: 8082
-  selector:
-    k8s-app: heapster
-
----
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: monitoring-influxdb-grafana-v4
-  namespace: kube-system
-  labels:
-    k8s-app: influxGrafana
-    version: v4
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      k8s-app: influxGrafana
-      version: v4
-  template:
-    metadata:
-      labels:
-        k8s-app: influxGrafana
-        version: v4
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-    spec:
-      priorityClassName: system-cluster-critical
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
-      containers:
-        - name: influxdb
-          image: k8s.gcr.io/heapster-influxdb-$ARCH:v1.3.3
-          resources:
-            limits:
-              cpu: 100m
-              memory: 500Mi
-            requests:
-              cpu: 100m
-              memory: 500Mi
-          ports:
-            - name: http
-              containerPort: 8083
-            - name: api
-              containerPort: 8086
-          volumeMounts:
-          - name: influxdb-persistent-storage
-            mountPath: /data
-        - name: grafana
-          image: k8s.gcr.io/heapster-grafana-$ARCH:v4.4.3
-          env:
-          resources:
-            # keep request = limit to keep this container in guaranteed class
-            limits:
-              cpu: 100m
-              memory: 100Mi
-            requests:
-              cpu: 100m
-              memory: 100Mi
-          env:
-            # This variable is required to setup templates in Grafana.
-            - name: INFLUXDB_SERVICE_URL
-              value: http://monitoring-influxdb:8086
-              # The following env variables are required to make Grafana accessible via
-              # the kubernetes api-server proxy. On production clusters, we recommend
-              # removing these env variables, setup auth for grafana, and expose the grafana
-              # service using a LoadBalancer or a public IP.
-            - name: GF_AUTH_BASIC_ENABLED
-              value: "false"
-            - name: GF_AUTH_ANONYMOUS_ENABLED
-              value: "true"
-            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
-              value: Admin
-            - name: GF_SERVER_ROOT_URL
-              value: /api/v1/namespaces/kube-system/services/monitoring-grafana/proxy/
-          ports:
-          - name: ui
-            containerPort: 3000
-          volumeMounts:
-          - name: grafana-persistent-storage
-            mountPath: /var
-      volumes:
-      - name: influxdb-persistent-storage
-        emptyDir: {}
-      - name: grafana-persistent-storage
-        emptyDir: {}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: heapster
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: heapster
-  labels:
-    addonmanager.kubernetes.io/mode: Reconcile
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:heapster
-subjects:
-- kind: ServiceAccount
-  name: heapster
-  namespace: kube-system    
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: heapster-config
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: EnsureExists
-data:
-  NannyConfiguration: |-
-    apiVersion: nannyconfig/v1alpha1
-    kind: NannyConfiguration
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: eventer-config
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: EnsureExists
-data:
-  NannyConfiguration: |-
-    apiVersion: nannyconfig/v1alpha1
-    kind: NannyConfiguration
-
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: heapster-v1.5.2
-  namespace: kube-system
-  labels:
-    k8s-app: heapster
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.2
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      k8s-app: heapster
-      version: v1.5.2
-  template:
-    metadata:
-      labels:
-        k8s-app: heapster
-        version: v1.5.2
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-    spec:
-      priorityClassName: system-cluster-critical
-      containers:
-        - image: k8s.gcr.io/heapster-$ARCH:v1.5.2
-          name: heapster
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8082
-              scheme: HTTP
-            initialDelaySeconds: 180
-            timeoutSeconds: 5
-          command:
-            - /heapster
-            - --source=kubernetes.summary_api:''
-            - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: k8s.gcr.io/heapster-$ARCH:v1.5.2
-          name: eventer
-          command:
-            - /eventer
-            - --source=kubernetes:''
-            - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: cdkbot/addon-resizer-$ARCH:1.8.1
-          name: heapster-nanny
-          resources:
-            limits:
-              cpu: 50m
-              memory: 92360Ki
-            requests:
-              cpu: 50m
-              memory: 92360Ki
-          env:
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          volumeMounts:
-          - name: heapster-config-volume
-            mountPath: /etc/config
-          command:
-            - /pod_nanny
-            - --config-dir=/etc/config
-            - --cpu=80m
-            - --extra-cpu=0.5m
-            - --memory=140Mi
-            - --extra-memory=4Mi
-            - --threshold=5
-            - --deployment=heapster-v1.5.2
-            - --container=heapster
-            - --poll-period=300000
-            - --estimator=exponential
-        - image: cdkbot/addon-resizer-$ARCH:1.8.1
-          name: eventer-nanny
-          resources:
-            limits:
-              cpu: 50m
-              memory: 92360Ki
-            requests:
-              cpu: 50m
-              memory: 92360Ki
-          env:
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          volumeMounts:
-          - name: eventer-config-volume
-            mountPath: /etc/config
-          command:
-            - /pod_nanny
-            - --config-dir=/etc/config
-            - --cpu=100m
-            - --extra-cpu=0m
-            - --memory=190Mi
-            - --extra-memory=500Ki
-            - --threshold=5
-            - --deployment=heapster-v1.5.2
-            - --container=eventer
-            - --poll-period=300000
-            - --estimator=exponential
-      volumes:
-        - name: heapster-config-volume
-          configMap:
-            name: heapster-config
-        - name: eventer-config-volume
-          configMap:
-            name: eventer-config
-      serviceAccountName: heapster
-      tolerations:
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"

--- a/microk8s-resources/actions/disable.dashboard.sh
+++ b/microk8s-resources/actions/disable.dashboard.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Disabling Dashboard"
+
+ARCH=$(arch)
+TAG="0.25.1"
+EXTRA_ARGS="- --publish-status-address=127.0.0.1"
+
+
+KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+# Clean up old ingress controller resources in the default namespace, in case these are still lurking around.  
+$KUBECTL delete service -n kube-system monitoring-grafana  > /dev/null 2>&1 || true
+$KUBECTL delete service -n kube-system monitoring-influxdb  > /dev/null 2>&1 || true
+$KUBECTL delete service -n kube-system heapster  > /dev/null 2>&1 || true
+
+$KUBECTL delete deployment -n kube-system monitoring-influxdb-grafana-v4  > /dev/null 2>&1 || true
+$KUBECTL delete deployment -n kube-system heapster-v1.5.2  > /dev/null 2>&1 || true
+$KUBECTL delete clusterrolebinding heapster  > /dev/null 2>&1 || true
+$KUBECTL delete configmap -n kube-system heapster-config  > /dev/null 2>&1 || true
+$KUBECTL delete configmap -n kube-system eventer-config  > /dev/null 2>&1 || true
+$KUBECTL delete serviceaccount -n kube-system heapster  > /dev/null 2>&1 || true 
+
+use_manifest dashboard delete 
+
+echo "Dashboard is disabled"

--- a/microk8s-resources/actions/enable.dashboard.sh
+++ b/microk8s-resources/actions/enable.dashboard.sh
@@ -4,6 +4,8 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
+echo "Enabling Kubernetes Dashboard"
+"$SNAP/microk8s-enable.wrapper" metrics-server
 echo "Applying manifest"
 use_manifest dashboard apply
 

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -19,7 +19,7 @@ microk8s-addons:
 
     - name: "dashboard"
       description: "The Kubernetes dashboard"
-      version: "2.0.0-beta5"
+      version: "2.0.0"
       check_status: "pod/kubernetes-dashboard"
       supported_architectures:
       - arm64

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -18,34 +18,23 @@ from utils import (
 
 def validate_dns_dashboard():
     """
-    Validate the dashboard addon by looking at the grafana URL.
-    Validate DNS by starting a busy box and nslookuping the kubernetes default service.
+    Validate the dashboard addon by trying to access the kubernetes dashboard.
+    The dashboard will return an HTML indicating that it is up and running.
     """
-    wait_for_pod_state("", "kube-system", "running", label="k8s-app=influxGrafana")
-    cluster_info = kubectl("cluster-info")
-    # Cluster info output is colored so we better search for the port in the url pattern
-    # instead of trying to extract the url substring
-    regex = "http(.?)://127.0.0.1:([0-9]+)/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy"
-    grafana_pattern = re.compile(regex)
-    for url in cluster_info.split():
-        port_search = grafana_pattern.search(url)
-        if port_search:
-            break
-
-    grafana_url = "http{}://127.0.0.1:{}" \
-                  "/api/v1/namespaces/kube-system/services/" \
-                  "monitoring-grafana/proxy".format(port_search.group(1), port_search.group(2))
-    assert grafana_url
-
-    attempt = 50
-    while attempt >= 0:
-        resp = requests.get(grafana_url, verify=False)
-        if (resp.status_code == 200 and grafana_url.startswith('http://')) or \
-            (resp.status_code == 401 and grafana_url.startswith('https://')):
-            break
-        time.sleep(2)
+    wait_for_pod_state("", "kube-system", "running", label="k8s-app=kubernetes-dashboard")
+    wait_for_pod_state("", "kube-system", "running", label="k8s-app=dashboard-metrics-scraper")
+    attempt = 30
+    while attempt > 0:
+        try:
+            output = kubectl("get --raw /api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/")
+            if "Kubernetes Dashboard" in output:
+                break
+        except:
+            pass
+        time.sleep(10)
         attempt -= 1
-    assert resp.status_code in [200, 401]
+
+    assert attempt > 0
 
 
 def validate_storage():


### PR DESCRIPTION
Upgrade dashboard to v2.0.0
Remove influx, heapster and grafana.
Enable metrics-server when enabling dashboard add-on.