### PR TITLE
Support for NGINX Ingress Controller default certificate

### DIFF
--- a/microk8s-resources/actions/disable.ingress.sh
+++ b/microk8s-resources/actions/disable.ingress.sh
@@ -8,6 +8,7 @@ echo "Disabling Ingress"
 
 ARCH=$(arch)
 TAG="0.25.1"
+DEFAULT_CERT="- ' '" # This default value is always fine when deleting resources.
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 
 
@@ -24,6 +25,7 @@ $KUBECTL delete daemonset -n default nginx-ingress-microk8s-controller || true
 
 declare -A map
 map[\$TAG]="$TAG"
+map[\$DEFAULT_CERT]="$DEFAULT_CERT"
 map[\$EXTRA_ARGS]="$EXTRA_ARGS"
 use_manifest ingress delete "$(declare -p map)"
 

--- a/microk8s-resources/actions/enable.ingress.sh
+++ b/microk8s-resources/actions/enable.ingress.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 source $SNAP/actions/common/utils.sh
 
@@ -9,12 +9,14 @@ read -ra ARGUMENTS <<<"$1"
 read -r key value <<<$(echo "${ARGUMENTS[@]}" | gawk -F "=" '{print $1 ,$2}')
 read -ra CERT_SECRET <<< "$value"
 
-KEY_NAME="defaultcert"
+KEY_NAME="default-ssl-certificate"
 
 if [ ! -z "$key" ] && [ "$key" != $KEY_NAME ]
 then
-  echo "You should use the the '$KEY_NAME' as key in the argument passed and not '$key'. Eg. microk8s.enable ingress:$KEY_NAME=namespace/secret_name";
-  exit
+  echo "Unknown argument '$key'."
+  echo "You can use '$KEY_NAME' to load the default TLS certificate from a secret, eg"
+  echo "   microk8s enable ingress:$KEY_NAME=namespace/secret_name"
+  exit 1
 fi
 
 echo "Enabling Ingress"

--- a/microk8s-resources/actions/enable.ingress.sh
+++ b/microk8s-resources/actions/enable.ingress.sh
@@ -4,15 +4,35 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
+read -ra ARGUMENTS <<<"$1"
+
+read -r key value <<<$(echo "${ARGUMENTS[@]}" | gawk -F "=" '{print $1 ,$2}')
+read -ra CERT_SECRET <<< "$value"
+
+KEY_NAME="defaultcert"
+
+if [ ! -z "$key" ] && [ "$key" != $KEY_NAME ]
+then
+  echo "You should use the the '$KEY_NAME' as key in the argument passed and not '$key'. Eg. microk8s.enable ingress:$KEY_NAME=namespace/secret_name";
+  exit
+fi
+
 echo "Enabling Ingress"
 
 ARCH=$(arch)
 TAG="0.25.1"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
+DEFAULT_CERT="- ' '"
 
+if [ ! -z "$CERT_SECRET" ]
+then
+  DEFAULT_CERT="- --default-ssl-certificate=${CERT_SECRET}"
+  echo "Setting ${CERT_SECRET} as default ingress certificate"
+fi
 
 declare -A map
 map[\$TAG]="$TAG"
+map[\$DEFAULT_CERT]="$DEFAULT_CERT"
 map[\$EXTRA_ARGS]="$EXTRA_ARGS"
 use_manifest ingress apply "$(declare -p map)"
 

--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -183,4 +183,5 @@ spec:
         - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-microk8s-conf
         - --tcp-services-configmap=$(POD_NAMESPACE)/nginx-ingress-tcp-microk8s-conf
         - --udp-services-configmap=$(POD_NAMESPACE)/nginx-ingress-udp-microk8s-conf
+        $DEFAULT_CERT
         $EXTRA_ARGS


### PR DESCRIPTION
Added support for optional NGINX Ingress Controller default certificate.
See https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate

The new, optional key-value pair is parsed in [`enable.ingress.sh`](https://github.com/marcobellaccini/microk8s/blob/master/microk8s-resources/actions/enable.ingress.sh) in the same way as in [`enable.host-access.sh`](https://github.com/ubuntu/microk8s/blob/master/microk8s-resources/actions/enable.host-access.sh).

Usage example:
`microk8s.enable ingress:defaultcert=namespace/secretname`