### PR TITLE
Update MetalLB to v0.9.3 and add support for CIDR notation

### DIFF
--- a/microk8s-resources/actions/enable.metallb.sh
+++ b/microk8s-resources/actions/enable.metallb.sh
@@ -28,18 +28,21 @@ then
   then
     echo "You have to input an IP Range value when asked, or provide it as an argument to the enable command, eg:"
     echo "  microk8s enable metallb:10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111"
+    echo "You can also use CIDR notation, eg."
+    echo "  microk8s enable metallb:192.168.1.240/24"
     exit 1
   fi
 else
   ip_range_input="${ARGUMENTS[@]}"
 fi
-
+MEMBERLIST_SECRET=$(${SNAP}/usr/bin/openssl rand -base64 128 | ${SNAP}/usr/bin/base64 -w0)
 REGEX_IP_RANGE='^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$'
+REGEX_IP_CIDR='^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9]{1,3}\/[0-9]{1,3}$'
 ip_ranges=(`echo $ip_range_input | sed 's/,/\n/g'`)
 ip_range_str="addresses:"
 for ip_range in "${ip_ranges[@]}"
 do
-  if [[ $ip_range =~ $REGEX_IP_RANGE ]]
+  if [[ $ip_range =~ $REGEX_IP_RANGE ||  $ip_range =~ $REGEX_IP_CIDR ]]
   then
     ip_range_str="${ip_range_str}\n      - ${ip_range}"
   else
@@ -47,6 +50,7 @@ do
     exit 1
   fi
 done
-echo "Applying registry manifest"
-cat $SNAP/actions/metallb.yaml | $SNAP/bin/sed "s/{{allow_escalation}}/$ALLOWESCALATION/g" | $SNAP/bin/sed "s/{{addresses}}/$ip_range_str/g" | $KUBECTL apply -f -
+echo "Applying Metallb manifest"
+
+cat $SNAP/actions/metallb.yaml | $SNAP/bin/sed "s@{{member_list}}@$MEMBERLIST_SECRET@g" | $SNAP/bin/sed "s@{{allow_escalation}}@$ALLOWESCALATION@g" | $SNAP/bin/sed "s@{{addresses}}@$ip_range_str@g" | $KUBECTL apply -f -
 echo "MetalLB is enabled"

--- a/microk8s-resources/actions/metallb.yaml
+++ b/microk8s-resources/actions/metallb.yaml
@@ -327,7 +327,7 @@ spec:
               name: memberlist
               key: secretkey
         image: metallb/speaker:v0.9.3
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: speaker
         ports:
         - containerPort: 7472
@@ -383,7 +383,7 @@ spec:
         - --port=7472
         - --config=config
         image: metallb/controller:v0.9.3
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: controller
         ports:
         - containerPort: 7472

--- a/microk8s-resources/actions/metallb.yaml
+++ b/microk8s-resources/actions/metallb.yaml
@@ -5,6 +5,57 @@ metadata:
     app: metallb
   name: metallb-system
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: memberlist
+  namespace: metallb-system
+type: Opaque
+data:
+  secretkey: {{member_list}}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+spec:
+  allowPrivilegeEscalation: {{allow_escalation}}
+  allowedCapabilities: []
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: {{allow_escalation}}
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -13,18 +64,26 @@ metadata:
   name: speaker
   namespace: metallb-system
 spec:
-  allowPrivilegeEscalation: {{allow_escalation}}
+  allowPrivilegeEscalation: {{allow_escalation}} 
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
   - SYS_ADMIN
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: {{allow_escalation}}
   fsGroup:
     rule: RunAsAny
+  hostIPC: false
   hostNetwork: true
+  hostPID: false
   hostPorts:
   - max: 7472
     min: 7472
   privileged: true
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
   runAsUser:
     rule: RunAsAny
   seLinux:
@@ -32,7 +91,9 @@ spec:
   supplementalGroups:
     rule: RunAsAny
   volumes:
-  - '*'
+  - configMap
+  - secret
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -79,6 +140,14 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - policy
+  resourceNames:
+  - controller
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -105,7 +174,7 @@ rules:
   - create
   - patch
 - apiGroups:
-  - extensions
+  - policy
   resourceNames:
   - speaker
   resources:
@@ -129,6 +198,21 @@ rules:
   - get
   - list
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -177,6 +261,21 @@ subjects:
 - kind: ServiceAccount
   name: speaker
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-lister
+subjects:
+- kind: ServiceAccount
+  name: speaker
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -212,8 +311,23 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: metallb/speaker:v0.8.2
-        imagePullPolicy: IfNotPresent
+        - name: METALLB_ML_BIND_ADDR
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: METALLB_ML_LABELS
+          value: "app=metallb,component=speaker"
+        - name: METALLB_ML_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: METALLB_ML_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: memberlist
+              key: secretkey
+        image: metallb/speaker:v0.9.3
+        imagePullPolicy: Always
         name: speaker
         ports:
         - containerPort: 7472
@@ -236,7 +350,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       serviceAccountName: speaker
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 2
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -268,8 +382,8 @@ spec:
       - args:
         - --port=7472
         - --config=config
-        image: metallb/controller:v0.8.2
-        imagePullPolicy: IfNotPresent
+        image: metallb/controller:v0.9.3
+        imagePullPolicy: Always
         name: controller
         ports:
         - containerPort: 7472

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -145,7 +145,7 @@ microk8s-addons:
 
     - name: "metallb"
       description: "Loadbalancer for your Kubernetes cluster"
-      version: "0.8.2"
+      version: "0.9.3"
       check_status: "pod/speaker"
       supported_architectures:
       - amd64

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -281,7 +281,7 @@ class TestAddons(object):
     )
     def test_metallb_addon(self):
         addon = "metallb"
-        ip_ranges = "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111"
+        ip_ranges = "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28"
         print("Enabling metallb")
         microk8s_enable("{}:{}".format(addon, ip_ranges), timeout_insec=500)
         validate_metallb_config(ip_ranges)

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -165,7 +165,7 @@ class TestUpgrade(object):
             except:
                 print('Will not test the cilium addon')
             try:
-                ip_ranges = "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111"
+                ip_ranges = "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28"
                 enable = microk8s_enable("{}:{}".format("metallb", ip_ranges), timeout_insec=500)
                 assert "MetalLB is enabled" in enable and "Nothing to do for" not in enable
                 validate_metallb_config(ip_ranges)

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -165,7 +165,9 @@ class TestUpgrade(object):
             except:
                 print('Will not test the cilium addon')
             try:
-                ip_ranges = "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28"
+                ip_ranges = (
+                    "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28"
+                )
                 enable = microk8s_enable("{}:{}".format("metallb", ip_ranges), timeout_insec=500)
                 assert "MetalLB is enabled" in enable and "Nothing to do for" not in enable
                 validate_metallb_config(ip_ranges)


### PR DESCRIPTION
This PR add CIDR support when specifying IP addresses.  Also upgrades metallb v0.9.3.