### PR TITLE
Fix path to openssl

### DIFF
--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -136,7 +136,7 @@ def get_etcd_client_cert(master_ip, master_port, token):
     cer_req_file = "{}/certs/server.remote.csr".format(snapdata_path)
     cmd_cert = (
         "{snap}/usr/bin/openssl req -new -sha256 -key {snapdata}/certs/server.key -out {csr} "
-        "-config {SNAP_DATA}/certs/csr.conf".format(
+        "-config {snapdata}/certs/csr.conf".format(
             snap=snap_path, snapdata=snapdata_path, csr=cer_req_file
         )
     )

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -135,8 +135,10 @@ def get_etcd_client_cert(master_ip, master_port, token):
     """
     cer_req_file = "{}/certs/server.remote.csr".format(snapdata_path)
     cmd_cert = (
-        "openssl req -new -sha256 -key {SNAP_DATA}/certs/server.key -out {csr} "
-        "-config {SNAP_DATA}/certs/csr.conf".format(SNAP_DATA=snapdata_path, csr=cer_req_file)
+        "{snp}/usr/bin/openssl req -new -sha256 -key {SNAP_DATA}/certs/server.key -out {csr} "
+        "-config {SNAP_DATA}/certs/csr.conf".format(
+            snp=snap_path, SNAP_DATA=snapdata_path, csr=cer_req_file
+        )
     )
     subprocess.check_call(cmd_cert.split())
     with open(cer_req_file) as fp:

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -135,9 +135,9 @@ def get_etcd_client_cert(master_ip, master_port, token):
     """
     cer_req_file = "{}/certs/server.remote.csr".format(snapdata_path)
     cmd_cert = (
-        "{snp}/usr/bin/openssl req -new -sha256 -key {SNAP_DATA}/certs/server.key -out {csr} "
+        "{snap}/usr/bin/openssl req -new -sha256 -key {snapdata}/certs/server.key -out {csr} "
         "-config {SNAP_DATA}/certs/csr.conf".format(
-            snp=snap_path, SNAP_DATA=snapdata_path, csr=cer_req_file
+            snap=snap_path, snapdata=snapdata_path, csr=cer_req_file
         )
     )
     subprocess.check_call(cmd_cert.split())


### PR DESCRIPTION
Running microk8s on certain distributions such as Centos 7.4, resulted
in failure to execute openssl. This happened because the path to
openssl was not being correctly set within the snap. As a result
either no openssl was found or the wrong one was selected leading
to linker relocation errors.

This commit fixes the issue by specifying the full path to openssl.

Fixes: https://github.com/ubuntu/microk8s/issues/1270