### PR TITLE
check for possible missing profile with vanilla LXD container

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -191,8 +191,8 @@ function suggest_fixes {
     # make sure the /dev/kmsg is available, indicating a potential missing profile
     if [ ! -c "/dev/kmsg" ]  # kmsg is a character device
     then
-      printf -- '\033[0;33mWARNING: \033[0m microk8s profile might be missing. \n'
-      printf -- '\t  Refer to this help document to get microk8s working in with LXD: \n'
+      printf -- '\033[0;33mWARNING: \033[0m the lxc profile for MicroK8s might be missing. \n'
+      printf -- '\t  Refer to this help document to get MicroK8s working in with LXD: \n'
       printf -- '\t  https://microk8s.io/docs/lxd \n'
     fi
   fi

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -183,6 +183,19 @@ function suggest_fixes {
       printf -- '\tgrubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0" \n'
     fi
   fi
+
+  # LXD Specific Checks
+  if cat /proc/1/environ | grep "container=lxc" &> /dev/null
+    then
+
+    # make sure the /dev/kmsg is available, indicating a potential missing profile
+    if [ ! -c "/dev/kmsg" ]  # kmsg is a character device
+    then
+      printf -- '\033[0;33mWARNING: \033[0m microk8s profile might be missing. \n'
+      printf -- '\t  Refer to this help document to get microk8s working in with LXD: \n'
+      printf -- '\t  https://microk8s.io/docs/lxd \n'
+    fi
+  fi
 }
 
 function fedora_release {


### PR DESCRIPTION
#1404 

**Output of `microk8s.inspect`**

```root@issue-1404:~# microk8s.inspect
Inspecting Certificates
Inspecting services
  Service snap.microk8s.daemon-cluster-agent is running
  Service snap.microk8s.daemon-containerd is running
  Service snap.microk8s.daemon-apiserver is running
  Service snap.microk8s.daemon-apiserver-kicker is running
  Service snap.microk8s.daemon-proxy is running
 FAIL:  Service snap.microk8s.daemon-kubelet is not running
For more details look at: sudo journalctl -u snap.microk8s.daemon-kubelet
  Service snap.microk8s.daemon-scheduler is running
  Service snap.microk8s.daemon-controller-manager is running
  Service snap.microk8s.daemon-flanneld is running
  Service snap.microk8s.daemon-etcd is running
  Copy service arguments to the final report tarball
Inspecting AppArmor configuration
Gathering system information
  Copy processes list to the final report tarball
  Copy snap list to the final report tarball
  Copy VM name (or none) to the final report tarball
  Copy disk usage information to the final report tarball
  Copy memory usage information to the final report tarball
  Copy server uptime to the final report tarball
  Copy current linux distribution to the final report tarball
  Copy openSSL information to the final report tarball
  Copy network configuration to the final report tarball
Inspecting kubernetes cluster
  Inspect kubernetes cluster

WARNING:  microk8s profile might be missing. 
	   Refer to this help document to get microk8s working in with LXD: 
	   https://microk8s.io/docs/lxd 
Building the report tarball
  Report tarball is at /var/snap/microk8s/x1/inspection-report-20200721_210504.tar.gz
```