### PR TITLE
upgrade linkerd 2.9.0

### DIFF
--- a/microk8s-resources/actions/enable.linkerd.sh
+++ b/microk8s-resources/actions/enable.linkerd.sh
@@ -8,14 +8,16 @@ CA_CERT=/snap/core/current/etc/ssl/certs/ca-certificates.crt
 read -ra ARGUMENTS <<< "$1"
 argz=("${ARGUMENTS[@]/#/--}")
 
+ARCH=$(arch)
+
 # check if linkerd cli is already in the system.  Download if it doesn't exist.
 if [ ! -f "${SNAP_DATA}/bin/linkerd" ]; then
-  LINKERD_VERSION="${LINKERD_VERSION:-v2.8.0}"
+  LINKERD_VERSION="${LINKERD_VERSION:-v2.9.0}"
   echo "Fetching Linkerd2 version $LINKERD_VERSION."
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
   LINKERD_VERSION=$(echo $LINKERD_VERSION | sed 's/v//g')
   echo "$LINKERD_VERSION"
-  run_with_sudo "${SNAP}/usr/bin/curl" --cacert $CA_CERT -L https://github.com/linkerd/linkerd2/releases/download/stable-${LINKERD_VERSION}/linkerd2-cli-stable-${LINKERD_VERSION}-linux -o "$SNAP_DATA/bin/linkerd"
+  run_with_sudo "${SNAP}/usr/bin/curl" --cacert $CA_CERT -L https://github.com/linkerd/linkerd2/releases/download/stable-${LINKERD_VERSION}/linkerd2-cli-stable-${LINKERD_VERSION}-linux-${ARCH} -o "$SNAP_DATA/bin/linkerd"
   run_with_sudo chmod uo+x "$SNAP_DATA/bin/linkerd"
 fi
 

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -101,10 +101,11 @@ microk8s-addons:
 
     - name: "linkerd"
       description: "Linkerd is a service mesh for Kubernetes and other frameworks"
-      version: "2.7.0"
+      version: "2.9.0"
       check_status: "pod/linkerd-controller"
       supported_architectures:
       - amd64
+      - arm64
 
     - name: "cilium"
       description: "SDN, fast with full network policy"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -484,9 +484,6 @@ parts:
         rm "actions/enable.jaeger.sh"
         rm "actions/disable.jaeger.sh"
         rm -rf "actions/jaeger"
-        # Linkerd support
-        rm "actions/enable.linkerd.sh"
-        rm "actions/disable.linkerd.sh"
         # Juju support
         rm "actions/enable.juju.sh"
         rm "actions/disable.juju.sh"

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -213,9 +213,6 @@ class TestAddons(object):
         print("Disabling metrics-server")
         microk8s_disable("metrics-server")
 
-    @pytest.mark.skip(
-        "disabling the linkerd test due to https://github.com/linkerd/linkerd2/issues/4918"
-    )
     @pytest.mark.skipif(
         platform.machine() != 'x86_64',
         reason="Linkerd tests are only relevant in x86 architectures",


### PR DESCRIPTION
This upgrade now enables Linkerd on `arm64`.  I need help to test this in an `arm64` based architecture.  

See Linkerd 2.9.0 announcement [here](https://linkerd.io/2020/11/09/announcing-linkerd-2.9/)
