### PR TITLE
Feature/jdstrand/strict updates

### DIFF
--- a/microk8s-resources/actions/disable.helm.sh
+++ b/microk8s-resources/actions/disable.helm.sh
@@ -8,5 +8,5 @@ echo "Disabling Helm"
 
 if [ -f "${SNAP_DATA}/bin/helm" ]
 then
-  sudo rm -f "$SNAP_DATA/bin/helm"
+  rm -f "$SNAP_DATA/bin/helm"
 fi

--- a/microk8s-resources/actions/disable.helm3.sh
+++ b/microk8s-resources/actions/disable.helm3.sh
@@ -8,5 +8,5 @@ echo "Disabling Helm 3"
 
 if [ -f "${SNAP_DATA}/bin/helm3" ]
 then
-  sudo rm -f "$SNAP_DATA/bin/helm3"
+  rm -f "$SNAP_DATA/bin/helm3"
 fi

--- a/microk8s-resources/wrappers/microk8s-ctr.wrapper
+++ b/microk8s-resources/wrappers/microk8s-ctr.wrapper
@@ -11,4 +11,4 @@ source $SNAP/actions/common/utils.sh
 SNAPSHOTTER=$(snapshotter)
 
 declare -a args="($(cat $SNAP_DATA/args/ctr))"
-sudo -E LD_LIBRARY_PATH="$IN_SNAP_LD_LIBRARY_PATH" CONTAINERD_SNAPSHOTTER="$SNAPSHOTTER" "${SNAP}/bin/ctr" "${args[@]}" "$@"
+LD_LIBRARY_PATH="$IN_SNAP_LD_LIBRARY_PATH" CONTAINERD_SNAPSHOTTER="$SNAPSHOTTER" "${SNAP}/bin/ctr" "${args[@]}" "$@"

--- a/microk8s-resources/wrappers/microk8s-disable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-disable.wrapper
@@ -6,6 +6,9 @@ ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
+# avoid AppArmor denial in strict mode when running under sudo without -H
+cd "$SNAP"
+
 source $SNAP/actions/common/utils.sh
 
 if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]

--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -6,6 +6,9 @@ ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
+# avoid AppArmor denial in strict mode when running under sudo without -H
+cd "$SNAP"
+
 source $SNAP/actions/common/utils.sh
 
 if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]

--- a/microk8s-resources/wrappers/microk8s-join.wrapper
+++ b/microk8s-resources/wrappers/microk8s-join.wrapper
@@ -11,4 +11,4 @@ source $SNAP/actions/common/utils.sh
 
 exit_if_no_permissions
 
-sudo -E  LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/cluster/join.py $@
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/cluster/join.py $@

--- a/microk8s-resources/wrappers/microk8s.wrapper
+++ b/microk8s-resources/wrappers/microk8s.wrapper
@@ -22,7 +22,7 @@ if [ -f "${SNAP}/microk8s-${APP}.wrapper" ]; then
     "${SNAP}/microk8s-${APP}.wrapper" "$@"
     readonly EXIT="$?"
 elif [ "${APP}" == "inspect" ]; then
-    sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh
+    SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh
     readonly EXIT="$?"
 elif [ "${APP}" == "help" ] || [ "${APP}" == "--help" ] || [ "$APP" == "-h" ]; then
     help

--- a/patches/runc-patches/snap-runc-no-prctl.patch
+++ b/patches/runc-patches/snap-runc-no-prctl.patch
@@ -1,8 +1,7 @@
-diff --git a/libcontainer/setns_init_linux.go b/libcontainer/setns_init_linux.go
-index 0b9cd885..f6b53d1a 100644
---- a/libcontainer/setns_init_linux.go
-+++ b/libcontainer/setns_init_linux.go
-@@ -56,11 +56,6 @@ func (l *linuxSetnsInit) Init() error {
+diff -Naur a/libcontainer/setns_init_linux.go b/libcontainer/setns_init_linux.go
+--- a/libcontainer/setns_init_linux.go	2020-08-04 15:53:52.419656110 -0500
++++ b/libcontainer/setns_init_linux.go	2020-08-05 08:34:55.799786404 -0500
+@@ -56,11 +56,12 @@
  			return err
  		}
  	}
@@ -11,6 +10,33 @@ index 0b9cd885..f6b53d1a 100644
 -			return err
 -		}
 -	}
++	// incompatible with snapd
++	//if l.config.NoNewPrivileges {
++	//	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++	//		return err
++	//	}
++	//}
  	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
  		return err
  	}
+diff -Naur a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
+--- a/libcontainer/standard_init_linux.go	2020-08-04 15:54:57.552256956 -0500
++++ b/libcontainer/standard_init_linux.go	2020-08-05 08:32:02.134205845 -0500
+@@ -135,11 +135,12 @@
+ 	if err != nil {
+ 		return errors.Wrap(err, "get pdeath signal")
+ 	}
+-	if l.config.NoNewPrivileges {
+-		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+-			return errors.Wrap(err, "set nonewprivileges")
+-		}
+-	}
++	// incompatible with snapd
++	//if l.config.NoNewPrivileges {
++	//	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++	//		return errors.Wrap(err, "set nonewprivileges")
++	//	}
++	//}
+ 	// Tell our parent that we're ready to Execv. This must be done before the
+ 	// Seccomp rules have been applied, because we need to be able to read and
+ 	// write to a socket.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -121,6 +121,7 @@ apps:
     - docker-support
     - docker-privileged
     - firewall-control
+    - k8s-journald
     - kernel-module-control
     - network-control
   daemon-scheduler:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,6 +90,7 @@ apps:
     - opengl
     - cifs-mount
     - fuse-support
+    - kernel-crypto-api
   daemon-apiserver:
     command: run-with-config-args kube-apiserver
     daemon: simple


### PR DESCRIPTION
* snap/snapcraft.yaml: update daemon-controller-manager to plugs k8s-journald
* update snap-runc-no-prctl.patch for standard_init_linux.go too
* microk8s-{dis,en}able.wrapper: avoid denial when running under sudo without -H
* remove all uses of sudo from wrappers
* plugs kernel-crypto-api for daemon-containerd