### PR TITLE
Run containerd unconfined

### DIFF
--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -2,6 +2,11 @@
 
 set -ex
 
+# Re-exec outside of apparmor confinement
+if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" != "unconfined" ]; then
+    exec aa-exec -p unconfined -- "$0" "$@"
+fi
+
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"

--- a/tests/test-upgrade-path.py
+++ b/tests/test-upgrade-path.py
@@ -75,6 +75,7 @@ class TestUpgradePath(object):
             cmd = "sudo snap refresh microk8s --classic --channel={}".format(channel)
             run_until_success(cmd)
             wait_for_installation()
+            time.sleep(30)
             channel_minor += 1
 
         print("Installing {}".format(upgrade_to))

--- a/tests/test-upgrade-path.py
+++ b/tests/test-upgrade-path.py
@@ -82,7 +82,7 @@ class TestUpgradePath(object):
             cmd = "sudo snap install {} --classic --dangerous".format(upgrade_to)
         else:
             cmd = "sudo snap refresh microk8s --channel={}".format(upgrade_to)
-        run_until_success(cmd)
+        run_until_success(cmd, timeout_insec=300)
         # Allow for the refresh to be processed
-        time.sleep(10)
-        wait_for_installation()
+        time.sleep(20)
+        wait_for_installation(timeout_insec=600)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -118,13 +118,13 @@ def wait_for_pod_state(
         time.sleep(3)
 
 
-def wait_for_installation(cluster_nodes=1):
+def wait_for_installation(cluster_nodes=1, timeout_insec=360):
     """
     Wait for kubernetes service to appear.
     """
     while True:
         cmd = 'svc kubernetes'
-        data = kubectl_get(cmd, 300)
+        data = kubectl_get(cmd, timeout_insec)
         service = data['metadata']['name']
         if 'kubernetes' in service:
             break
@@ -133,7 +133,7 @@ def wait_for_installation(cluster_nodes=1):
 
     while True:
         cmd = 'get no'
-        nodes = kubectl(cmd, 300)
+        nodes = kubectl(cmd, timeout_insec)
         if nodes.count(' Ready') == cluster_nodes:
             break
         else:


### PR DESCRIPTION
Running containerd unconfined allows us to handle AllowPrivilegeEscallation flag correctly.

Fixes https://github.com/ubuntu/microk8s/issues/784