### PR TITLE
Adding start wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tests/__pycache__
 **/tests/*.pyc
 .venv/
 .vscode/
+/installer/.venv/
 /installer/**/__pycache__
 /installer/dist/
 /installer/build/

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,3 +1,4 @@
+.venv/
 bin/
 lib/
 lib64

--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -42,6 +42,10 @@ def cli(ctx, help):
         elif ctx.args[0] == "uninstall":
             uninstall()
             exit(0)
+        elif ctx.args[0] == "start":
+            start()
+            run(ctx.args)
+            exit(0)
         elif ctx.args[0] == "stop":
             run(ctx.args)
             stop()
@@ -261,6 +265,16 @@ def dashboard_proxy() -> None:
         return 1
 
 
+def start() -> None:
+    vm_provider_name = "multipass"
+    vm_provider_class = get_provider_for(vm_provider_name)
+    vm_provider_class.ensure_provider()
+    instance = vm_provider_class(echoer=Echo())
+    instance_info = instance.get_instance_info()
+    if not instance_info.is_running():
+        instance.start()
+
+
 def stop() -> None:
     vm_provider_name = "multipass"
     vm_provider_class = get_provider_for(vm_provider_name)
@@ -278,7 +292,10 @@ def run(cmd) -> None:
     try:
         vm_provider_class.ensure_provider()
         instance = vm_provider_class(echoer=echo)
-        instance.get_instance_info()
+        instance_info = instance.get_instance_info()
+        if not instance_info.is_running():
+            instance.start()
+            instance.run(["microk8s.start"])
         command = cmd[0]
         cmd[0] = "microk8s.{}".format(command)
         instance.run(cmd)

--- a/installer/vm_providers/_multipass/_multipass.py
+++ b/installer/vm_providers/_multipass/_multipass.py
@@ -173,6 +173,13 @@ class Multipass(Provider):
             instance_name=self.instance_name, json_info=instance_info_raw.decode()
         )
 
+    def start(self) -> None:
+        instance_info = self._instance_info = self._get_instance_info()
+        if not instance_info.is_stopped():
+            return
+
+        self._multipass_cmd.start(instance_name=self.instance_name)
+
     def stop(self) -> None:
         instance_info = self._instance_info = self._get_instance_info()
         if instance_info.is_stopped():


### PR DESCRIPTION
Not sure how this flew under the radar for so long. 

`start` now added to the multi-OS wrapper and the VM will be re-launched if someone tries to run a command on a stopped cluster.