### PR TITLE
Fix Kubeflow arg handling

### DIFF
--- a/microk8s-resources/actions/enable.kubeflow.sh
+++ b/microk8s-resources/actions/enable.kubeflow.sh
@@ -202,6 +202,7 @@ def main():
             }
         }
     else:
+        bundle = args['bundle']
         bundle_type = 'full'
         password_overlay = {
             "applications": {


### PR DESCRIPTION
Follow-up to #1441, which missed converting this variable usage.