### PR TITLE
Remove the ha-cluster subcommand from status

### DIFF
--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -42,7 +42,7 @@ def print_short(isReady, enabled_addons, disabled_addons):
 
 
 def print_pretty(isReady, enabled_addons, disabled_addons):
-    console_formatter = "{:>1} {:<20} # {}"
+    console_formatter = "{:>3} {:<20} # {}"
     if isReady:
         print("microk8s is running")
         if not is_ha_enabled():
@@ -73,12 +73,11 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
 
         print("addons:")
         if enabled_addons and len(enabled_addons) > 0:
-            print('{:>2}'.format("enabled:"))
+            print('{:>4}'.format("enabled:"))
             for enabled in enabled_addons:
                 print(console_formatter.format("", enabled["name"], enabled["description"]))
-            print("")
         if disabled_addons and len(disabled_addons) > 0:
-            print('{:>2}'.format("disabled:"))
+            print('{:>4}'.format("disabled:"))
             for disabled in disabled_addons:
                 print(console_formatter.format("", disabled["name"], disabled["description"]))
     else:
@@ -110,13 +109,11 @@ def print_yaml(isReady, enabled_addons, disabled_addons):
     print("microk8s:")
     print("{:>2}{} {}".format("", "running:", isReady))
 
-    print("{:>2}".format("ha:"))
+    print("{:>2}".format("high-availability:"))
     ha_enabled = is_ha_enabled()
     print("{:>2}{} {}".format("", "enabled:", ha_enabled))
     if ha_enabled:
         info = get_dqlite_info()
-        ha_formed = ha_cluster_formed(info)
-        print("{:>2}{} {}".format("", "completed:", ha_formed))
         print("{:>2}{}".format("", "nodes:"))
         for node in info:
             print("{:>6}address: {:<1}".format("- ", node[0]))

--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -73,11 +73,11 @@ def print_pretty(isReady, enabled_addons, disabled_addons):
 
         print("addons:")
         if enabled_addons and len(enabled_addons) > 0:
-            print('{:>4}'.format("enabled:"))
+            print('{:>2}{}'.format("", "enabled:"))
             for enabled in enabled_addons:
                 print(console_formatter.format("", enabled["name"], enabled["description"]))
         if disabled_addons and len(disabled_addons) > 0:
-            print('{:>4}'.format("disabled:"))
+            print('{:>2}{}'.format("", "disabled:"))
             for disabled in disabled_addons:
                 print(console_formatter.format("", disabled["name"], disabled["description"]))
     else:


### PR DESCRIPTION
This PR updates the microk8s.status command in the following way:

The `--format short` does not change, is the old default output. It is short, so it does not need to report HA status, plus it can be used for backwards compatibility
```
ubuntu@ip-172-31-24-191:~$ sudo microk8s.status --format short | head -n 20
microk8s is running
addons:
ha-cluster: enabled
cilium: disabled
dashboard: disabled
dns: disabled
fluentd: disabled
gpu: disabled
helm: disabled
helm3: disabled
host-access: disabled
ingress: disabled
istio: disabled
jaeger: disabled
knative: disabled
kubeflow: disabled
linkerd: disabled
metallb: disabled
metrics-server: disabled
multus: disabled
```

The new default output is the same as `--format pretty`:
```
ubuntu@ip-172-31-24-191:~$ sudo microk8s.status
microk8s is running
high-availability: no
  datastore master nodes: 127.0.0.1:19001
  datastore standby nodes: none
addons:
enabled:
  ha-cluster           # Configure high availability on the current node

disabled:
  cilium               # SDN, fast with full network policy
  dashboard            # The Kubernetes dashboard
  dns                  # CoreDNS
  fluentd              # Elasticsearch-Fluentd-Kibana logging and monitoring
  gpu                  # Automatic enablement of Nvidia CUDA
  helm                 # Helm 2 - the package manager for Kubernetes
  helm3                # Helm 3 - Kubernetes package manager
  host-access          # Allow Pods connecting to Host services smoothly
  ingress              # Ingress controller for external access
  istio                # Core Istio service mesh services
  jaeger               # Kubernetes Jaeger operator with its simple config
  knative              # The Knative framework on Kubernetes.
  kubeflow             # Kubeflow for easy ML deployments
  linkerd              # Linkerd is a service mesh for Kubernetes and other frameworks
  metallb              # Loadbalancer for your Kubernetes cluster
  metrics-server       # K8s Metrics Server for API access to service metrics
  multus               # Multus CNI enables attaching multiple network interfaces to pods
  prometheus           # Prometheus operator for monitoring and logging
  rbac                 # Role-Based Access Control for authorisation
  registry             # Private image registry exposed on localhost:32000
  storage              # Storage class; allocates storage from host directory
```

The `--format yaml` reports the HA as well. 
```
ubuntu@ip-172-31-24-191:~$ sudo microk8s.status --format yaml | head -n 20
microk8s:
  running: True
ha:
  enabled: True
  completed: False
  nodes:
    - address: 127.0.0.1:19001
      role: voter
addons:
  - name: ha-cluster
    description: Configure high availability on the current node
    version: 0.1.0
    status: enabled
  - name: cilium
    description: SDN, fast with full network policy
    version: 1.6
    status: disabled
  - name: dashboard
    description: The Kubernetes dashboard
    version: 2.0.0
```


The HA section looks like this:
```
high-availability: no
  datastore master nodes: 127.0.0.1:19001
  datastore standby nodes: none
```

- high-availability: yes|no
- datastore master nodes: the voter nodes
  datastore standby nodes: the non-voters but replicating the database nodes

On the yaml we report:
-  enabled: True|False, if ha is enabled or not
-  completed: False|True, if more than three voters are present ha is complete


Here is an example where HA is formed:
```
ha:
  enabled: True
  completed: True
  nodes:
    - address: 172.31.24.191:19001
      role: voter
    - address: 172.31.25.112:19001
      role: voter
    - address: 172.31.30.18:19001
      role: voter
```

```
high-availability: yes
  datastore master nodes: 172.31.24.191:19001 172.31.25.112:19001 172.31.30.18:19001
  datastore standby nodes: none
```
