### PR TITLE
Small tweaks to build documentation

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -5,12 +5,14 @@ A VM managed by Multipass is spawned to contain the build process. If you don’
 snapcraft will first prompt for its automatic installation.
 
 Alternatively, you can build the snap in an LXC container.
-LXD is needed in this case:
+Snapcraft and LXD are needed in this case:
 ```
+sudo snap install snapcraft --classic
 sudo snap install lxd
 sudo apt-get remove lxd* -y
 sudo apt-get remove lxc* -y
 sudo lxd init
+sudo usermod -a -G lxd ${USER}
 ```
 
 Build the snap with:

--- a/docs/build.md
+++ b/docs/build.md
@@ -22,6 +22,11 @@ cd ./microk8s/
 snapcraft --use-lxd
 ```
 
+Install the newly compiled snap:
+```
+snap install microk8s_*_amd64.snap --classic --dangerous
+```
+
 ## Building a custom MicroK8s package
 
 To produce a custom build with specific component versions we cannot use the snapcraft build process on the host OS. We need to

--- a/docs/build.md
+++ b/docs/build.md
@@ -24,7 +24,7 @@ snapcraft --use-lxd
 
 Install the newly compiled snap:
 ```
-snap install microk8s_*_amd64.snap --classic --dangerous
+sudo snap install microk8s_*_amd64.snap --classic --dangerous
 ```
 
 ## Building a custom MicroK8s package


### PR DESCRIPTION
Added a few small changes to build documentation to cover things I ran into building, namely:

- install snapcraft
- add user to LXD group so they can access LXD during build
- line to show how to install the resulting package (there is one in another section, but thought it'd be good to have it up top in regular build instructions)