### PR TITLE
Transition scripts from dqlite and calico to flannel and etcd

### DIFF
--- a/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 echo "Switching master to dqlite"
 

--- a/upgrade-scripts/001-switch-to-dqlite/commit-node.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/commit-node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 echo "Switching node to dqlite"
 

--- a/upgrade-scripts/001-switch-to-dqlite/prepare-node.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/prepare-node.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-set -e
-
 echo "Nothing to do to praparing node for dqlite"

--- a/upgrade-scripts/002-switch-to-flannel-etcd/commit-master.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/commit-master.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -ex
+
+echo "Switching master to dqlite"
+
+source $SNAP/actions/common/utils.sh
+CA_CERT=/snap/core/current/etc/ssl/certs/ca-certificates.crt
+
+BACKUP_DIR="$SNAP_DATA/var/tmp/upgrades/002-switch-to-flannel-etcd"
+DB_DIR="$BACKUP_DIR/db"
+
+mkdir -p "$BACKUP_DIR/args/"
+
+if [ -e "$SNAP_DATA/args/cni-network/cni.yaml" ]; then
+  KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+  $KUBECTL delete -f "$SNAP_DATA/args/cni-network/cni.yaml" || true
+  sleep 10
+fi
+
+echo "Configuring services"
+${SNAP}/microk8s-stop.wrapper
+
+cp "$SNAP_DATA"/args/kube-apiserver "$BACKUP_DIR/args"
+skip_opt_in_config "storage-backend" kube-apiserver
+skip_opt_in_config "storage-dir" kube-apiserver
+refresh_opt_in_config "etcd-servers" 'https://127.0.0.1:12379' kube-apiserver
+refresh_opt_in_config "etcd-cafile" "\${SNAP_DATA}/certs/ca.crt" kube-apiserver
+refresh_opt_in_config "etcd-certfile" "\${SNAP_DATA}/certs/server.crt" kube-apiserver
+refresh_opt_in_config "etcd-keyfile" "\${SNAP_DATA}/certs/server.key" kube-apiserver
+
+cp "$SNAP_DATA"/args/etcd "$BACKUP_DIR/args"
+rm -rf ${SNAP_COMMON}/var/run/etcd/*
+cp "$SNAP"/default-args/etcd "$SNAP_DATA"/args/
+chmod 660 "$SNAP_DATA"/args/etcd
+
+cp -r "$SNAP_DATA"/args/cni-network "$BACKUP_DIR/args/"
+rm "$SNAP_DATA"/args/cni-network/*
+cp "$SNAP"/default-args/cni-network/* "$SNAP_DATA"/args/cni-network/
+chmod -R 660 "$SNAP_DATA"/args/cni-network
+
+if getent group microk8s >/dev/null 2>&1
+then
+  chgrp microk8s -R ${SNAP_DATA}/args/ || true
+fi
+
+set_service_expected_to_start etcd
+set_service_expected_to_start flanneld
+
+${SNAP}/microk8s-start.wrapper
+${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30
+
+echo "Switch to etcd and flanneld completed"

--- a/upgrade-scripts/002-switch-to-flannel-etcd/commit-node.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/commit-node.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+echo "This will transition only the master node"
+exit 1

--- a/upgrade-scripts/002-switch-to-flannel-etcd/description.txt
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/description.txt
@@ -1,0 +1,1 @@
+Migrates to a flannel and etcd setup

--- a/upgrade-scripts/002-switch-to-flannel-etcd/prepare-master.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/prepare-master.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Master ready for flannel-etcd transition"

--- a/upgrade-scripts/002-switch-to-flannel-etcd/prepare-node.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/prepare-node.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "This will transition only the master node"
+exit 1

--- a/upgrade-scripts/002-switch-to-flannel-etcd/rollback-master.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/rollback-master.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -ex
+
+echo "Rolling back dqlite upgrade on master"
+
+source $SNAP/actions/common/utils.sh
+CA_CERT=/snap/core/current/etc/ssl/certs/ca-certificates.crt
+BACKUP_DIR="$SNAP_DATA/var/tmp/upgrades/002-switch-to-flannel-etcd"
+
+${SNAP}/microk8s-stop.wrapper
+
+echo "Restarting etcd"
+set_service_not_expected_to_start etcd
+if [ -e "$BACKUP_DIR/args/etcd" ]; then
+  cp "$BACKUP_DIR"/args/etcd "$SNAP_DATA/args/"
+fi
+
+echo "Restarting kube-apiserver"
+if [ -e "$BACKUP_DIR/args/kube-apiserver" ]; then
+  cp "$BACKUP_DIR"/args/kube-apiserver "$SNAP_DATA/args/"
+fi
+
+set_service_not_expected_to_start flanneld
+if [ -e "$BACKUP_DIR/args/cni-network" ]; then
+  rm "$SNAP_DATA"/args/cni-network/*
+  cp "$BACKUP_DIR"/args/cni-network/* "$SNAP_DATA/args/cni-network/"
+fi
+
+chmod -R ug+rwX "${SNAP_DATA}/args/"
+chmod -R o-rwX "${SNAP_DATA}/args/"
+if getent group microk8s >/dev/null 2>&1
+then
+  chgrp microk8s -R ${SNAP_DATA}/args/ || true
+fi
+
+${SNAP}/microk8s-start.wrapper || true
+${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30
+
+if [ -e "$SNAP_DATA/args/cni-network/cni.yaml" ]; then
+  KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+  $KUBECTL apply -f "$SNAP_DATA/args/cni-network/cni.yaml"
+fi
+
+echo "Flannle-etcd rolled back"

--- a/upgrade-scripts/002-switch-to-flannel-etcd/rollback-node.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/rollback-node.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+echo "This will transition only the master node"
+exit 1


### PR DESCRIPTION
This PR includes a set of scripts that would allow to transition a *single* node from a setup with dqlite+calico to etcd+flannel. This is needed when a node departs a cluster and needs to get back to its prior state. These scripts will be exercised when the user calls `microk8s disable ha-cluster`.

In case the transition to etcd+flannel fails we have a rollback script to bring the current state back.