### PR TITLE
Start dqlite and calico by default

### DIFF
--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -75,4 +75,4 @@ oom_score = 0
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
         endpoint = ["https://registry-1.docker.io", ]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:32000"]
-        endpoint = ["http://localhost:32000"]        
+        endpoint = ["http://localhost:32000"]

--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -9,11 +9,10 @@
 --kubelet-client-key=${SNAP_DATA}/certs/server.key
 --secure-port=16443
 --token-auth-file=${SNAP_DATA}/credentials/known_tokens.csv
---etcd-servers='https://127.0.0.1:12379'
---etcd-cafile=${SNAP_DATA}/certs/ca.crt
---etcd-certfile=${SNAP_DATA}/certs/server.crt
---etcd-keyfile=${SNAP_DATA}/certs/server.key
 --insecure-port=0
+--storage-backend=dqlite
+--storage-dir=${SNAP_DATA}/var/kubernetes/backend/
+--allow-privileged=true
 
 # Enable the aggregation layer
 --requestheader-client-ca-file=${SNAP_DATA}/certs/front-proxy-ca.crt

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -296,7 +296,7 @@ then
   chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ || true
 fi
 
-if ! [ -L "${SNAP_DATA}/opt/cni/bin/flanneld" ]
+if ! [ -e "${SNAP_DATA}/opt/cni/bin/flanneld" ]
 then
   # cover situation where cilium was installed prior to this update
   if [ -f "${SNAP_DATA}/opt/cni/bin/loopback" ] && [ -f "${SNAP}/opt/cni/bin/loopback" ]; then
@@ -422,3 +422,23 @@ then
   refresh_opt_in_config cluster-cidr 10.1.0.0/16 kube-proxy
   snapctl restart ${SNAP_NAME}.daemon-proxy
 fi
+
+if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ]
+then
+  echo "Setting up the CNI"
+  start_timer="$(date +%s)"
+  # Wait up to two minutes for the apiserver to come up.
+  # TODO: this polling is not good enough. We should find a new way to ensure the apiserver is up.
+  timeout="120"
+  KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+  while ! ($KUBECTL get all --all-namespaces | grep -z "service/kubernetes") &> /dev/null
+  do
+    sleep 5
+    now="$(date +%s)"
+    if [[ "$now" > "$(($start_timer + $timeout))" ]] ; then
+      break
+    fi
+  done
+  $KUBECTL apply -f "${SNAP_DATA}/args/cni-network/cni.yaml"
+fi
+

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -89,3 +89,20 @@ done
 
 init_cluster
 
+mkdir -p "${SNAP_DATA}/var/lock"
+set_service_not_expected_to_start etcd
+set_service_not_expected_to_start flanneld
+
+touch "${SNAP_DATA}/var/lock/ha-cluster"
+
+RESOURCES="$SNAP/upgrade-scripts/000-switch-to-calico/resources"
+BACKUP_DIR="$SNAP_DATA/var/tmp/upgrades/000-switch-to-calico"
+
+mkdir -p "$BACKUP_DIR"
+
+mkdir -p "$BACKUP_DIR/args/cni-network/"
+cp "$SNAP_DATA"/args/cni-network/* "$BACKUP_DIR/args/cni-network/" 2>/dev/null || true
+rm -rf "$SNAP_DATA"/args/cni-network/*
+cp "$RESOURCES/calico.yaml" "$SNAP_DATA/args/cni-network/cni.yaml"
+mkdir -p "$SNAP_DATA/opt/cni/bin/"
+cp -R "$SNAP"/opt/cni/bin/* "$SNAP_DATA"/opt/cni/bin/

--- a/upgrade-scripts/002-switch-to-flannel-etcd/commit-master.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/commit-master.sh
@@ -21,12 +21,14 @@ echo "Configuring services"
 ${SNAP}/microk8s-stop.wrapper
 
 cp "$SNAP_DATA"/args/kube-apiserver "$BACKUP_DIR/args"
-skip_opt_in_config "storage-backend" kube-apiserver
-skip_opt_in_config "storage-dir" kube-apiserver
-refresh_opt_in_config "etcd-servers" 'https://127.0.0.1:12379' kube-apiserver
-refresh_opt_in_config "etcd-cafile" "\${SNAP_DATA}/certs/ca.crt" kube-apiserver
-refresh_opt_in_config "etcd-certfile" "\${SNAP_DATA}/certs/server.crt" kube-apiserver
-refresh_opt_in_config "etcd-keyfile" "\${SNAP_DATA}/certs/server.key" kube-apiserver
+
+"${SNAP}/bin/sed" -i '/--storage-backend/d' "$SNAP_DATA/args/kube-apiserver"
+"${SNAP}/bin/sed" -i '/--storage-dir/d' "$SNAP_DATA/args/kube-apiserver"
+
+echo "--etcd-servers=https://127.0.0.1:12379" >> "$SNAP_DATA/args/kube-apiserver"
+echo "--etcd-cafile=\${SNAP_DATA}/certs/ca.crt" >> "$SNAP_DATA/args/kube-apiserver"
+echo "--etcd-certfile=\${SNAP_DATA}/certs/server.crt" >> "$SNAP_DATA/args/kube-apiserver"
+echo "--etcd-keyfile=\${SNAP_DATA}/certs/server.key" >> "$SNAP_DATA/args/kube-apiserver"
 
 cp "$SNAP_DATA"/args/etcd "$BACKUP_DIR/args"
 rm -rf ${SNAP_COMMON}/var/run/etcd/*


### PR DESCRIPTION
Start microk8s with calico and dqlite without the need to `microk8s enable ha-cluster`.

`microk8s disable ha-cluster` will get you back to etcd+flannel