### PR TITLE
Added support for user CA cert and key

### DIFF
--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -80,38 +80,35 @@ function revert {
   $SNAP/microk8s-start.wrapper
 }
 
-function refresh_ca {
+function backup_ca_crt_and_key {
   echo "Backing up CA cert and key under $BACKUP"
-  run_with_sudo mkdir -p $SNAP_DATA/var/log/ca-backup/
-  if [ -e ${SNAP_DATA}/certs/ca.crt ]
+  run_with_sudo mkdir -p "${BACKUP}"
+
+  if [ -e "${SNAP_DATA}/certs/ca.crt" ]
   then
-      run_with_sudo cp ${SNAP_DATA}/certs/ca.crt $BACKUP
-  fi
-  if [ -e ${SNAP_DATA}/certs/ca.key ]
-  then
-      run_with_sudo cp ${SNAP_DATA}/certs/ca.key $BACKUP
+      run_with_sudo cp "${SNAP_DATA}/certs/ca.crt" "$BACKUP"
   fi
 
-  echo "Creating new CA certificate and key"
-  run_with_sudo rm -f ${SNAP_DATA}/certs/ca.crt
-  run_with_sudo rm -f ${SNAP_DATA}/certs/ca.key
-
-  if [ -e ${CAPATH}/ca.crt ]
+  if [ -e "${SNAP_DATA}/certs/ca.key" ]
   then
-      run_with_sudo cp ${CAPATH}/ca.crt ${SNAP_DATA}/certs/ca.crt
+      run_with_sudo cp "${SNAP_DATA}/certs/ca.key" "$BACKUP"
+  fi
+}
+
+function refresh_ca {
+  if [ -e "${CAPATH}/ca.crt" ] && [ -e "${CAPATH}/ca.key" ]
+  then
+      backup_ca_crt_and_key
+
+      echo "Removing old CA certificate and key"
+      run_with_sudo rm -f "${SNAP_DATA}/certs/ca.crt"
+      run_with_sudo rm -f "${SNAP_DATA}/certs/ca.key"
+
+      echo "Copying new CA certificate and key"
+      run_with_sudo cp "${CAPATH}/ca.crt" "${SNAP_DATA}/certs/ca.crt"
+      run_with_sudo cp "${CAPATH}/ca.key" "${SNAP_DATA}/certs/ca.key"
   else
-      echo "Could not find ca.crt in $CAPATH, aborting cert update"
-      run_with_sudo cp ${BACKUP}/ca.crt ${SNAP_DATA}/certs/ca.crt
-      exit 1
-  fi
-
-  if [ -e ${CAPATH}/ca.key ]
-  then
-      run_with_sudo cp ${CAPATH}/ca.key ${SNAP_DATA}/certs/ca.key
-  else
-      echo "Could not find ca.key in $CAPATH, aborting cert update"
-      run_with_sudo cp ${BACKUP}/ca.crt ${SNAP_DATA}/certs/ca.crt
-      run_with_sudo cp ${BACKUP}/ca.key ${SNAP_DATA}/certs/ca.key
+      echo "Could not find ca.crt and ca.key in $CAPATH, aborting CA certificate update"
       exit 1
   fi
 

--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -81,6 +81,7 @@ function revert {
 }
 
 function check_ca_crt_dates {
+    # parse date range in certificate
     IFS=$'\n'
     date_range=()
     for line in $(openssl x509 -noout -in ${CAPATH}/ca.crt -dates | sed -e 's/^.*=//')
@@ -89,17 +90,13 @@ function check_ca_crt_dates {
         date_range+=("${dt}")
     done
     unset IFS
+
+    # compare current date with date range in certificate
     date_now=$(date "+%s")
-    if [ ${date_range[0]} -gt ${date_now} ]
-    then
-        echo "Certificate is valid in the future so rejecting now"
-        exit 1
-    fi
-    if  [ ${date_now} -gt ${date_range[1]} ]
-    then
-        echo "Rejecting expired certificate"
-        exit 1
-    fi
+    test ${date_now} -gt ${date_range[0]}
+    exit_if "Certificate is valid in the future but not now"
+    test ${date_range[1]} -gt ${date_now}
+    exit_if "Certificate has expired"
 }
 
 function exit_if {

--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -80,6 +80,60 @@ function revert {
   $SNAP/microk8s-start.wrapper
 }
 
+function check_ca_crt_dates {
+    IFS=$'\n'
+    date_range=()
+    for line in $(openssl x509 -noout -in ${CAPATH}/ca.crt -dates | sed -e 's/^.*=//')
+    do
+        dt=$(date "+%s" -d "$line")
+        date_range+=("${dt}")
+    done
+    unset IFS
+    date_now=$(date "+%s")
+    if [ ${date_range[0]} -gt ${date_now} ]
+    then
+        echo "Certificate is valid in the future so rejecting now"
+        exit 1
+    fi
+    if  [ ${date_now} -gt ${date_range[1]} ]
+    then
+        echo "Rejecting expired certificate"
+        exit 1
+    fi
+}
+
+function exit_if {
+    if [ $? -ne 0 ]; then
+        echo "$1"
+        exit 1
+    fi;
+}
+
+function validate_ca_crt_and_key {
+    # Check CA private key
+    openssl rsa -in "${CAPATH}/ca.key" -check -noout -out /dev/null
+    exit_if "CA Private key is invalid"
+
+    # Check CA certificate
+    openssl x509 -in "${CAPATH}/ca.crt" -text -noout -out /dev/null
+    exit_if "CA certificate is invalid"
+
+    # Check that CA private key matches CA certificate
+    md5cert=$(openssl x509 -noout -modulus -in ${CAPATH}/ca.crt | openssl md5)
+    md5key=$(openssl rsa -noout -modulus -in ${CAPATH}/ca.key | openssl md5)
+    test "$md5cert" = "$md5key"
+    exit_if "CA Private Key does not match CA Certifiate"
+
+    # Verify that the public keys contained in the CA private key file and the CA certificate are the same
+    md5cert=$(openssl x509 -in "${CAPATH}/ca.crt" -noout -pubkey | openssl md5)
+    md5key=$(openssl rsa -in "${CAPATH}/ca.key" -pubout 2>&1 | grep -v 'writing RSA key' | openssl md5)
+    test "$md5cert" = "$md5key"
+    exit_if "CA Public key does not match CA Certifiate"
+
+    # Check certificate date is currently valid
+    check_ca_crt_dates
+}
+
 function backup_ca_crt_and_key {
   echo "Backing up CA cert and key under $BACKUP"
   run_with_sudo mkdir -p "${BACKUP}"
@@ -98,6 +152,10 @@ function backup_ca_crt_and_key {
 function refresh_ca {
   if [ -e "${CAPATH}/ca.crt" ] && [ -e "${CAPATH}/ca.key" ]
   then
+      # validate CA certificate and CA key
+      validate_ca_crt_and_key
+
+      # backup CA certificate and CA key
       backup_ca_crt_and_key
 
       echo "Removing old CA certificate and key"

--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -19,7 +19,7 @@ INSTALL=false
 UNDO=false
 CHECK=false
 REFRESH=false
-PARSED=$(getopt --options=iuhcr: --longoptions=install,undo,help,check,refresh: --name "$@" -- "$@")
+PARSED=$(getopt --options=iuhcr: --longoptions=install,undo,help,check,refresh: --name "refresh-certs" -- "$@")
 eval set -- "$PARSED"
 while true; do
   case "$1" in
@@ -108,11 +108,11 @@ function exit_if {
 
 function validate_ca_crt_and_key {
     # Check CA private key
-    openssl rsa -in "${CAPATH}/ca.key" -check -noout -out /dev/null
+    openssl rsa -in "${CAPATH}/ca.key" -check -noout -out /dev/null 2>/dev/null
     exit_if "CA Private key is invalid"
 
     # Check CA certificate
-    openssl x509 -in "${CAPATH}/ca.crt" -text -noout -out /dev/null
+    openssl x509 -in "${CAPATH}/ca.crt" -text -noout -out /dev/null > /dev/null
     exit_if "CA certificate is invalid"
 
     # Check that CA private key matches CA certificate
@@ -167,7 +167,9 @@ function refresh_ca {
       exit 1
   fi
 
+  echo "Generating auxilary certificates"
   gen_server_cert
+  echo "Restarting "
   update_configs
 }
 

--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -162,6 +162,8 @@ function refresh_ca {
       echo "Copying new CA certificate and key"
       run_with_sudo cp "${CAPATH}/ca.crt" "${SNAP_DATA}/certs/ca.crt"
       run_with_sudo cp "${CAPATH}/ca.key" "${SNAP_DATA}/certs/ca.key"
+      run_with_sudo chgrp microk8s "${SNAP_DATA}/certs/ca.crt"
+      run_with_sudo chgrp microk8s "${SNAP_DATA}/certs/ca.key"
   else
       echo "Could not find ca.crt and ca.key in $CAPATH, aborting CA certificate update"
       exit 1

--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -112,6 +112,7 @@ function refresh_ca {
       exit 1
   fi
 
+  gen_server_cert
   update_configs
 }
 

--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -18,7 +18,8 @@ BACKUP=$SNAP_DATA/var/log/ca-backup/
 INSTALL=false
 UNDO=false
 CHECK=false
-PARSED=$(getopt --options=iuhc --longoptions=install,undo,help,check --name "$@" -- "$@")
+REFRESH=false
+PARSED=$(getopt --options=iuhcr: --longoptions=install,undo,help,check,refresh: --name "$@" -- "$@")
 eval set -- "$PARSED"
 while true; do
   case "$1" in
@@ -34,6 +35,11 @@ while true; do
         CHECK=true
         shift
         ;;
+    -r|--refresh)
+        REFRESH=true
+        CAPATH=$2
+        shift 2
+        ;;
     -h|--help)
         echo "Usage: $0 [OPTIONS]"
         echo
@@ -43,6 +49,7 @@ while true; do
         echo " -h, --help          Show this help"
         echo " -u, --undo          Revert the last refresh performed"
         echo " -c, --check         Check the expiration time of the installed CA"
+        echo " -r, --refresh path  Change CA cert and key"
         echo " -i, --install       Install new CA certificates"
         exit 0
         ;;
@@ -73,6 +80,43 @@ function revert {
   $SNAP/microk8s-start.wrapper
 }
 
+function refresh_ca {
+  echo "Backing up CA cert and key under $BACKUP"
+  run_with_sudo mkdir -p $SNAP_DATA/var/log/ca-backup/
+  if [ -e ${SNAP_DATA}/certs/ca.crt ]
+  then
+      run_with_sudo cp ${SNAP_DATA}/certs/ca.crt $BACKUP
+  fi
+  if [ -e ${SNAP_DATA}/certs/ca.key ]
+  then
+      run_with_sudo cp ${SNAP_DATA}/certs/ca.key $BACKUP
+  fi
+
+  echo "Creating new CA certificate and key"
+  run_with_sudo rm -f ${SNAP_DATA}/certs/ca.crt
+  run_with_sudo rm -f ${SNAP_DATA}/certs/ca.key
+
+  if [ -e ${CAPATH}/ca.crt ]
+  then
+      run_with_sudo cp ${CAPATH}/ca.crt ${SNAP_DATA}/certs/ca.crt
+  else
+      echo "Could not find ca.crt in $CAPATH, aborting cert update"
+      run_with_sudo cp ${BACKUP}/ca.crt ${SNAP_DATA}/certs/ca.crt
+      exit 1
+  fi
+
+  if [ -e ${CAPATH}/ca.key ]
+  then
+      run_with_sudo cp ${CAPATH}/ca.key ${SNAP_DATA}/certs/ca.key
+  else
+      echo "Could not find ca.key in $CAPATH, aborting cert update"
+      run_with_sudo cp ${BACKUP}/ca.crt ${SNAP_DATA}/certs/ca.crt
+      run_with_sudo cp ${BACKUP}/ca.key ${SNAP_DATA}/certs/ca.key
+      exit 1
+  fi
+
+  update_configs
+}
 
 function refresh {
   # Backup
@@ -88,6 +132,10 @@ function refresh {
   produce_certs
   rm -rf .srl
 
+  update_configs
+}
+
+function update_configs {
   # Create the basic tokens
   echo "Creating new kubeconfig file"
   ca_data=$(cat ${SNAP_DATA}/certs/ca.crt | ${SNAP}/usr/bin/base64 -w 0)
@@ -170,6 +218,10 @@ then
 elif [[ "$INSTALL" == "true" ]]
 then
   refresh
+  exit 0
+elif [[ "$REFRESH" == "true" ]]
+then
+  refresh_ca
   exit 0
 else
   echo "Use the --help to see the available options."


### PR DESCRIPTION
This commit adds an option (-r/--refresh) to the
microk8s-refresh-certs script to support user supplied
CA certificate and key.