### PR TITLE
Add new add-on for Multus CNI

### DIFF
--- a/microk8s-resources/actions/disable.cilium.sh
+++ b/microk8s-resources/actions/disable.cilium.sh
@@ -37,15 +37,6 @@ fi
 
 set_service_expected_to_start flanneld
 
-echo "Restarting kubelet"
-refresh_opt_in_config "cni-bin-dir" "\${SNAP}/opt/cni/bin/" kubelet
-run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-kubelet"
-echo "Restarting containerd"
-if ! grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
-  run_with_sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-fi
-run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-containerd"
-
 echo "Restarting flanneld"
 run_with_sudo preserve_env snapctl stop "${SNAP_NAME}.daemon-flanneld"
 

--- a/microk8s-resources/actions/disable.multus.sh
+++ b/microk8s-resources/actions/disable.multus.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+
+source "${SNAP}/actions/common/utils.sh"
+
+KUBECTL="${SNAP}/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+
+if [ -f "${SNAP_DATA}/args/cni-network/00-multus.conf" ]
+then
+  echo "Disabling Multus"
+  echo "Checking if multus daemonset is running"
+  DS_CHECK=$(${KUBECTL} get pods -n kube-system --selector=app=multus -o name)
+  if [ -n "${DS_CHECK}" ]; then
+    echo "Found multus deamonset, removing it and cleaning up OS files"
+    cat "${SNAP}/actions/multus.yaml" | ${SNAP}/bin/sed "s#{{SNAP_DATA}}#${SNAP_DATA}#g" | ${KUBECTL} delete -f - 
+    run_with_sudo rm -f "${SNAP_DATA}/args/cni-network/00-multus.conf"
+    run_with_sudo rm -rf "${SNAP_DATA}/args/cni-network/multus.d"
+    run_with_sudo rm -f "${SNAP_DATA}/opt/cni/bin/multus"
+
+    echo -n "Waiting for multus daemonset to terminate."
+    while [ -n "${DS_CHECK}" ]; do
+      sleep 3
+      DS_CHECK=$(${KUBECTL} get pods -n kube-system --selector=app=multus -o name)
+      echo -n "."
+    done 
+    echo
+    echo "Multus daemonset terminated."
+    echo "Initiating removal on all other nodes."
+    nodes_addon multus disable
+  else
+    echo "Daemonset not found so we are likely a node, cleaning up OS files"
+    run_with_sudo rm -f "${SNAP_DATA}/args/cni-network/00-multus.conf"
+    run_with_sudo rm -rf "${SNAP_DATA}/args/cni-network/multus.d"
+    run_with_sudo rm -f "${SNAP_DATA}/opt/cni/bin/multus"
+  fi
+  echo "Multus is disabled"
+else
+  echo "Multus is not installed."
+fi

--- a/microk8s-resources/actions/enable.cilium.sh
+++ b/microk8s-resources/actions/enable.cilium.sh
@@ -17,20 +17,9 @@ echo "Restarting kube-apiserver"
 refresh_opt_in_config "allow-privileged" "true" kube-apiserver
 run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-apiserver"
 
-# Reconfigure kubelet/containerd to pick up the new CNI config and binary.
-echo "Restarting kubelet"
-refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
-run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-kubelet"
-
 set_service_not_expected_to_start flanneld
 run_with_sudo preserve_env snapctl stop "${SNAP_NAME}.daemon-flanneld"
 remove_vxlan_interfaces
-
-if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
-  echo "Restarting containerd"
-  run_with_sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-containerd"
-fi
 
 echo "Enabling Cilium"
 

--- a/microk8s-resources/actions/enable.multus.sh
+++ b/microk8s-resources/actions/enable.multus.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+source "${SNAP}/actions/common/utils.sh"
+
+KUBECTL="${SNAP}/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+
+echo "Enabling Multus"
+
+if [ -f "${SNAP_DATA}/args/cni-network/00-multus.conf" ]
+then
+  echo "Multus is already installed."
+else
+  echo "Waiting for microk8s to be ready."
+  "${SNAP}/microk8s-status.wrapper" --wait-ready >/dev/null
+
+  echo "Applying manifest for multus daemonset."
+  cat "${SNAP}/actions/multus.yaml" | "${SNAP}/bin/sed" "s#{{SNAP_DATA}}#${SNAP_DATA}#g" | ${KUBECTL} apply -f -
+
+  echo -n "Waiting for multus daemonset to start."
+  until [ -f "${SNAP_DATA}/opt/cni/bin/multus" ]; do
+    sleep 1
+    echo -n "."
+  done
+  echo
+  echo "Multus is enabled"
+fi
+
+echo "Multus is enabled with version:"
+"${SNAP_DATA}/opt/cni/bin/multus" -v
+
+echo
+echo "Currently installed CNI and IPAM plugins include:"
+echo $(cd "${SNAP_DATA}/opt/cni/bin/"; ls)
+
+echo
+echo "New CNI plugins can be installed in ${SNAP_DATA}/opt/cni/bin/"
+
+echo
+echo "For information on configuration please refer to the multus documentation."
+echo "  First you need to create network definitions:"
+echo "    https://github.com/intel/multus-cni/blob/master/doc/how-to-use.md#create-network-attachment-definition"
+echo "  Then you need to tell your pods to use those networks via annotations"
+echo "    https://github.com/intel/multus-cni/blob/master/doc/how-to-use.md#run-pod-with-network-annotation"
+echo

--- a/microk8s-resources/actions/multus.yaml
+++ b/microk8s-resources/actions/multus.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  scope: Namespaced
+  names:
+    plural: network-attachment-definitions
+    singular: network-attachment-definition
+    kind: NetworkAttachmentDefinition
+    shortNames:
+    - net-attach-def
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+          Working Group to express the intent for attaching pods to one or more logical or physical
+          networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
+        type: object
+        properties:
+          spec:
+            description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
+            type: object
+            properties:
+              config:
+                description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
+                type: string
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: multus
+rules:
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: multus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: multus
+subjects:
+- kind: ServiceAccount
+  name: multus
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: multus
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds-amd64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: multus
+    name: multus
+spec:
+  selector:
+    matchLabels:
+      name: multus
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: multus
+        name: multus
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: multus
+      containers:
+      - name: kube-multus
+        image: nfvpe/multus:v3.4.2
+        command: ["/entrypoint.sh"]
+        args:
+        - "--multus-conf-file=auto"
+        - "--multus-kubeconfig-file-host={{SNAP_DATA}}/args/cni-network/multus.d/multus.kubeconfig"
+        - "--cni-version=0.3.1"
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - name: cni
+          mountPath: /host/etc/cni/net.d
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
+      volumes:
+      - name: cni
+        hostPath:
+          path: "{{SNAP_DATA}}/args/cni-network/"
+      - name: cnibin
+        hostPath:
+          path: "{{SNAP_DATA}}/opt/cni/bin/"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds-arm64
+  namespace: kube-system
+  labels:
+    tier: node
+    app: multus
+    name: multus
+spec:
+  selector:
+    matchLabels:
+      name: multus
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: multus
+        name: multus
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: multus
+      containers:
+      - name: kube-multus
+        image: nfvpe/multus:v3.4.2
+        command: ["/entrypoint.sh"]
+        args:
+        - "--multus-conf-file=auto"
+        - "--multus-kubeconfig-file-host={{SNAP_DATA}}/args/cni-network/multus.d/multus.kubeconfig"
+        - "--cni-version=0.3.1"
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "90Mi"
+          limits:
+            cpu: "100m"
+            memory: "90Mi"
+        securityContext:
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - name: cni
+          mountPath: /host/etc/cni/net.d
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
+      volumes:
+      - name: cni
+        hostPath:
+          path: "{{SNAP_DATA}}/args/cni-network/"
+      - name: cnibin
+        hostPath:
+          path: "{{SNAP_DATA}}/opt/cni/bin/"

--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -62,7 +62,7 @@ oom_score = 0
   # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
   [plugins."io.containerd.grpc.v1.cri".cni]
     # bin_dir is the directory in which the binaries for the plugin is kept.
-    bin_dir = "${SNAP}/opt/cni/bin"
+    bin_dir = "${SNAP_DATA}/opt/cni/bin"
 
     # conf_dir is the directory in which the admin places a CNI conf.
     conf_dir = "${SNAP_DATA}/args/cni-network"

--- a/microk8s-resources/default-args/kubelet
+++ b/microk8s-resources/default-args/kubelet
@@ -6,7 +6,7 @@
 --root-dir=${SNAP_COMMON}/var/lib/kubelet
 --fail-swap-on=false
 --cni-conf-dir=${SNAP_DATA}/args/cni-network/
---cni-bin-dir=${SNAP}/opt/cni/bin/
+--cni-bin-dir=${SNAP_DATA}/opt/cni/bin/
 --feature-gates=DevicePlugins=true
 --eviction-hard="memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi"
 --container-runtime=remote

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -113,6 +113,14 @@ microk8s-addons:
       supported_architectures:
       - amd64
 
+    - name: "multus"
+      description: "Multus CNI enables attaching multiple network interfaces to pods"
+      version: "3.4.2"
+      check_status: "${SNAP_DATA}/args/cni-network/00-multus.conf"
+      supported_architectures:
+      - amd64
+      - arm64
+
     - name: "helm"
       description: "Helm 2 - the package manager for Kubernetes"
       version: "2.16.0"

--- a/microk8s-resources/wrappers/run-flanneld-with-args
+++ b/microk8s-resources/wrappers/run-flanneld-with-args
@@ -45,4 +45,4 @@ fi
 
 # This is really the only way I could find to get the args passed in correctly. WTF
 declare -a args="($(cat $SNAP_DATA/args/flanneld))"
-exec "$SNAP/opt/cni/bin/flanneld" "${args[@]}"
+exec "$SNAP_DATA/opt/cni/bin/flanneld" "${args[@]}"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -296,6 +296,22 @@ then
   chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ || true
 fi
 
+if ! [ -L "${SNAP_DATA}/opt/cni/bin/flanneld" ]
+then
+  # cover situation where cilium was installed prior to this update
+  if [ -f "${SNAP_DATA}/opt/cni/bin/loopback" ] && [ -f "${SNAP}/opt/cni/bin/loopback" ]; then
+    rm -f "${SNAP_DATA}/opt/cni/bin/loopback"
+  fi
+  # as only one cni bin dir can be used we will use the one in SNAP_DATA but have links to
+  # the real CNI plugins we distribute in SNAP
+  mkdir -p "${SNAP_DATA}/opt/cni/bin/"
+  (
+    cd "${SNAP}/opt/cni/bin/"
+    MY_SNAP_DIR=$(dirname "${SNAP}")
+    for i in *; do ln -s "${MY_SNAP_DIR}/current/opt/cni/bin/$i" "${SNAP_DATA}/opt/cni/bin/${i}"; done
+  )
+fi
+
 if ! [ -f "${SNAP_DATA}/args/flanneld" ]
 then
   mkdir -p ${SNAP_DATA}/args/cni-network/

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -354,6 +354,13 @@ then
   snapctl restart ${SNAP_NAME}.daemon-apiserver
 fi
 
+if [ -f "${SNAP_DATA}/args/cni-network/00-multus.conf" ]
+then
+  echo "Multus is enabled we need to reconfigure it."
+  ${SNAP}/actions/disable.multus.sh
+  ${SNAP}/actions/enable.multus.sh
+fi
+
 if [ -L "${SNAP_DATA}/bin/cilium" ]
 then
   echo "Cilium is enabled we need to reconfigure it."

--- a/tests/templates/multus-alpine.yaml
+++ b/tests/templates/multus-alpine.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: multus-alpine
+  name: multus-alpine
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[
+      {
+         "name" : "net1",
+         "interface": "eth1",
+         "ips": ["10.111.111.111"]
+      },
+      {
+         "name" : "net2",
+         "interface": "eth2",
+         "ips": ["10.222.222.222"]
+      }
+    ]'
+spec:
+  containers:
+    - name: multus-alpine
+      image: alpine:latest
+      command: ["sh"]
+      args: ["-c", "while [ true ]; do ifconfig; sleep 3; done"]
+  restartPolicy: Always

--- a/tests/templates/multus-networks.yaml
+++ b/tests/templates/multus-networks.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: net1
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "name": "net1",
+    "type": "ptp",
+    "ipam": {
+      "type": "host-local",
+      "subnet": "10.111.111.0/24"
+    }
+  }'
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: net2
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "name": "net2",
+    "type": "ptp",
+    "ipam": {
+      "type": "host-local",
+      "subnet": "10.222.222.0/24"
+    }
+  }'

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -18,6 +18,7 @@ from validators import (
     validate_linkerd,
     validate_rbac,
     validate_cilium,
+    validate_multus,
     validate_kubeflow,
 )
 from utils import (
@@ -148,6 +149,23 @@ class TestAddons(object):
         print("Disabling Cilium")
         microk8s_disable("cilium")
 
+    @pytest.mark.skipif(
+        os.environ.get('UNDER_TIME_PRESSURE') == 'True',
+        reason="Skipping multus tests as we are under time pressure",
+    )
+    def test_multus(self):
+        """
+        Sets up and validates Multus.
+        """
+        print("Enabling Multus")
+        p = Popen(
+            "/snap/bin/microk8s.enable multus".split(), stdout=PIPE, stdin=PIPE, stderr=STDOUT
+        )
+        print("Validating Multus")
+        validate_multus()
+        print("Disabling Multus")
+        microk8s_disable("multus")
+
     def test_metrics_server(self):
         """
         Test the metrics server.
@@ -166,7 +184,7 @@ class TestAddons(object):
     )
     @pytest.mark.skipif(
         os.environ.get('UNDER_TIME_PRESSURE') == 'True',
-        reason="Skipping cilium tests as we are under time pressure",
+        reason="Skipping jaeger, prometheus and fluentd tests as we are under time pressure",
     )
     def test_monitoring_addons(self):
         """

--- a/tests/test-live-addons.py
+++ b/tests/test-live-addons.py
@@ -11,6 +11,7 @@ from validators import (
     validate_fluentd,
     validate_jaeger,
     validate_cilium,
+    validate_multus,
     validate_linkerd,
     validate_gpu,
     validate_kubeflow,
@@ -99,6 +100,12 @@ class TestLiveAddons(object):
         Validates Cilium works.
         """
         validate_cilium()
+
+    def test_multus(self):
+        """
+        Validates Multus works.
+        """
+        validate_multus()
 
     def test_linkerd(self):
         """

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -14,6 +14,7 @@ from validators import (
     validate_jaeger,
     validate_kubeflow,
     validate_cilium,
+    validate_multus,
 )
 from subprocess import check_call, CalledProcessError, check_output
 from utils import microk8s_enable, wait_for_pod_state, wait_for_installation, run_until_success
@@ -154,6 +155,14 @@ class TestUpgrade(object):
                 test_matrix['cilium'] = validate_cilium
             except:
                 print('Will not test the cilium addon')
+
+            try:
+                enable = microk8s_enable("multus", timeout_insec=150)
+                assert "Nothing to do for" not in enable
+                validate_multus()
+                test_matrix['multus'] = validate_multus
+            except:
+                print('Will not test the multus addon')
 
         # Refresh the snap to the target
         if upgrade_to.endswith('.snap'):

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -396,6 +396,27 @@ def validate_cilium():
     kubectl("delete -f {}".format(manifest))
 
 
+def validate_multus():
+    """
+    Validate multus by deploying alpine pod with 3 interfaces.
+    """
+
+    wait_for_installation()
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    networks = os.path.join(here, "templates", "multus-networks.yaml")
+    kubectl("create -f {}".format(my_nets))
+    manifest = os.path.join(here, "templates", "multus-alpine.yaml")
+    kubectl("apply -f {}".format(manifest))
+    wait_for_pod_state("", "default", "running", label="app=multus-alpine")
+    output = kubectl("exec multus-alpine -- ifconfig eth1", err_out='no')
+    assert "10.111.111.111" in output
+    output = kubectl("exec multus-alpine -- ifconfig eth2", err_out='no')
+    assert "10.222.222.222" in output
+    kubectl("delete -f {}".format(manifest))
+    kubectl("delete -f {}".format(networks))
+
+
 def validate_kubeflow():
     """
     Validate kubeflow

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -405,7 +405,7 @@ def validate_multus():
 
     here = os.path.dirname(os.path.abspath(__file__))
     networks = os.path.join(here, "templates", "multus-networks.yaml")
-    kubectl("create -f {}".format(my_nets))
+    kubectl("create -f {}".format(networks))
     manifest = os.path.join(here, "templates", "multus-alpine.yaml")
     kubectl("apply -f {}".format(manifest))
     wait_for_pod_state("", "default", "running", label="app=multus-alpine")

--- a/upgrade-scripts/000-switch-to-calico/commit-node.sh
+++ b/upgrade-scripts/000-switch-to-calico/commit-node.sh
@@ -14,19 +14,11 @@ mkdir -p "$BACKUP_DIR"
 
 mkdir -p "$BACKUP_DIR/args/cni-network/"
 cp "$SNAP_DATA"/args/cni-network/* "$BACKUP_DIR/args/cni-network/" 2>/dev/null || true
-rm "$SNAP_DATA"/args/cni-network/*
+find "$SNAP_DATA"/args/cni-network/* -not -name '*multus*' -exec rm -f {} \;
 run_with_sudo cp "$RESOURCES/calico.yaml" "$SNAP_DATA/args/cni-network/cni.yaml"
-mkdir -p "$SNAP_DATA/opt/cni/bin/"
-cp -R "$SNAP"/opt/cni/bin/* "$SNAP_DATA"/opt/cni/bin/
 
 cp "$SNAP_DATA"/args/kube-apiserver "$BACKUP_DIR/args"
 refresh_opt_in_config "allow-privileged" "true" kube-apiserver
-
-# Reconfigure kubelet/containerd to pick up the new CNI config and binary.
-cp "$SNAP_DATA"/args/kubelet "$BACKUP_DIR/args"
-echo "Restarting kubelet"
-refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
-snapctl restart ${SNAP_NAME}.daemon-kubelet
 
 cp "$SNAP_DATA"/args/kube-proxy "$BACKUP_DIR/args"
 echo "Restarting kube proxy"
@@ -36,12 +28,5 @@ snapctl restart ${SNAP_NAME}.daemon-proxy
 set_service_not_expected_to_start flanneld
 snapctl stop ${SNAP_NAME}.daemon-flanneld
 remove_vxlan_interfaces
-
-cp "$SNAP_DATA"/args/containerd-template.toml "$BACKUP_DIR/args"
-if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
-  echo "Restarting containerd"
-  "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  snapctl restart ${SNAP_NAME}.daemon-containerd
-fi
 
 echo "Calico is enabled"

--- a/upgrade-scripts/000-switch-to-calico/rollback-master.sh
+++ b/upgrade-scripts/000-switch-to-calico/rollback-master.sh
@@ -15,8 +15,8 @@ fi
 BACKUP_DIR="$SNAP_DATA/var/tmp/upgrades/000-switch-to-calico"
 
 if [ -e "$BACKUP_DIR/args/cni-network/flannel.conflist" ]; then
-  rm -rf "$SNAP_DATA"/args/cni-network/*
-  cp "$BACKUP_DIR"/args/cni-network/* "$SNAP_DATA/args/cni-network/"
+  find "$SNAP_DATA"/args/cni-network/* -not -name '*multus*' -exec rm -f {} \;
+  cp -rf "$BACKUP_DIR"/args/cni-network/* "$SNAP_DATA/args/cni-network/"
 fi
 
 echo "Restarting kubelet"
@@ -43,12 +43,5 @@ echo "Restarting flannel"
 set_service_expected_to_start flanneld
 remove_vxlan_interfaces
 snapctl start ${SNAP_NAME}.daemon-flanneld
-
-echo "Restarting kubelet"
-if grep -qE "bin_dir.*SNAP_DATA}\/" $SNAP_DATA/args/containerd-template.toml; then
-  echo "Restarting containerd"
-  "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  snapctl restart ${SNAP_NAME}.daemon-containerd
-fi
 
 echo "Calico rolledback"

--- a/upgrade-scripts/002-switch-to-flannel-etcd/commit-master.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/commit-master.sh
@@ -34,7 +34,7 @@ cp "$SNAP"/default-args/etcd "$SNAP_DATA"/args/
 chmod 660 "$SNAP_DATA"/args/etcd
 
 cp -r "$SNAP_DATA"/args/cni-network "$BACKUP_DIR/args/"
-rm "$SNAP_DATA"/args/cni-network/*
+find "$SNAP_DATA"/args/cni-network/* -not -name '*multus*' -exec rm -f {} \;
 cp "$SNAP"/default-args/cni-network/* "$SNAP_DATA"/args/cni-network/
 chmod -R 660 "$SNAP_DATA"/args/cni-network
 

--- a/upgrade-scripts/002-switch-to-flannel-etcd/rollback-master.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/rollback-master.sh
@@ -22,8 +22,8 @@ fi
 
 set_service_not_expected_to_start flanneld
 if [ -e "$BACKUP_DIR/args/cni-network" ]; then
-  rm "$SNAP_DATA"/args/cni-network/*
-  cp "$BACKUP_DIR"/args/cni-network/* "$SNAP_DATA/args/cni-network/"
+  find "$SNAP_DATA"/args/cni-network/* -not -name '*multus*' -exec rm -f {} \;
+  cp -rf "$BACKUP_DIR"/args/cni-network/* "$SNAP_DATA/args/cni-network/"
 fi
 
 chmod -R ug+rwX "${SNAP_DATA}/args/"


### PR DESCRIPTION
This PR creates a new add-on that installs the Multus CNI plugin.  Multus CNI enables attaching multiple network interfaces to pods in Kubernetes (details here: https://github.com/intel/multus-cni).  The install is transparent and the current CNI plugin is carried forward as the default in Multus.  With Multus installed users can easily add multiple interfaces to pods using varying CNI plugins (like bridge, macvlan, ipvlan, ptp, etc.) all of which wasn't possible previously in microk8s without some hacking. 

I've sorted out enable/disable compatibility with the cilium (the only other CNI add-on) so either one or both may be enabled simultaneously.  It may make sense to make a more structural changes to store CNI plugins in SNAP_DATA in general, but I'll save that for a later PR.

Multus supports installation via their pod or manually, I've opted for the manual install approach in this PR so there is no pod that runs or remains running.  Installation defaults to the latest version at the time of enabling but supports the MULTUS_VERSION env variable if a specific version is required.

I've provided a test case that creates a pod with multiple interfaces but I don't know how the test the test so it may need a closer look.

Open to any suggestions for recommendations for improvement.
