### PR TITLE
Support for Ambassador API Gateway and Ingress Controller

### DIFF
--- a/installer/common/definitions.py
+++ b/installer/common/definitions.py
@@ -1,6 +1,7 @@
 MAX_CHARACTERS_WRAP: int = 120
 command_descriptions = {
     'add-node': "Adds a node to a cluster",
+    'ambassador': "Ambassador API Gateway and Ingress",
     'cilium': "The cilium client",
     'config': "Print the kubeconfig",
     'ctr': "The containerd client",

--- a/microk8s-resources/actions/disable.ambassador.sh
+++ b/microk8s-resources/actions/disable.ambassador.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+NAMESPACE_AMB="ambassador"
+
+MANIFEST_VER="latest"
+
+MANIFEST_CRD="https://github.com/datawire/ambassador-operator/releases/$MANIFEST_VER/download/ambassador-operator-crds.yaml"
+
+MANIFEST_AMB="https://github.com/datawire/ambassador-operator/releases/$MANIFEST_VER/download/ambassador-operator-microk8s.yaml"
+
+KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+
+KUBECTL_DELETE_ARGS="--wait=true --timeout=180s --ignore-not-found=true"
+
+echo "Disabling Ambassador"
+
+# remove the AmbassadorInstallation, so the Ambassador Operator will remove Ambassador
+# we should wait until Ambassador is fully uninstalled before moving forward
+$KUBECTL delete $KUBECTL_DELETE_ARGS -n $NAMESPACE_AMB ambassadorinstallation ambassador
+
+# give some time to the operator for finishing the uninstallation
+sleep 5
+
+# unload the the manifests
+$KUBECTL delete $KUBECTL_DELETE_ARGS -n $NAMESPACE_AMB -f "$MANIFEST_AMB" > /dev/null 2>&1
+$KUBECTL delete $KUBECTL_DELETE_ARGS -n $NAMESPACE_AMB -f "$MANIFEST_CRD" > /dev/null 2>&1
+
+# delete the "ambassador" namespace
+$KUBECTL delete $KUBECTL_DELETE_ARGS namespace "$NAMESPACE_AMB" > /dev/null 2>&1 || true
+
+echo "Ambassador is disabled"

--- a/microk8s-resources/actions/enable.ambassador.sh
+++ b/microk8s-resources/actions/enable.ambassador.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+NAMESPACE_AMB="ambassador"
+
+MANIFEST_VER="latest"
+
+MANIFEST_CRD="https://github.com/datawire/ambassador-operator/releases/$MANIFEST_VER/download/ambassador-operator-crds.yaml"
+
+MANIFEST_AMB="https://github.com/datawire/ambassador-operator/releases/$MANIFEST_VER/download/ambassador-operator-microk8s.yaml"
+
+KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+
+
+echo "Enabling Ambassador"
+
+# make sure nginx ingress is not enabled
+"$SNAP/microk8s-disable.wrapper" ingress > /dev/null 2>&1 || true
+
+# the operator will start failing without dns
+"$SNAP/microk8s-enable.wrapper" dns
+
+# make sure the "ambassador" namespace exists
+$KUBECTL create namespace "$NAMESPACE_AMB" > /dev/null 2>&1 || true
+
+# load the CRD and wait for it to be installed
+$KUBECTL apply -f "$MANIFEST_CRD"
+
+# wait for the CRD to be ready (otherwise we cannot load the AmbassadorInstallation)
+$KUBECTL wait --for condition=established --timeout=60s crd ambassadorinstallations.getambassador.io
+
+# load the rest of the manifests, and wait for them to be ready
+$KUBECTL apply -n "$NAMESPACE_AMB" -f "$MANIFEST_AMB"
+
+# print a final help message
+echo "Ambassador has been installed"
+echo ""
+echo "Ingresses annotated with 'kubernetes.io/ingress.class=ambassador' will be managed by Ambassador."

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -32,7 +32,7 @@ microk8s-addons:
       supported_architectures:
       - arm64
       - amd64
-    
+
     - name: "storage"
       description: "Storage class; allocates storage from host directory"
       version: "1.0.0"
@@ -40,7 +40,7 @@ microk8s-addons:
       supported_architectures:
       - arm64
       - amd64
-        
+
     - name: "registry"
       description: "Private image registry exposed on localhost:32000"
       version: "2.6"
@@ -159,3 +159,10 @@ microk8s-addons:
       supported_architectures:
       - amd64
       - arm64
+
+    - name: "ambassador"
+      description: "Ambassador API Gateway and Ingress"
+      version: ""
+      check_status: "deployment.apps/ambassador-operator"
+      supported_architectures:
+      - amd64

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -6,6 +6,7 @@ from validators import (
     validate_dns_dashboard,
     validate_storage,
     validate_ingress,
+    validate_ambassador,
     validate_gpu,
     validate_istio,
     validate_knative,
@@ -79,6 +80,22 @@ class TestAddons(object):
         print("Disabling DNS")
         microk8s_disable("dns")
         '''
+
+    @pytest.mark.skipif(
+        platform.machine() != 'x86_64',
+        reason="Ambassador tests are only relevant in x86 architectures",
+    )
+    def test_ambassador(self):
+        """
+        Test Ambassador.
+
+        """
+        print("Enabling Ambassador")
+        microk8s_enable("ambassador")
+        print("Validating ambassador")
+        validate_ambassador()
+        print("Disabling Ambassador")
+        microk8s_disable("ambassador")
 
     @pytest.mark.skipif(
         os.environ.get('UNDER_TIME_PRESSURE') == 'True',

--- a/tests/test-live-addons.py
+++ b/tests/test-live-addons.py
@@ -2,6 +2,7 @@ from validators import (
     validate_dns_dashboard,
     validate_storage,
     validate_ingress,
+    validate_ambassador,
     validate_istio,
     validate_knative,
     validate_registry,
@@ -45,6 +46,13 @@ class TestLiveAddons(object):
 
         """
         validate_ingress()
+
+    def test_ambassador(self):
+        """
+        Validates Ambassador works.
+
+        """
+        validate_ambassador()
 
     def test_istio(self):
         """

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -7,6 +7,7 @@ from validators import (
     validate_dns_dashboard,
     validate_storage,
     validate_ingress,
+    validate_ambassador,
     validate_gpu,
     validate_registry,
     validate_forward,
@@ -193,7 +194,7 @@ class TestUpgrade(object):
 
             # The kubeflow deployment is huge. It will not fit comfortably
             # with the rest of the addons on the same machine during an upgrade
-            # we will need to find another way to test it. 
+            # we will need to find another way to test it.
             try:
                 enable = microk8s_enable("kubeflow", timeout_insec=30)
                 assert "Nothing to do for" not in enable


### PR DESCRIPTION
This PR adds support for installing [Ambassador](https://getambassador.io/), an API Gateway and Ingress Controller, in microk8s.

Ambassador is installed via the Ambassador Operator which is the recommended way of installing Ambassador - it makes sure users always have the latest version of Ambassador installed and takes care of the update schedule as well.
