### PR TITLE
fix the kubepublic name to kube-public

### DIFF
--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -52,7 +52,7 @@ do
     if [ $installed_registry_help -eq 0 ] &&
        snapctl services microk8s.daemon-apiserver | grep active &> /dev/null
     then
-      if ! "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get configmap local-registry-hosting -n kubepublic &> /dev/null
+      if ! "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" get configmap local-registry-hosting -n kube-public &> /dev/null
       then
         use_manifest registry-help apply
       fi


### PR DESCRIPTION
api-service-kicker check for the local-registry if installed in `kube-public`