### PR TITLE
Update containerd to 1.3.7

### DIFF
--- a/build-scripts/set-env-variables.sh
+++ b/build-scripts/set-env-variables.sh
@@ -16,10 +16,10 @@ export CNI_VERSION="${CNI_VERSION:-v0.7.1}"
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v0.13.0}"
 export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v0.13.0}"
 # RUNC commit matching the containerd release commit
-# Tag 1.3.4
-export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-814b7956fafc7a0980ea07e950f983d0837e5578}"
-# Release v1.0.0-rc10
-export RUNC_COMMIT="${RUNC_COMMIT:-dc9208a3303feef5b3839f4323d9beb36df0a9dd}"
+# Tag 1.3.7
+export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-8fba4e9a7d01810a393d5d25a3621dc101981175}"
+# Release v1.0.0-rc92
+export RUNC_COMMIT="${RUNC_COMMIT:-ff819c7e9184c13b7c2607fe6c30ae19403a7aff}"
 # Set this to the kubernetes fork you want to build binaries from
 export KUBERNETES_REPOSITORY="${KUBERNETES_REPOSITORY:-github.com/kubernetes/kubernetes}"
 


### PR DESCRIPTION
This PR fixes the multiple bug reports relating to containerd not pulling over HTTP, even when forced (https://github.com/containerd/cri/issues/1433).

Fixes: https://github.com/ubuntu/microk8s/issues/1444