### PR TITLE
Do not reset multi-node clusters

### DIFF
--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -118,10 +118,10 @@ then
   exit 0
 fi
 
-NODES_NUM=$($KUBECTL get no | wc -l)
+NODES_NUM=$($KUBECTL get no -o name | wc -l)
 if [ $NODES_NUM -ge 2 ]
 then
-  echo "This is a multi-node MicroK8s deployment. Reset will reduce the cluster to a single node cluster."
+  echo "This is a multi-node MicroK8s deployment. Reset is applicable for single node clusters."
   echo "Please remove all joined nodes before calling reset."
   exit 0
 fi
@@ -158,6 +158,13 @@ while getopts ':h-:' opt; do
 
   esac
 done
+
+# Fail if there are parameters we do not expect
+if [ $(( $# - $OPTIND )) -ge 0 ]; then
+  echo "Invalid parameter" >&2
+  echo "Try '${SNAP_NAME} --help' for more information."
+  exit 2
+fi
 
 exit_if_stopped
 exit_if_no_permissions

--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -113,9 +113,19 @@ apply_cni() {
 
 if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
 then
-  echo "This MicroK8s deployment is acting as a node in a cluster. Please use the microk8s reset on the master."
+  echo "This MicroK8s deployment is acting as a node in a cluster."
+  echo "Please remove the node before calling reset."
   exit 0
 fi
+
+NODES_NUM=$($KUBECTL get no | wc -l)
+if [ $NODES_NUM -ge 2 ]
+then
+  echo "This is a multi-node MicroK8s deployment. Reset will reduce the cluster to a single node cluster."
+  echo "Please remove all joined nodes before calling reset."
+  exit 0
+fi
+
 
 destroy_storage_enabled=false
 while getopts ':h-:' opt; do

--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -7,7 +7,8 @@ source $SNAP/actions/common/utils.sh
 
 if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
 then
-  echo "This MicroK8s deployment is acting as a node in a cluster. Please use the microk8s reset on the master."
+  echo "This MicroK8s deployment is acting as a node in a cluster."
+  echo "Use 'snap start microk8s' to start services on this node."
   exit 0
 fi
 

--- a/microk8s-resources/wrappers/microk8s-stop.wrapper
+++ b/microk8s-resources/wrappers/microk8s-stop.wrapper
@@ -8,7 +8,8 @@ source $SNAP/actions/common/utils.sh
 
 if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
 then
-  echo "This MicroK8s deployment is acting as a node in a cluster. Please use the microk8s stop on the master."
+  echo "This MicroK8s deployment is acting as a node in a cluster."
+  echo "Use 'snap stop microk8s' to stop services on this node."
   exit 0
 fi
 


### PR DESCRIPTION
Works towards addressing cases similar to https://github.com/ubuntu/microk8s/issues/1748

- `microk8s reset` will not run on multinode clusters. resetting means we revert to a single node cluster and this is not the right way to bring down a multi-node cluster.
- providing more arguments on `microk8s reset` will cause the reset to fail, eg if the user does a `mcirok8s reset healp` the reset will not happen
- improve wording in error messages in clustered node.