### PR TITLE
Fix long option "--check" of refresh certs command

### DIFF
--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -18,7 +18,7 @@ BACKUP=$SNAP_DATA/var/log/ca-backup/
 INSTALL=false
 UNDO=false
 CHECK=false
-PARSED=$(getopt --options=iuhc --longoptions=install,undo,help,check: --name "$@" -- "$@")
+PARSED=$(getopt --options=iuhc --longoptions=install,undo,help,check --name "$@" -- "$@")
 eval set -- "$PARSED"
 while true; do
   case "$1" in


### PR DESCRIPTION
The definition of the long option `--check` for the (great) `refresh-certs` command (as introduced in #1159) included an excessive trailing colon, making it require an argument:

```text
$ microk8s refresh-certs --check
--check: option '--check' requires an argument

$ microk8s refresh-certs -c
The CA certificate will expire in 3649 days.
```

From `man getopt`, emphasis mine:

> `-l`, `--longoptions` _longopts_
>
> The long (multi-character) options to be recognized. More than one option name may be specified at once, by separating the names with commas. This option may be given more than once, the `longopts` are cumulative. **Each long option name in longopts may be followed by one colon to indicate it has a required argument**, and by two colons to indicate it has an optional argument.

This tiny fix simply makes `-c` and `--check` behave the same.