### PR TITLE
Remove crashed nodes

### DIFF
--- a/microk8s-resources/wrappers/microk8s-remove-node.wrapper
+++ b/microk8s-resources/wrappers/microk8s-remove-node.wrapper
@@ -11,9 +11,17 @@ export PYTHONNOUSERSITE=false
 source $SNAP/actions/common/utils.sh
 
 if echo "$*" | grep -q -- 'help'; then
-  echo "Usage: microk8s remove <node>"
-  echo ""
-  echo "microk8s remove will remove the node provided from the cluster."
+  if [ -e "${SNAP_DATA}/var/lock/ha-cluster" ]
+  then
+    echo "Usage: microk8s remove <node> [--force]"
+    echo ""
+    echo "microk8s remove will remove the node provided from the cluster."
+    echo "--force   Remove node not available anymore (eg crashed)."
+  else
+    echo "Usage: microk8s remove <node>"
+    echo ""
+    echo "microk8s remove will remove the node provided from the cluster."
+  fi
   exit 0
 fi
 
@@ -25,8 +33,13 @@ then
   exit 1
 fi
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -eq 0 ]; then
     echo "Please provide the node you want to remove."
+  exit 1
+fi
+
+if [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] && [ "$#" -eq 2 ] && ! [ "$2" == "--force" ] ; then
+    echo "Please provide the node and the optional --force flag."
   exit 1
 fi
 

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -387,12 +387,16 @@ def delete_dqlite_node(delete_node, dqlite_ep):
     if len(delete_node) > 0 and "127.0.0.1" not in delete_node[0]:
         for ep in dqlite_ep:
             try:
-                subprocess.check_output("curl -X DELETE https://{}/cluster/{} --cacert {} --key {} --cert {}  -k -s"
-                                        .format(ep, delete_node[0], cluster_cert_file, cluster_key_file, cluster_cert_file)
-                                        .split())
-                break
-            except subprocess.CalledProcessError:
-                print("Contacting node {} failed.".format(ep))
+                url = 'https://{}/cluster/{}'.format(ep, delete_node[0])
+                resp = requests.delete(url, cert=(cluster_cert_file, cluster_key_file), verify=False)
+                if resp.status_code != 200:
+                    print("Contacting node {} failed. Exit code {}.".format(ep, resp.status_code))
+                    exit(2)
+                else:
+                    break
+            except Exception as err:
+                print("Contacting node {} failed. Error:".format(ep))
+                print(repr(err))
                 exit(2)
 
 


### PR DESCRIPTION
Wen removing a dqlite node we need to:
- fail if the node is present on the dqlite cluster and ask the user to call `microk8s.leave` from the departing node.
- if the dqlite node has crashed and is not available anymore, allow the forceful removal of the node with the `--force` flag. 

A node to be removed should first un-register with dqlite and we should be certain that node will not try to reenter the cluster.