### PR TITLE
Enable snapcraft verbose output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - sudo /snap/bin/lxd waitready
   - sudo /snap/bin/lxd init --auto
   - sudo usermod --append --groups lxd $USER
-  - sg lxd -c 'snapcraft --use-lxd'
+  - sg lxd -c 'SNAPCRAFT_ENABLE_DEVELOPER_DEBUG=yes snapcraft --use-lxd'
   - sudo apt update
   - sudo snap install *.snap --classic --dangerous
   - sudo pip3 install --upgrade pip


### PR DESCRIPTION
Adding verbose output will help travis not timeout due to no output..... I hope.