### PR TITLE
configure multus to use symlinked current SNAP_DATA locations

### DIFF
--- a/microk8s-resources/actions/enable.multus.sh
+++ b/microk8s-resources/actions/enable.multus.sh
@@ -5,6 +5,7 @@ set -e
 source "${SNAP}/actions/common/utils.sh"
 
 KUBECTL="${SNAP}/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+CUR_DATA=$(dirname "${SNAP_DATA}")/current
 
 echo "Enabling Multus"
 
@@ -16,7 +17,7 @@ else
   "${SNAP}/microk8s-status.wrapper" --wait-ready >/dev/null
 
   echo "Applying manifest for multus daemonset."
-  cat "${SNAP}/actions/multus.yaml" | "${SNAP}/bin/sed" "s#{{SNAP_DATA}}#${SNAP_DATA}#g" | ${KUBECTL} apply -f -
+  cat "${SNAP}/actions/multus.yaml" | "${SNAP}/bin/sed" "s#{{SNAP_DATA}}#${CUR_DATA}#g" | ${KUBECTL} apply -f -
 
   echo -n "Waiting for multus daemonset to start."
   until [ -f "${SNAP_DATA}/opt/cni/bin/multus" ]; do
@@ -35,7 +36,7 @@ echo "Currently installed CNI and IPAM plugins include:"
 echo $(cd "${SNAP_DATA}/opt/cni/bin/"; ls)
 
 echo
-echo "New CNI plugins can be installed in ${SNAP_DATA}/opt/cni/bin/"
+echo "New CNI plugins can be installed in ${CUR_DATA}/opt/cni/bin/"
 
 echo
 echo "For information on configuration please refer to the multus documentation."


### PR DESCRIPTION
Fixes issue #1495.

Changes the multus daemon set to use the "current" path symlinks for its mounts and arguments.  This should allow it to survive refreshes and upgrades without needing to be disabled/re-enabled.