### PR TITLE
Fix help option for inspect command

### DIFF
--- a/microk8s-resources/wrappers/microk8s.wrapper
+++ b/microk8s-resources/wrappers/microk8s.wrapper
@@ -22,7 +22,7 @@ if [ -f "${SNAP}/microk8s-${APP}.wrapper" ]; then
     "${SNAP}/microk8s-${APP}.wrapper" "$@"
     readonly EXIT="$?"
 elif [ "${APP}" == "inspect" ]; then
-    sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh
+    sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh "$@"
     readonly EXIT="$?"
 elif [ "${APP}" == "help" ] || [ "${APP}" == "--help" ] || [ "$APP" == "-h" ]; then
     help

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -247,7 +247,7 @@ function check_certificates {
 }
 
 
-if [ ${#@} -ne 0 ] && [ "${@#"--help"}" = "" ]; then
+if [ ${#@} -ne 0 ] && [ "$*" == "--help" ]; then
   print_help
   exit 0;
 fi;


### PR DESCRIPTION
_microk8s inspect --help_   doesn't invoke the help function.  The arguments aren't passed to the inspect script by the microk8s wrapper.