### PR TITLE
Handle not reachable nodes

### DIFF
--- a/scripts/cluster/distributed_op.py
+++ b/scripts/cluster/distributed_op.py
@@ -62,9 +62,12 @@ def do_op(remote_op):
                             remote_op["action_str"], node_ep, res.status_code
                         )
                     )
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
             print("Could not query for nodes")
-
+            raise SystemExit(e)
+        except requests.exceptions.RequestException as e:
+            print("Failed to reach node.")
+            raise SystemExit(e)
     else:
         with open(callback_tokens_file, "r+") as fp:
             for _, line in enumerate(fp):


### PR DESCRIPTION
This PR changes the error message shown to the user in the case of an error:
```
ubuntu@ip-172-31-40-63:~/microk8s$ microk8s.enable dashboard
Enabling Kubernetes Dashboard
Enabling Metrics-Server
clusterrole.rbac.authorization.k8s.io/system:aggregated-metrics-reader created
clusterrolebinding.rbac.authorization.k8s.io/metrics-server:system:auth-delegator created
rolebinding.rbac.authorization.k8s.io/metrics-server-auth-reader created
apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io created
serviceaccount/metrics-server created
deployment.apps/metrics-server created
service/metrics-server created
clusterrole.rbac.authorization.k8s.io/system:metrics-server created
clusterrolebinding.rbac.authorization.k8s.io/system:metrics-server created
clusterrolebinding.rbac.authorization.k8s.io/microk8s-admin created
Adding argument --authentication-token-webhook to nodes.
Configuring node 172.31.40.63
Configuring node 10.228.72.149
Failed to reach node.
HTTPSConnectionPool(host='10.228.72.149', port=25000): Max retries exceeded with url: /cluster/api/v1.0/configure (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f75bf492048>: Failed to establish a new connection: [Errno 113] No route to host',))
Failed to enable metrics-server
Failed to enable dashboard
```

Fixes: https://github.com/ubuntu/microk8s/issues/1443