### PR TITLE
Change ownership of files under the dqlite path

### DIFF
--- a/scripts/wrappers/control-plane-kicker.py
+++ b/scripts/wrappers/control-plane-kicker.py
@@ -54,7 +54,7 @@ def microk8s_group_exists():
         cmd = "getent group microk8s"
         subprocess.check_call(cmd.split())
         return True
-    except:
+    except subprocess.CalledProcessError:
         return False
 
 

--- a/scripts/wrappers/control-plane-kicker.py
+++ b/scripts/wrappers/control-plane-kicker.py
@@ -11,6 +11,7 @@ from common.utils import (
     is_service_expected_to_start,
     set_service_expected_to_start,
 )
+import os
 
 services = [
     'controller-manager',
@@ -44,11 +45,43 @@ def stop_control_plane_services():
             set_service_expected_to_start(service, False)
 
 
+def microk8s_group_exists():
+    """
+    Check the existence of the microk8s group
+    :return: True is the microk8s group exists
+    """
+    try:
+        cmd = "getent group microk8s"
+        subprocess.check_call(cmd.split())
+        return True
+    except:
+        return False
+
+
+def set_dqlite_file_permissions():
+    """
+    Set the file permissions in the dqlite backend directory
+    """
+    dqlite_path = os.path.expandvars("${SNAP_DATA}/var/kubernetes/backend")
+    try:
+        cmd = "chmod -R ug+rwX {}".format(dqlite_path)
+        subprocess.check_call(cmd.split())
+        cmd = "chgrp microk8s -R {}".format(dqlite_path)
+        subprocess.check_call(cmd.split())
+    except Exception as e:
+        print("Failed to set the file permissions in dqlite.")
+        print(e)
+
+
 if __name__ == '__main__':
     while True:
         # Check for changes every 10 seconds
         sleep(10)
         try:
+
+            if microk8s_group_exists():
+                set_dqlite_file_permissions()
+
             # We will not attempt to stop services if:
             # 1. The cluster is not ready
             # 2. We are not on an HA cluster


### PR DESCRIPTION
This is a bug fix. If you call `microk8s status` without `sudo` from a user in the `microk8s` group you get back an exception saying `info.yaml` inside the dqlite storage directory cannot be accessed.
```
$ microk8s.status
microk8s is running
Traceback (most recent call last):
  File "/snap/microk8s/1564/scripts/wrappers/status.py", line 242, in <module>
    print_pretty(isReady, enabled, disabled)
  File "/snap/microk8s/1564/scripts/wrappers/status.py", line 51, in print_pretty
    info = get_dqlite_info()
  File "/snap/microk8s/1564/scripts/wrappers/common/utils.py", line 71, in get_dqlite_info
    with open("{}/info.yaml".format(cluster_dir), mode='r') as f:
PermissionError: [Errno 13] Permission denied: '/var/snap/microk8s/1564/var/kubernetes/backend/info.yaml'
```

The dqlite daemon runs as root so its files created with -rw------ permissions and they belong to the root:root user and group. Snap daemons cannot run as a different user and they cannot change to another default group (tested with `newgrp microk8s`). So I do not see any way to create the files with proper permissions owned by root:microk8s.

The hack here is the control-plane-kicker to check the existence of the `microk8s` group and change the permissions and ownership of the dqlite files :( .

Fixes: https://github.com/ubuntu/microk8s/issues/1430