### PR TITLE
Fix upgrade from non-HA to HA

### DIFF
--- a/scripts/wrappers/upgrade.py
+++ b/scripts/wrappers/upgrade.py
@@ -142,7 +142,7 @@ def get_nodes_info(safe=True):
                         if host not in nodes.decode():
                             print("Node {} not present".format(host))
                             continue
-                        node_info = [(parts[0], parts[1])]
+                        node_info.append((parts[0], parts[1]))
         except subprocess.CalledProcessError:
             print("Error in gathering cluster node information. Upgrade aborted.")
             exit(1)
@@ -151,7 +151,7 @@ def get_nodes_info(safe=True):
             with open(callback_tokens_file, "r+") as fp:
                 for _, line in enumerate(fp):
                     parts = line.split()
-                    node_info = [(parts[0], parts[1])]
+                    node_info.append((parts[0], parts[1]))
 
     return node_info
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -435,7 +435,8 @@ then
   snapctl restart ${SNAP_NAME}.daemon-proxy
 fi
 
-if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ]
+if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
+   [ -e "${SNAP_DATA}/var/lock/ha-cluster" ]
 then
   echo "Setting up the CNI"
   start_timer="$(date +%s)"

--- a/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
@@ -35,21 +35,23 @@ then
   init_cluster
 fi
 
-snapctl start microk8s.daemon-etcd
 snapctl start microk8s.daemon-apiserver
 
-# TODO do some proper wait here
-sleep 15
+if is_service_expected_to_start etcd
+then
+  snapctl start microk8s.daemon-etcd
+  # TODO do some proper wait here
+  sleep 15
 
-rm -rf "$DB_DIR"
-$SNAP/bin/migrator --mode backup --endpoint "http://127.0.0.1:12379" --db-dir "$DB_DIR" --debug
-chmod 600 "$DB_DIR"
-$SNAP/bin/migrator --mode restore --endpoint "unix:///var/snap/microk8s/current/var/kubernetes/backend/kine.sock" --db-dir "$DB_DIR" --debug
+  rm -rf "$DB_DIR"
+  $SNAP/bin/migrator --mode backup --endpoint "http://127.0.0.1:12379" --db-dir "$DB_DIR" --debug
+  chmod 600 "$DB_DIR"
+  $SNAP/bin/migrator --mode restore --endpoint "unix:///var/snap/microk8s/current/var/kubernetes/backend/kine.sock" --db-dir "$DB_DIR" --debug
 
-sleep 10
-
-set_service_not_expected_to_start etcd
-snapctl stop microk8s.daemon-etcd
+  sleep 10
+  set_service_not_expected_to_start etcd
+  snapctl stop microk8s.daemon-etcd
+fi
 
 ${SNAP}/microk8s-start.wrapper
 ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30

--- a/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
+++ b/upgrade-scripts/001-switch-to-dqlite/commit-master.sh
@@ -37,7 +37,8 @@ fi
 
 snapctl start microk8s.daemon-apiserver
 
-if is_service_expected_to_start etcd
+run_etcd="$(is_service_expected_to_start etcd)"
+if [ "${run_etcd}" == "1" ]
 then
   snapctl start microk8s.daemon-etcd
   # TODO do some proper wait here


### PR DESCRIPTION
This PR addresses a few bugs on the transition of a cluster from non-HA to HA.

- If one starts an HA transition and never finishes it (calls `microk8s.enable ha-cluster` on the master node but does not transition the nodes to HA) any refreshes on the nodes will fail if they are following a 1.19+ track.
- The upgrade process was not triggered on all nodes.
- If the node we call `microk8s enable ha-cluster` was already on a non-HA cluster that gets upgraded to HA it may have etcd disabled because it may have already transitioned to dqlite. In this case we should not try to take a backup of etcd.

The workaround for all the above is after we remove the node from the cluster via `microk8s.leave` we `snap remove microk8s` and reinstall so we join a clean node.