### PR TITLE
Add delay for the fluentd deletion

### DIFF
--- a/microk8s-resources/actions/disable.fluentd.sh
+++ b/microk8s-resources/actions/disable.fluentd.sh
@@ -17,5 +17,7 @@ $KUBECTL -n kube-system delete daemonset fluentd-es-v2.2.0 || true
 $KUBECTL label nodes "$NODENAME" beta.kubernetes.io/fluentd-ds-ready- || true
 
 $KUBECTL delete -f "${SNAP}/actions/fluentd"
+# Allow for a few seconds for the deletion to take place
+sleep 10
 
 echo "Fluentd-Elasticsearch is disabled"


### PR DESCRIPTION
Fluentd delete followed by an immediate reset causes some pods to stay in "terminating" state.

