### PR TITLE
Fix pytest dependency for xenial testing

### DIFF
--- a/tests/lxc/install-deps/ubuntu_16.04
+++ b/tests/lxc/install-deps/ubuntu_16.04
@@ -4,7 +4,7 @@ export $(grep -v '^#' /etc/environment | xargs)
 
 apt-get update
 apt-get install python3-pip docker.io -y
-pip3 install -U pytest requests pyyaml
+pip3 install -U importlib-metadata==2.1.0 pytest requests pyyaml
 # Attempting to address https://forum.snapcraft.io/t/lxd-refresh-cause-container-socket-error/8698
 # if core is to be installed by microk8s it fails
 snap install core | true


### PR DESCRIPTION
The reason pytest isn't running on xenial is because importlib-metadata doesn't support python 3.5 on pypy any longer. I've pinned the version here which fixes the issue. It's worth considering using apt packages rather than pypy when available for this very reason. I didn't make that change here, just fixed the existing setup.