### PR TITLE
Test on GH

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -34,3 +34,26 @@ jobs:
       with:
         name: microk8s.snap
         path: microk8s.snap
+    - name: Running upgrade path test
+      run: |
+        set -x
+        sudo pip3 install --upgrade pip
+        sudo pip3 install -U pytest
+        sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade.py::TestUpgrade::test_refresh_path
+        sudo snap remove microk8s
+    - name: Running addons tests
+      run: |
+        set -x
+        sudo snap install *.snap --classic --dangerous
+        ./tests/smoke-test.sh
+        export UNDER_TIME_PRESSURE="True"
+        (cd tests; pytest -s verify-branches.py)
+        (cd tests; sudo -E pytest -s -ra test-addons.py)
+        sudo microk8s reset
+        sudo snap remove microk8s
+    - name: Running upgrade tests
+      run: |
+        set -x
+        export UNDER_TIME_PRESSURE="True"
+        sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade.py
+


### PR DESCRIPTION
Tests are running on GH with this PR.

We also run the refresh path test where we start from 1.14 and upgrade all the way to the snap just built.