### PR TITLE
Test the refresh path from an old track (1.14) all the way to now

### DIFF
--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -1,6 +1,8 @@
+import pytest
 import os
 import platform
 import time
+import requests
 from validators import (
     validate_dns_dashboard,
     validate_storage,
@@ -16,7 +18,12 @@ from validators import (
     validate_cilium,
 )
 from subprocess import check_call, CalledProcessError, check_output
-from utils import microk8s_enable, wait_for_pod_state, wait_for_installation, run_until_success
+from utils import (
+    microk8s_enable,
+    wait_for_pod_state,
+    wait_for_installation,
+    run_until_success,
+)
 
 upgrade_from = os.environ.get('UPGRADE_MICROK8S_FROM', 'beta')
 # Have UPGRADE_MICROK8S_TO point to a file to upgrade to that file
@@ -28,6 +35,70 @@ class TestUpgrade(object):
     """
     Validates a microk8s upgrade path
     """
+
+    @pytest.mark.skipif(
+        os.environ.get('UNDER_TIME_PRESSURE') == 'True',
+        reason="Skipping refresh path tast as we are under time pressure",
+    )
+    def test_refresh_path(self):
+        """
+        Deploy an old snap and try to refresh until the current one.
+
+        """
+        start_channel = 14
+
+        last_stable_minor = None
+        if upgrade_from.startswith('latest') or '/' not in upgrade_from:
+            attempt = 0
+            release_url = "https://dl.k8s.io/release/stable.txt"
+            while attempt < 10 and not last_stable_minor:
+                r = requests.get(release_url)
+                if r.status_code == 200:
+                    last_stable_str = r.content.decode().strip()
+                    # We have "v1.18.4" and we need the "18"
+                    last_stable_parts = last_stable_str.split('.')
+                    last_stable_minor = int(last_stable_parts[1])
+                else:
+                    time.sleep(3)
+                    attempt += 1
+        else:
+            channel_parts = upgrade_from.split('.')
+            channel_parts = channel_parts[1].split('/')
+            print(channel_parts)
+            last_stable_minor = int(channel_parts[0])
+
+        print("")
+        print(
+            "Testing refresh path from 1.{} to 1.{} and finally refresh to {}".format(
+                start_channel, last_stable_minor, upgrade_to
+            )
+        )
+        assert last_stable_minor is not None
+
+        channel = "1.{}/stable".format(start_channel)
+        print("Installing {}".format(channel))
+        cmd = "sudo snap install microk8s --classic --channel={}".format(channel)
+        run_until_success(cmd)
+        wait_for_installation()
+        channel_minor = start_channel
+        channel_minor += 1
+        while channel_minor <= last_stable_minor:
+            channel = "1.{}/stable".format(channel_minor)
+            print("Refreshing to {}".format(channel))
+            cmd = "sudo snap refresh microk8s --classic --channel={}".format(channel)
+            run_until_success(cmd)
+            wait_for_installation()
+            channel_minor += 1
+
+        print("Installing {}".format(upgrade_to))
+        if upgrade_to.endswith('.snap'):
+            cmd = "sudo snap install {} --classic --dangerous".format(upgrade_to)
+        else:
+            cmd = "sudo snap refresh microk8s --channel={}".format(upgrade_to)
+        run_until_success(cmd)
+        # Allow for the refresh to be processed
+        time.sleep(10)
+        wait_for_installation()
 
     def test_upgrade(self):
         """


### PR DESCRIPTION
This will guard against issues like https://github.com/ubuntu/microk8s/issues/1293 . We start from an old release and refresh until the latest snap. The configure hook on all releases in exercised during this test.
