### PR TITLE
Rebase and add port management for dqlite-cluster agent

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -505,7 +505,9 @@ function valid_ip() {
 init_cluster() {
   mkdir -p ${SNAP_DATA}/var/kubernetes/backend
   IP="127.0.0.1"
-  # TODO: make the port configurable
+  # To configure dqlite do:
+  # echo "Address: 1.2.3.4:6364" > $STORAGE_DIR/update.yaml
+  # after the initialisation but before connecting other nodes
   echo "Address: $IP:19001" > ${SNAP_DATA}/var/kubernetes/backend/init.yaml
   DNS=$($SNAP/bin/hostname)
   mkdir -p $SNAP_DATA/var/tmp/

--- a/microk8s-resources/actions/enable.ingress.sh
+++ b/microk8s-resources/actions/enable.ingress.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 source $SNAP/actions/common/utils.sh
 
@@ -22,7 +22,7 @@ fi
 echo "Enabling Ingress"
 
 ARCH=$(arch)
-TAG="0.25.1"
+TAG="0.33.0"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 DEFAULT_CERT="- ' '"
 

--- a/microk8s-resources/actions/enable.kubeflow.sh
+++ b/microk8s-resources/actions/enable.kubeflow.sh
@@ -9,10 +9,16 @@ import sys
 import tempfile
 import textwrap
 import time
-from itertools import count
 from distutils.util import strtobool
+from itertools import count
+from urllib.error import URLError
+from urllib.request import urlopen
+from urllib.parse import urlparse
 
 MIN_MEM_GB = 14
+CONNECTIVITY_CHECKS = [
+    'https://api.jujucharms.com/charmstore/v5/~kubeflow-charmers/ambassador-88/icon.svg',
+]
 
 
 def run(*args, die=True, debug=False, stdout=True):
@@ -122,6 +128,20 @@ def main():
             " if you'd like to proceed anyways."
         )
         sys.exit(1)
+
+    for url in CONNECTIVITY_CHECKS:
+        try:
+            response = urlopen(url)
+        except URLError:
+            host = urlparse(url).netloc
+            print("Couldn't contact %s" % host)
+            print("Please check your network connectivity before enabling Kubeflow.")
+            sys.exit(1)
+
+        if response.status != 200:
+            print("URL connectivity check failed with response %s" % response.status)
+            print("Please check your network connectivity before enabling Kubeflow.")
+            sys.exit(1)
 
     password_overlay = {
         "applications": {

--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -156,7 +156,7 @@ spec:
       hostNetwork: true
       serviceAccountName: nginx-ingress-microk8s-serviceaccount
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller-$ARCH:$TAG
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:$TAG
         name: nginx-ingress-microk8s
         livenessProbe:
           httpGet:

--- a/scripts/cluster/common/utils.py
+++ b/scripts/cluster/common/utils.py
@@ -3,6 +3,7 @@ import shutil
 import time
 import string
 import random
+import yaml
 
 
 def try_set_file_permissions(file):
@@ -105,3 +106,43 @@ def is_node_running_dqlite():
     """
     ha_lock = os.path.expandvars("${SNAP_DATA}/var/lock/ha-cluster")
     return os.path.isfile(ha_lock)
+
+
+def get_dqlite_port():
+    """
+    What is the port dqlite listens on
+
+    :return: the dqlite port
+    """
+    # We get the dqlite port from the already existing deployment
+    snapdata_path = os.environ.get('SNAP_DATA')
+    cluster_dir = "{}/var/kubernetes/backend".format(snapdata_path)
+    dqlite_info = "{}/info.yaml".format(cluster_dir)
+    port = 19001
+    if os.path.exists(dqlite_info):
+        with open(dqlite_info) as f:
+            data = yaml.load(f, Loader=yaml.FullLoader)
+        if 'Address' in data:
+            port = data['Address'].split(':')[1]
+
+    return port
+
+
+def get_cluster_agent_port():
+    """
+    What is the cluster agent port
+
+    :return: the port
+    """
+    cluster_agent_port = "25000"
+    snapdata_path = os.environ.get('SNAP_DATA')
+    filename = "{}/args/cluster-agent".format(snapdata_path)
+    with open(filename) as fp:
+        for _, line in enumerate(fp):
+            if line.startswith("--bind"):
+                port_parse = line.split(' ')
+                port_parse = port_parse[-1].split('=')
+                port_parse = port_parse[-1].split(':')
+                if len(port_parse) > 1:
+                    cluster_agent_port = port_parse[1].rstrip()
+    return cluster_agent_port

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -375,6 +375,11 @@ then
     snapctl restart ${SNAP_NAME}.daemon-containerd
 fi
 
+if [ ! -f ${SNAP_DATA}/args/cluster-agent ]
+then
+   cp ${SNAP}/default-args/cluster-agent ${SNAP_DATA}/args/cluster-agent
+fi
+
 if ! grep -e "\-\-timeout" ${SNAP_DATA}/args/cluster-agent
 then
   refresh_opt_in_config timeout 240 cluster-agent

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -437,7 +437,7 @@ parts:
   # b) the version dependencies of each package is met.
   nvidia-runtime:
     plugin: dump
-    source: https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64/nvidia-container-runtime_2.0.0+docker18.06.1-1_amd64.deb
+    source: https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64/nvidia-container-runtime_3.2.0-1_amd64.deb
     source-type: deb
     override-build: |
       set -eu
@@ -449,9 +449,9 @@ parts:
         echo "Skipped"
       fi
 
-  nvidia-runtime-hook:
+  nvidia-toolkit:
     plugin: dump
-    source: https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64/nvidia-container-runtime-hook_1.4.0-1_amd64.deb
+    source: https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64/nvidia-container-toolkit_1.1.2-1_amd64.deb
     source-type: deb
     override-build: |
       set -eu
@@ -465,7 +465,7 @@ parts:
 
   libnvidia:
     plugin: dump
-    source: https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64/libnvidia-container1_1.0.0-1_amd64.deb
+    source: https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64/libnvidia-container1_1.1.1-1_amd64.deb
     source-type: deb
     override-build: |
       set -eu
@@ -479,7 +479,7 @@ parts:
 
   libnvidia-tools:
     plugin: dump
-    source: https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64/libnvidia-container-tools_1.0.0-1_amd64.deb
+    source: https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64/libnvidia-container-tools_1.1.1-1_amd64.deb
     source-type: deb
     override-build: |
       set -eu


### PR DESCRIPTION
Configuration should be done at the beginning, when you have one node.

The cluster agent port should be the same across all nodes because there is no single configuration point.   