### PR TITLE
Improving the HA UX experience

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -425,7 +425,7 @@ get_node() {
 }
 
 wait_for_node() {
-  get_node
+  get_node &> /dev/null
 }
 
 drain_node() {
@@ -494,5 +494,9 @@ init_cluster() {
   $SNAP/bin/sed -i 's/HOSTIP/'"${IP}"'/g' $SNAP_DATA/var/tmp/csr-dqlite.conf
   ${SNAP}/usr/bin/openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout ${SNAP_DATA}/var/kubernetes/backend/cluster.key -out ${SNAP_DATA}/var/kubernetes/backend/cluster.crt -subj "/CN=k8s" -config $SNAP_DATA/var/tmp/csr-dqlite.conf -extensions v3_ext
   chmod -R o-rwX ${SNAP_DATA}/var/kubernetes/backend/
+  if getent group microk8s >/dev/null 2>&1
+  then
+    chgrp microk8s -R ${SNAP_DATA}/var/kubernetes/backend/ || true
+  fi
 }
 

--- a/microk8s-resources/wrappers/microk8s-leave.wrapper
+++ b/microk8s-resources/wrappers/microk8s-leave.wrapper
@@ -33,4 +33,4 @@ then
   exit 1
 fi
 
-${SNAP}/usr/bin/python3 ${SNAP}/scripts/cluster/join.py reset
+run_with_sudo preserve_env ${SNAP}/usr/bin/python3 ${SNAP}/scripts/cluster/join.py reset

--- a/scripts/cluster/agent.py
+++ b/scripts/cluster/agent.py
@@ -285,7 +285,9 @@ def join_node_etcd():
         return Response(json.dumps(error_msg), mimetype='application/json', status=500)
 
     if is_node_running_dqlite():
-        error_msg = {"error": "Not possible to join. This is an HA dqlite cluster."}
+        msg = ("Failed to join the cluster. This is an HA dqlite cluster. \n"
+               "Please, retry after enabling HA on this joining node with 'microk8s enable ha-cluster'.")
+        error_msg = {"error": msg}
         return Response(json.dumps(error_msg), mimetype='application/json', status=501)
 
     add_token_to_certs_request(token)

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -337,6 +337,7 @@ def reset_current_dqlite_installation():
 
     delete_dqlite_node(my_ep, other_ep)
 
+    print("Generating new cluster certificates.", flush=True)
     shutil.rmtree(cluster_dir, ignore_errors=True)
     os.mkdir(cluster_dir)
     if os.path.isfile("{}/cluster.crt".format(cluster_backup_dir)):
@@ -344,20 +345,23 @@ def reset_current_dqlite_installation():
         shutil.copy("{}/cluster.crt".format(cluster_backup_dir), "{}/cluster.crt".format(cluster_dir))
         shutil.copy("{}/cluster.key".format(cluster_backup_dir), "{}/cluster.key".format(cluster_dir))
     else:
-        # This nod never joined a cluster. A cluster was formed around it.
+        # This node never joined a cluster. A cluster was formed around it.
         hostname = socket.gethostname()  # type: str
         ip = '127.0.0.1'  # type: str
         shutil.copy('{}/microk8s-resources/certs/csr-dqlite.conf.template'.format(snap_path),
                     '{}/var/tmp/csr-dqlite.conf'.format(snapdata_path))
         subprocess.check_call("{}/bin/sed -i s/HOSTNAME/{}/g {}/var/tmp/csr-dqlite.conf"
-                              .format(snap_path, hostname, snapdata_path).split())
+                              .format(snap_path, hostname, snapdata_path).split(),
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         subprocess.check_call("{}/bin/sed -i s/HOSTIP/{}/g  {}/var/tmp/csr-dqlite.conf"
-                              .format(snap_path, ip, snapdata_path).split())
+                              .format(snap_path, ip, snapdata_path).split(),
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         subprocess.check_call('{0}/usr/bin/openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes '
                               '-keyout {1}/var/kubernetes/backend/cluster.key '
                               '-out {1}/var/kubernetes/backend/cluster.crt '
                               '-subj "/CN=k8s" -config {1}/var/tmp/csr-dqlite.conf -extensions v3_ext'
-                              .format(snap_path, snapdata_path).split())
+                              .format(snap_path, snapdata_path).split(),
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     # TODO make this port configurable
     init_data = {'Address': '127.0.0.1:19001'}  # type: Dict[str, str]
@@ -371,9 +375,11 @@ def reset_current_dqlite_installation():
     time.sleep(10)
     while waits > 0:
         try:
-            subprocess.check_output("{}/microk8s-kubectl.wrapper get service/kubernetes".format(snap_path).split())
-            subprocess.check_output("{}/microk8s-kubectl.wrapper apply -f {}/args/cni-network/cni.yaml"
-                                  .format(snap_path, snapdata_path).split())
+            subprocess.check_call("{}/microk8s-kubectl.wrapper get service/kubernetes".format(snap_path).split(),
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.check_call("{}/microk8s-kubectl.wrapper apply -f {}/args/cni-network/cni.yaml"
+                                  .format(snap_path, snapdata_path).split(),
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             break
         except subprocess.CalledProcessError:
             print(".", end=" ", flush=True)
@@ -622,11 +628,13 @@ def restart_all_services():
     """
     Restart all services
     """
-    subprocess.check_call("{}/microk8s-stop.wrapper".format(snap_path).split())
+    subprocess.check_call("{}/microk8s-stop.wrapper".format(snap_path).split(),
+                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     waits = 10
     while waits > 0:
         try:
-            subprocess.check_call("{}/microk8s-start.wrapper".format(snap_path).split())
+            subprocess.check_call("{}/microk8s-start.wrapper".format(snap_path).split(),
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             break
         except subprocess.CalledProcessError:
             time.sleep(5)

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -293,7 +293,7 @@ fi
 
 if getent group microk8s >/dev/null 2>&1
 then
-  chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ || true
+  chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ || true
 fi
 
 if ! [ -f "${SNAP_DATA}/args/flanneld" ]


### PR DESCRIPTION
A few fixes in this PR:
- we make sure dqlites storage directory `${SNAP_DATA}/var/kubernetes/backend/ ` has the right permissions so commands like `microk8s.leave` can reset it.
- when joining a dqlite cluster you are asked to first enable ha "Please, retry after enabling HA on this joining node with 'microk8s enable ha-cluster'."
- stop poluting stdout/stderr from subprocess.check_call
