### PR TITLE
Try s390x build with Ubuntu's etcd

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -200,9 +200,22 @@ parts:
     plugin: dump
     source: build-scripts/
     override-build: |
-      . ./set-env-variables.sh
-      curl -LO https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-$KUBE_ARCH.tar.gz
-      tar -xzvf etcd-*.tar.gz --strip-components=1
+      set -eu
+      ARCH=$(dpkg --print-architecture)
+      # No upstream etcd s390x builds yet
+      if [ "${ARCH}" = "s390x" ]
+      then
+        curl -LO https://launchpad.net/ubuntu/+source/etcd/3.2.26+dfsg-8/+build/19387496/+files/etcd-client_3.2.26+dfsg-8_s390x.deb
+        curl -LO https://launchpad.net/ubuntu/+source/etcd/3.2.26+dfsg-8/+build/19387496/+files/etcd-server_3.2.26+dfsg-8_s390x.deb
+        dpkg-deb -x etcd-client_3.2.26+dfsg-8_s390x.deb etcd-client
+        dpkg-deb -x etcd-server_3.2.26+dfsg-8_s390x.deb etcd-server
+        mv etcd-client/usr/bin/etcdctl .
+        mv etcd-server/usr/bin/etcd .
+      else
+        . ./set-env-variables.sh
+        curl -LO https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-$KUBE_ARCH.tar.gz
+        tar -xzvf etcd-*.tar.gz --strip-components=1
+      fi
       snapcraftctl build
     stage:
       - etcd


### PR DESCRIPTION
etcd upstream doesn't build/provide s390x builds.

I've modified the part, to download/unpack/use Ubuntu's ectd to create s390x snap of microk8s. It built, but I don't know if it works at all. See the snap at https://code.launchpad.net/~xnox/+snap/xnox-microk8s-test/+build/1142929

Maybe we can cross-build exact same etcd release as a part on Ubuntu? Or is slightly different etcd ok for microk8s?
