### PR TITLE
update ingress, relocate to the new repository k8s.gcr.io

### DIFF
--- a/microk8s-resources/actions/disable.ingress.sh
+++ b/microk8s-resources/actions/disable.ingress.sh
@@ -7,20 +7,20 @@ source $SNAP/actions/common/utils.sh
 echo "Disabling Ingress"
 
 ARCH=$(arch)
-TAG="0.25.1"
+TAG="v0.35.0"
 DEFAULT_CERT="- ' '" # This default value is always fine when deleting resources.
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 
 
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 # Clean up old ingress controller resources in the default namespace, in case these are still lurking around.  
-$KUBECTL delete deployment -n default default-http-backend || true
-$KUBECTL delete service -n default default-http-backend || true
-$KUBECTL delete serviceaccount -n default nginx-ingress-microk8s-serviceaccount || true 
-$KUBECTL delete role -n default nginx-ingress-microk8s-role || true 
-$KUBECTL delete rolebinding -n default nginx-ingress-microk8s || true 
-$KUBECTL delete configmap -n default nginx-load-balancer-microk8s-conf || true
-$KUBECTL delete daemonset -n default nginx-ingress-microk8s-controller || true
+$KUBECTL delete deployment -n default default-http-backend > /dev/null 2>&1 || true
+$KUBECTL delete service -n default default-http-backend > /dev/null 2>&1 || true
+$KUBECTL delete serviceaccount -n default nginx-ingress-microk8s-serviceaccount > /dev/null 2>&1 || true 
+$KUBECTL delete role -n default nginx-ingress-microk8s-role > /dev/null 2>&1 || true 
+$KUBECTL delete rolebinding -n default nginx-ingress-microk8s > /dev/null 2>&1 || true 
+$KUBECTL delete configmap -n default nginx-load-balancer-microk8s-conf > /dev/null 2>&1 || true
+$KUBECTL delete daemonset -n default nginx-ingress-microk8s-controller > /dev/null 2>&1 || true
 
 
 declare -A map

--- a/microk8s-resources/actions/enable.ingress.sh
+++ b/microk8s-resources/actions/enable.ingress.sh
@@ -22,7 +22,7 @@ fi
 echo "Enabling Ingress"
 
 ARCH=$(arch)
-TAG="0.33.0"
+TAG="v0.35.0"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 DEFAULT_CERT="- ' '"
 

--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -1,3 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: public
+  annotations:
+      ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -150,22 +159,41 @@ spec:
         name: nginx-ingress-microk8s
     spec:
       terminationGracePeriodSeconds: 60
-      # hostPort doesn't work with CNI, so we have to use hostNetwork instead
-      # see https://github.com/kubernetes/kubernetes/issues/23920
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
       serviceAccountName: nginx-ingress-microk8s-serviceaccount
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:$TAG
+      - image: k8s.gcr.io/ingress-nginx/controller:$TAG
         name: nginx-ingress-microk8s
         livenessProbe:
           httpGet:
             path: /healthz
             port: 10254
             scheme: HTTP
-          initialDelaySeconds: 30
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
           timeoutSeconds: 5
-        # use downward API
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - /wait-shutdown
+        securityContext:
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsUser: 101 # www-data          
         env:
           - name: POD_NAME
             valueFrom:
@@ -176,12 +204,20 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
         ports:
-        - containerPort: 80
-        - containerPort: 443
+        - name: http
+          containerPort: 80
+          hostPort: 80
+        - name: https
+          containerPort: 443
+          hostPort: 443
+        - name: health
+          containerPort: 10254
+          hostPort: 10254          
         args:
         - /nginx-ingress-controller
         - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-microk8s-conf
         - --tcp-services-configmap=$(POD_NAMESPACE)/nginx-ingress-tcp-microk8s-conf
         - --udp-services-configmap=$(POD_NAMESPACE)/nginx-ingress-udp-microk8s-conf
+        - --ingress-class=public
         $DEFAULT_CERT
         $EXTRA_ARGS

--- a/tests/templates/ingress.yaml
+++ b/tests/templates/ingress.yaml
@@ -48,7 +48,7 @@ spec:
   selector:
     app: microbot
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
  name: microbot-ingress-xip
@@ -58,11 +58,14 @@ spec:
      http:
        paths:
          - path: /
+           pathType: Prefix
            backend:
-             serviceName: microbot
-             servicePort: 80
+             service:
+               name: microbot
+               port:
+                 number: 80
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
  name: microbot-ingress-nip
@@ -72,6 +75,9 @@ spec:
      http:
        paths:
          - path: /
+           pathType: Prefix
            backend:
-             serviceName: microbot
-             servicePort: 80
+             service:
+               name: microbot
+               port:
+                 number: 80


### PR DESCRIPTION
Changes:
- Nginx Ingress has a new home.  quay repository is now read only.  Last image is `0.33.0`
- Upgraded nginx ingress to `v0.35.0`
- Introduce the use of `IngressClass`
- Use `networking.k8s.io/v1`