### PR TITLE
Move default CNI bin directory from SNAP to SNAP_DATA

### DIFF
--- a/microk8s-resources/actions/disable.cilium.sh
+++ b/microk8s-resources/actions/disable.cilium.sh
@@ -37,15 +37,6 @@ fi
 
 set_service_expected_to_start flanneld
 
-echo "Restarting kubelet"
-refresh_opt_in_config "cni-bin-dir" "\${SNAP}/opt/cni/bin/" kubelet
-run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-kubelet"
-echo "Restarting containerd"
-if ! grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
-  run_with_sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP_DATA}/opt;bin_dir = "${SNAP}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-fi
-run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-containerd"
-
 echo "Restarting flanneld"
 run_with_sudo preserve_env snapctl stop "${SNAP_NAME}.daemon-flanneld"
 

--- a/microk8s-resources/actions/enable.cilium.sh
+++ b/microk8s-resources/actions/enable.cilium.sh
@@ -17,20 +17,9 @@ echo "Restarting kube-apiserver"
 refresh_opt_in_config "allow-privileged" "true" kube-apiserver
 run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-apiserver"
 
-# Reconfigure kubelet/containerd to pick up the new CNI config and binary.
-echo "Restarting kubelet"
-refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
-run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-kubelet"
-
 set_service_not_expected_to_start flanneld
 run_with_sudo preserve_env snapctl stop "${SNAP_NAME}.daemon-flanneld"
 remove_vxlan_interfaces
-
-if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
-  echo "Restarting containerd"
-  run_with_sudo "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-containerd"
-fi
 
 echo "Enabling Cilium"
 

--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -62,7 +62,7 @@ oom_score = 0
   # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
   [plugins."io.containerd.grpc.v1.cri".cni]
     # bin_dir is the directory in which the binaries for the plugin is kept.
-    bin_dir = "${SNAP}/opt/cni/bin"
+    bin_dir = "${SNAP_DATA}/opt/cni/bin"
 
     # conf_dir is the directory in which the admin places a CNI conf.
     conf_dir = "${SNAP_DATA}/args/cni-network"

--- a/microk8s-resources/default-args/kubelet
+++ b/microk8s-resources/default-args/kubelet
@@ -6,7 +6,7 @@
 --root-dir=${SNAP_COMMON}/var/lib/kubelet
 --fail-swap-on=false
 --cni-conf-dir=${SNAP_DATA}/args/cni-network/
---cni-bin-dir=${SNAP}/opt/cni/bin/
+--cni-bin-dir=${SNAP_DATA}/opt/cni/bin/
 --feature-gates=DevicePlugins=true
 --eviction-hard="memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi"
 --container-runtime=remote

--- a/microk8s-resources/wrappers/run-flanneld-with-args
+++ b/microk8s-resources/wrappers/run-flanneld-with-args
@@ -45,4 +45,4 @@ fi
 
 # This is really the only way I could find to get the args passed in correctly. WTF
 declare -a args="($(cat $SNAP_DATA/args/flanneld))"
-exec "$SNAP/opt/cni/bin/flanneld" "${args[@]}"
+exec "$SNAP_DATA/opt/cni/bin/flanneld" "${args[@]}"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -296,6 +296,22 @@ then
   chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ || true
 fi
 
+if ! [ -L "${SNAP_DATA}/opt/cni/bin/flanneld" ]
+then
+  # cover situation where cilium was installed prior to this update
+  if [ -f "${SNAP_DATA}/opt/cni/bin/loopback" ] && [ -f "${SNAP}/opt/cni/bin/loopback" ]; then
+    rm -f "${SNAP_DATA}/opt/cni/bin/loopback"
+  fi
+  # as only one cni bin dir can be used we will use the one in SNAP_DATA but have links to
+  # the real CNI plugins we distribute in SNAP
+  mkdir -p "${SNAP_DATA}/opt/cni/bin/"
+  (
+    cd "${SNAP}/opt/cni/bin/"
+    MY_SNAP_DIR=$(dirname "${SNAP}")
+    for i in *; do ln -s "${MY_SNAP_DIR}/current/opt/cni/bin/$i" "${SNAP_DATA}/opt/cni/bin/${i}"; done
+  )
+fi
+
 if ! [ -f "${SNAP_DATA}/args/flanneld" ]
 then
   mkdir -p ${SNAP_DATA}/args/cni-network/

--- a/upgrade-scripts/000-switch-to-calico/commit-master.sh
+++ b/upgrade-scripts/000-switch-to-calico/commit-master.sh
@@ -23,12 +23,6 @@ cp "$SNAP_DATA"/args/kube-apiserver "$BACKUP_DIR/args"
 refresh_opt_in_config "allow-privileged" "true" kube-apiserver
 snapctl restart ${SNAP_NAME}.daemon-apiserver
 
-# Reconfigure kubelet/containerd to pick up the new CNI config and binary.
-cp "$SNAP_DATA"/args/kubelet "$BACKUP_DIR/args"
-echo "Restarting kubelet"
-refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
-snapctl restart ${SNAP_NAME}.daemon-kubelet
-
 cp "$SNAP_DATA"/args/kube-proxy "$BACKUP_DIR/args"
 echo "Restarting kube proxy"
 refresh_opt_in_config "cluster-cidr" "10.1.0.0/16" kube-proxy
@@ -37,13 +31,6 @@ snapctl restart ${SNAP_NAME}.daemon-proxy
 set_service_not_expected_to_start flanneld
 snapctl stop ${SNAP_NAME}.daemon-flanneld
 remove_vxlan_interfaces
-
-cp "$SNAP_DATA"/args/containerd-template.toml "$BACKUP_DIR/args"
-if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
-  echo "Restarting containerd"
-  "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  snapctl restart ${SNAP_NAME}.daemon-containerd
-fi
 
 # Allow for services to restart
 sleep 15

--- a/upgrade-scripts/000-switch-to-calico/commit-node.sh
+++ b/upgrade-scripts/000-switch-to-calico/commit-node.sh
@@ -16,17 +16,9 @@ mkdir -p "$BACKUP_DIR/args/cni-network/"
 cp "$SNAP_DATA"/args/cni-network/* "$BACKUP_DIR/args/cni-network/" 2>/dev/null || true
 rm "$SNAP_DATA"/args/cni-network/*
 run_with_sudo cp "$RESOURCES/calico.yaml" "$SNAP_DATA/args/cni-network/cni.yaml"
-mkdir -p "$SNAP_DATA/opt/cni/bin/"
-cp -R "$SNAP"/opt/cni/bin/* "$SNAP_DATA"/opt/cni/bin/
 
 cp "$SNAP_DATA"/args/kube-apiserver "$BACKUP_DIR/args"
 refresh_opt_in_config "allow-privileged" "true" kube-apiserver
-
-# Reconfigure kubelet/containerd to pick up the new CNI config and binary.
-cp "$SNAP_DATA"/args/kubelet "$BACKUP_DIR/args"
-echo "Restarting kubelet"
-refresh_opt_in_config "cni-bin-dir" "\${SNAP_DATA}/opt/cni/bin/" kubelet
-snapctl restart ${SNAP_NAME}.daemon-kubelet
 
 cp "$SNAP_DATA"/args/kube-proxy "$BACKUP_DIR/args"
 echo "Restarting kube proxy"
@@ -36,12 +28,5 @@ snapctl restart ${SNAP_NAME}.daemon-proxy
 set_service_not_expected_to_start flanneld
 snapctl stop ${SNAP_NAME}.daemon-flanneld
 remove_vxlan_interfaces
-
-cp "$SNAP_DATA"/args/containerd-template.toml "$BACKUP_DIR/args"
-if grep -qE "bin_dir.*SNAP}\/" $SNAP_DATA/args/containerd-template.toml; then
-  echo "Restarting containerd"
-  "${SNAP}/bin/sed" -i 's;bin_dir = "${SNAP}/opt;bin_dir = "${SNAP_DATA}/opt;g' "$SNAP_DATA/args/containerd-template.toml"
-  snapctl restart ${SNAP_NAME}.daemon-containerd
-fi
 
 echo "Calico is enabled"


### PR DESCRIPTION
This PR changes the default location of the CNI bin directory from "${SNAP}/opt/cni/bin" which is read-only to "${SNAP_DATA}/opt/cni/bin" which is writable.  This simplifies the installation of any add-ons or additions that need to add or manipulate CNI such as cilium, calico, or potentially multus.  Currently when any of those are enabled or disabled they need to switch the CNI bin directory and then switch it back which creates complications as well cross compatibility concerns (two are enabled, then one is disabled breaking the other).