### PR TITLE
enabling the registry should fail if localhost can resolve to an ipv6 address

### DIFF
--- a/microk8s-resources/actions/enable.registry.sh
+++ b/microk8s-resources/actions/enable.registry.sh
@@ -4,6 +4,14 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
+hostv6=$(getent ahostsv6 localhost | head -n1 | cut -d' ' -f1)
+if [ "$hostv6" = "::1" ]; then
+  echo "In-cluster registry does not work with ipv6"
+  echo "Remove the mapping from ::1 to localhost in /etc/hosts and try again"
+  echo "For more details, see https://github.com/ubuntu/microk8s/issues/196"
+  exit 1
+fi
+
 echo "Enabling the private registry"
 
 "$SNAP/microk8s-enable.wrapper" storage


### PR DESCRIPTION
Fixes https://github.com/ubuntu/microk8s/issues/196

I tested this a little bug a little bit with different microk8s channels. This comment (https://github.com/ubuntu/microk8s/issues/196#issuecomment-590403234) was particularly helpful in confirming that there's some underlying kubernetes networking issue, rather than something specific to `docker push`.

I can definitely reproduce the problem on --channel=1.17/stable. It might be fixed on --channel=1.18/stable, but supposedly ipv6 support on v1.18 is still in beta, so it seems safer to error on v1.18 too.