### PR TITLE
update echo text in flannel-etcd upgrade scripts

### DIFF
--- a/upgrade-scripts/002-switch-to-flannel-etcd/commit-master.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/commit-master.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-echo "Switching master to dqlite"
+echo "Switching master to flannel-etcd"
 
 source $SNAP/actions/common/utils.sh
 CA_CERT=/snap/core/current/etc/ssl/certs/ca-certificates.crt

--- a/upgrade-scripts/002-switch-to-flannel-etcd/rollback-master.sh
+++ b/upgrade-scripts/002-switch-to-flannel-etcd/rollback-master.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-echo "Rolling back dqlite upgrade on master"
+echo "Rolling back flannel-etcd upgrade on master"
 
 source $SNAP/actions/common/utils.sh
 CA_CERT=/snap/core/current/etc/ssl/certs/ca-certificates.crt
@@ -41,4 +41,4 @@ if [ -e "$SNAP_DATA/args/cni-network/cni.yaml" ]; then
   $KUBECTL apply -f "$SNAP_DATA/args/cni-network/cni.yaml"
 fi
 
-echo "Flannle-etcd rolled back"
+echo "Flannel-etcd rolled back"


### PR DESCRIPTION
At the beginning of these scripts, the "echo" command mentions "dqlite upgrade" while they are about switching to flannel-etcd.
This seems to be a copy/paste from similar scripts in upgrade-scripts/001-switch-to-dqlite.
I also noticed a small typo at the end of `rollback-master.sh` that I fixed at the same time.

See https://github.com/ubuntu/microk8s/issues/1752

I used `flannel-etcd` instead of dqlite to update the text, in an attempt to keep it consistent with the other files. But please let me know in case there are better descriptions that would apply here.