### PR TITLE
Apply cni.yaml in nodes with the apiserver

### DIFF
--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -192,7 +192,7 @@ def is_service_expected_to_start(service):
 
 def set_service_expected_to_start(service, start=True):
     """
-    Check if a service is not expected to start.
+    Set service as expected to start or not.
     :param service: the service name
     :param start: should the service start or not
     """

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -435,7 +435,10 @@ then
   snapctl restart ${SNAP_NAME}.daemon-proxy
 fi
 
-if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ]
+# Apply the CNI manifest from nodes in an HA cluster where the apiserver is expected to run
+if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
+   [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
+   ! [ -e "${SNAP_DATA}/var/lock/apiserver" ]
 then
   echo "Setting up the CNI"
   start_timer="$(date +%s)"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -437,8 +437,7 @@ fi
 
 # Apply the CNI manifest from nodes in an HA cluster where the apiserver is expected to run
 if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
-   [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
-   ! [ -e "${SNAP_DATA}/var/lock/apiserver" ]
+   [ -e "${SNAP_DATA}/var/lock/ha-cluster" ]
 then
   echo "Setting up the CNI"
   start_timer="$(date +%s)"


### PR DESCRIPTION
When refreshing a non HA node or a node with the apiserver not running we should not apply the cni.yaml