### PR TITLE
No not inspect etcd and flannel when in HA mode

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -230,7 +230,6 @@ check_certificates
 
 printf -- 'Inspecting services\n'
 check_service "snap.microk8s.daemon-cluster-agent"
-check_service "snap.microk8s.daemon-flanneld"
 check_service "snap.microk8s.daemon-containerd"
 check_service "snap.microk8s.daemon-apiserver"
 check_service "snap.microk8s.daemon-apiserver-kicker"
@@ -238,7 +237,12 @@ check_service "snap.microk8s.daemon-proxy"
 check_service "snap.microk8s.daemon-kubelet"
 check_service "snap.microk8s.daemon-scheduler"
 check_service "snap.microk8s.daemon-controller-manager"
-check_service "snap.microk8s.daemon-etcd"
+if ! [ -e "${SNAP_DATA}/var/lock/ha-cluster" ]
+then
+  check_service "snap.microk8s.daemon-flanneld"
+  check_service "snap.microk8s.daemon-etcd"
+fi
+
 store_args
 
 printf -- 'Inspecting AppArmor configuration\n'


### PR DESCRIPTION
Flannel and etcd are not running in HA, they should not be reported as error.