### PR TITLE
Build K8s binaries in separate build step

### DIFF
--- a/build-scripts/build-k8s-binaries.sh
+++ b/build-scripts/build-k8s-binaries.sh
@@ -8,13 +8,14 @@ export KUBE_SNAP_BINS="build/kube_bins/$KUBE_VERSION"
 mkdir -p $KUBE_SNAP_BINS/$KUBE_ARCH
 echo $KUBE_VERSION > $KUBE_SNAP_BINS/version
 
-export GOPATH=$SNAPCRAFT_PART_INSTALL/go
+export GOPATH=$SNAPCRAFT_PART_BUILD/go
+
+rm -rf $GOPATH
 mkdir -p $GOPATH
 
-go get -d $KUBERNETES_REPOSITORY || true
+git clone --depth 1 https://github.com/kubernetes/kubernetes $GOPATH/src/github.com/kubernetes/kubernetes/ -b $KUBERNETES_TAG
 
 (cd $GOPATH/src/$KUBERNETES_REPOSITORY
-  git checkout $KUBERNETES_TAG
   git config user.email "microk8s-builder-bot@ubuntu.com"
   git config user.name "MicroK8s builder bot"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -161,6 +161,7 @@ parts:
       - libuv1
     build-packages:
       - libuv1-dev
+      - pkg-config
     organize:
       usr/lib/: lib/
       include/: usr/include/
@@ -226,6 +227,53 @@ parts:
       flanneld: opt/cni/bin/
     stage:
       - opt/cni/bin/flanneld
+
+  k8s-binaries:
+    after: [dqlite]
+    build-snaps: [go]
+    plugin: dump
+    build-attributes: [no-patchelf]
+    source: build-scripts/
+    build-packages:
+      - build-essential
+      - curl
+      - git
+    override-build: |
+      set -eux
+      . ./set-env-variables.sh
+
+      # if "${KUBE_SNAP_BINS}" exist we have to use the binaries from there
+      # if "${KUBE_SNAP_BINS}" does not exist but it is set we will put the k8s binaries there
+      # if "${KUBE_SNAP_BINS}" does not exist and it is not set we do not need to keep the created binaries
+      if [ ! -e "${KUBE_SNAP_BINS}" ]; then
+        if [ -z "${KUBE_SNAP_BINS}" ]; then
+          . ./set-env-binaries-location.sh
+        fi
+        echo "Downloading binaries"
+        . ./fetch-other-binaries.sh
+        echo "Building k8s binaries"
+        . ./build-k8s-binaries.sh
+      else
+        echo "Binaries provided in $KUBE_SNAP_BINS"
+      fi
+      mkdir bins/
+      cp build/kube_bins/$KUBERNETES_TAG/$KUBE_ARCH/* bins/
+
+      # Add bash completion for microk8s kubectl.
+      bins/kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
+      bins/kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s.kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
+
+      snapcraftctl build
+    organize:
+      bins/*: .
+    stage:
+      - kube-apiserver
+      - kube-controller-manager
+      - kube-proxy
+      - kube-scheduler
+      - kubectl
+      - kubectl.bash
+      - kubelet
 
   libnftnl:
     plugin: autotools
@@ -342,7 +390,7 @@ parts:
     - python3-click
     - python3-dateutil
   microk8s:
-    after: [containerd, dqlite]
+    after: [containerd, dqlite, k8s-binaries]
     plugin: dump
     build-attributes: [no-patchelf]
     build-packages:
@@ -369,26 +417,9 @@ parts:
       - -go*
     override-build: |
       set -eux
-      . build-scripts/set-env-variables.sh
 
-      REMOVE_KUBE_SNAP_BINS=false
-      echo "Reached here"
-      # if "${KUBE_SNAP_BINS}" exist we have to use the binaries from there
-      # if "${KUBE_SNAP_BINS}" does not exist but it is set we will put the k8s binaries there
-      # if "${KUBE_SNAP_BINS}" does not exist and it is not set we do not need to keep the created binaries
-      if [ ! -e "${KUBE_SNAP_BINS}" ]; then
-        if [ -z "${KUBE_SNAP_BINS}" ]; then
-          # "${KUBE_SNAP_BINS}" not set, we will remove the binaries after we build them.
-          REMOVE_KUBE_SNAP_BINS=true
-          . build-scripts/set-env-binaries-location.sh
-        fi
-        echo "Downloading binaries"
-        . build-scripts/fetch-other-binaries.sh
-        echo "Building k8s binaries"
-        . build-scripts/build-k8s-binaries.sh
-      else
-        echo "Binaries provided in $KUBE_SNAP_BINS"
-      fi
+      . build-scripts/set-env-variables.sh
+      KUBE_SNAP_BINS="/root/parts/k8s-binaries/build/build/kube_bins/$KUBE_VERSION"
 
       echo "Setting default daemon configs"
       cp -r $KUBE_SNAP_ROOT/microk8s-resources/default-args .
@@ -399,29 +430,6 @@ parts:
 
       echo "Preparing containerd"
       cp $KUBE_SNAP_ROOT/microk8s-resources/containerd-profile .
-
-      echo "Preparing kube-apiserver"
-      cp $KUBE_SNAP_BINS/$KUBE_ARCH/kube-apiserver .
-      # Old versions will be pointing to these .csv files from inside their kube-apiserver config
-      # Keep them around for a couple of releases.
-      touch known_token.csv
-      cp $KUBE_SNAP_ROOT/microk8s-resources/basic_auth.csv .
-
-      echo "Preparing kube-controller-manager"
-      cp $KUBE_SNAP_BINS/$KUBE_ARCH/kube-controller-manager .
-
-      echo "Preparing kube-scheduler"
-      cp $KUBE_SNAP_BINS/$KUBE_ARCH/kube-scheduler .
-
-      echo "Preparing kubelet"
-      mkdir -p configs
-      cp $KUBE_SNAP_BINS/$KUBE_ARCH/kubelet .
-
-      echo "Preparing kube-proxy"
-      cp $KUBE_SNAP_BINS/$KUBE_ARCH/kube-proxy .
-
-      echo "Preparing kubelet"
-      cp $KUBE_SNAP_BINS/$KUBE_ARCH/kubectl .
 
       echo "Preparing user config"
       cp $KUBE_SNAP_ROOT/microk8s-resources/client.config.template .
@@ -477,13 +485,6 @@ parts:
       echo "Creating inspect hook"
       cp $KUBE_SNAP_ROOT/scripts/inspect.sh .
 
-      # Add bash completion for microk8s kubectl.
-      ./kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
-      ./kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s.kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
-
-      if $REMOVE_KUBE_SNAP_BINS; then
-        rm -rf "$KUBE_SNAP_BINS"
-      fi
       snapcraftctl build
 
   # Unfortunately we cannot add package repositories to our snaps

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -109,6 +109,7 @@ parts:
       usr/lib/: lib/
     prime:
       - lib/libco*so*
+
   raft:
     source: https://github.com/canonical/raft
     build-attributes: [no-patchelf]
@@ -122,6 +123,7 @@ parts:
     prime:
       - lib/libraft*so*
       - usr/include/
+
   sqlite:
     source: https://github.com/canonical/sqlite
     source-type: git
@@ -148,6 +150,7 @@ parts:
       - bin/sqlite3
       - lib/libsqlite3*so*
       - usr/include/
+
   dqlite:
     after:
       - libco
@@ -169,6 +172,7 @@ parts:
       - lib/libdqlite*so*
       - lib/*/libuv*
       - usr/include/
+
   dqlite-client:
     build-snaps: [go]
     after: [sqlite, dqlite]
@@ -263,6 +267,13 @@ parts:
       bins/kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
       bins/kubectl completion bash | sed "s/complete -o default -F __start_kubectl kubectl/complete -o default -F __start_kubectl microk8s.kubectl/g" | sed "s/complete -o default -o nospace -F __start_kubectl kubectl/complete -o default -o nospace -F __start_kubectl kubectl/g" > kubectl.bash
 
+      mkdir -p ./actions/
+      if [ "${ARCH}" = "amd64" ]
+      then
+        # Knative support
+        echo "Preparing knative"
+        cp -r $KUBE_SNAP_BINS/knative-yaml ./actions/knative
+      fi
       snapcraftctl build
     organize:
       bins/*: .
@@ -274,6 +285,7 @@ parts:
       - kubectl
       - kubectl.bash
       - kubelet
+      - actions
 
   libnftnl:
     plugin: autotools
@@ -281,6 +293,7 @@ parts:
     build-packages:
     - libjansson-dev
     - libmnl-dev
+
   iptables:
     after:
     - libnftnl
@@ -297,6 +310,7 @@ parts:
     - "--disable-shared"
     - "--enable-static"
     prime: [ -bin/iptables-xml ]
+
   migrator:
     build-snaps: [go]
     source: https://github.com/ktsakalozos/go-migrator
@@ -308,6 +322,7 @@ parts:
       - gcc
     prime:
       - bin/migrator
+
   containerd:
     build-snaps: [go]
     after: [iptables]
@@ -374,6 +389,7 @@ parts:
     - -sbin/xtables-multi
     - -sbin/iptables*
     - -lib/xtables
+
   cluster-agent:
     plugin: python
     python-version: python3
@@ -389,6 +405,7 @@ parts:
     - gunicorn3
     - python3-click
     - python3-dateutil
+
   microk8s:
     after: [containerd, dqlite, k8s-binaries]
     plugin: dump
@@ -415,11 +432,11 @@ parts:
       - -docs*
       - -build*
       - -go*
+      - -snap*
     override-build: |
       set -eux
 
       . build-scripts/set-env-variables.sh
-      KUBE_SNAP_BINS="/root/parts/k8s-binaries/build/build/kube_bins/$KUBE_VERSION"
 
       echo "Setting default daemon configs"
       cp -r $KUBE_SNAP_ROOT/microk8s-resources/default-args .
@@ -476,10 +493,6 @@ parts:
         rm "actions/enable.multus.sh"
         rm "actions/disable.multus.sh"
         rm "actions/multus.yaml"
-      else
-        # Knative support
-        echo "Preparing knative"
-        cp -r $KUBE_SNAP_BINS/knative-yaml ./actions/knative
       fi
 
       echo "Creating inspect hook"

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -217,7 +217,9 @@ class TestAddons(object):
         print("Disabling fluentd")
         microk8s_disable("fluentd")
 
-    @pytest.mark.skip("disabling the linkerd test due to https://github.com/linkerd/linkerd2/issues/4918")
+    @pytest.mark.skip(
+        "disabling the linkerd test due to https://github.com/linkerd/linkerd2/issues/4918"
+    )
     @pytest.mark.skipif(
         platform.machine() != 'x86_64',
         reason="Linkerd tests are only relevant in x86 architectures",


### PR DESCRIPTION
Since these don't rely on local source code changes other than what's under build-scripts/, if we build these in a separate snapcraft part, we won't have to rebuild them when making changes in most of the codebase. Building these binaries currently takes the majority of the time spent doing incremental rebuilds.