### PR TITLE
Do not test upgrades on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,3 @@ script:
   - (cd tests; sudo -E pytest -s -ra test-addons.py)
   - sudo microk8s reset
   - sudo snap remove microk8s
-  - sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade.py


### PR DESCRIPTION
We reduce the tests in Travis so we do not hit the respective test timeout.

Upgrades are tested in GH [1] so this PR does not have an imparct in test coverage.

[1] https://github.com/ubuntu/microk8s/blob/master/.github/workflows/build-snap.yml#L42