### PR TITLE
Enable prometheus on arm64 architecture

### DIFF
--- a/microk8s-resources/actions/enable.prometheus.sh
+++ b/microk8s-resources/actions/enable.prometheus.sh
@@ -35,6 +35,17 @@ get_kube_prometheus () {
   fi
 }
 
+use_multiarch_images() {
+  # Use multi-arch kube-state-metrics
+  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-state-metrics:v1.9.5@gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics:v1.9.7@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
+  # use kube-rbac-proxy multi-arch
+  # This is the same image used in the master branch of kube-prometheus
+  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-rbac-proxy:v0.4.1@quay.io/brancz/kube-rbac-proxy:v0.8.0@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
+  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-rbac-proxy:v0.4.1@quay.io/brancz/kube-rbac-proxy:v0.8.0@g' ${SNAP_DATA}/kube-prometheus/manifests/node-exporter-daemonset.yaml
+  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-rbac-proxy:v0.4.1@quay.io/brancz/kube-rbac-proxy:v0.8.0@g' ${SNAP_DATA}/kube-prometheus/manifests/setup/prometheus-operator-deployment.yaml
+}
+
+
 set_replicas_to_one() {
   # alert manager must be set to 1 replica
   run_with_sudo $SNAP/bin/sed -i 's@replicas: .@replicas: 1@g' ${SNAP_DATA}/kube-prometheus/manifests/alertmanager-alertmanager.yaml
@@ -62,6 +73,7 @@ done
 do_prerequisites
 get_kube_prometheus
 set_replicas_to_one
+use_multiarch_images
 enable_prometheus
 
 echo "The Prometheus operator is enabled (user/pass: admin/admin)"

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -84,6 +84,7 @@ microk8s-addons:
       check_status: "pod/prometheus-k8s-0"
       supported_architectures:
       - amd64
+      - arm64
 
     - name: "fluentd"
       description: "Elasticsearch-Fluentd-Kibana logging and monitoring"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -470,10 +470,6 @@ parts:
         # Knative support
         rm "actions/enable.knative.sh"
         rm "actions/disable.knative.sh"
-        # Prometheus support
-        rm "actions/enable.prometheus.sh"
-        rm "actions/disable.prometheus.sh"
-        rm -rf "actions/prometheus"
         # Fluentd support
         rm "actions/enable.fluentd.sh"
         rm "actions/disable.fluentd.sh"

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -134,15 +134,15 @@ class TestAddons(object):
 
     @pytest.mark.skipif(
         platform.machine() != 'x86_64',
-        reason="Fluentd, prometheus, jaeger tests are only relevant in x86 architectures",
+        reason="Fluentd and jaeger tests are only relevant in x86 architectures",
     )
     @pytest.mark.skipif(
         os.environ.get('UNDER_TIME_PRESSURE') == 'True',
-        reason="Skipping jaeger, prometheus and fluentd tests as we are under time pressure",
+        reason="Skipping jaeger and fluentd tests as we are under time pressure",
     )
     def test_monitoring_addons(self):
         """
-        Test jaeger, prometheus and fluentd.
+        Test jaeger and fluentd.
 
         """
 
@@ -159,10 +159,6 @@ class TestAddons(object):
         print("Disabling fluentd")
         microk8s_disable("fluentd")
 
-    @pytest.mark.skipif(
-        platform.machine() != 'x86_64',
-        reason="Prometheus is only relevant in x86 architectures",
-    )
     @pytest.mark.skipif(
         os.environ.get('SKIP_PROMETHEUS') == 'True',
         reason="Skipping prometheus if it crash loops on lxd",


### PR DESCRIPTION
The enable script will use the following multi-arch images:
*  `gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics:v1.9.7` instead of `quay.io/coreos/kube-state-metrics:v1.9.5`
*  `quay.io/brancz/kube-rbac-proxy:v0.8.0` instead of `quay.io/coreos/kube-rbac-proxy:v0.4.1`

The image `quay.io/brancz/kube-rbac-proxy:v0.8.0` is also referenced now in the `kube-prometheus` master branch.  The image is referenced from the author of the kube-rbac-proxy repository.

Tested it in AWS arm EC2 and it is looking good.

```shell
ubuntu@ip-172-31-18-25:~$ uname -a
Linux ip-172-31-18-25 5.4.0-1029-aws #30-Ubuntu SMP Tue Oct 20 10:08:09 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
ubuntu@ip-172-31-18-25:~$ kubectl -n monitoring get pods -o wide
NAME                                  READY   STATUS    RESTARTS   AGE   IP             NODE              NOMINATED NODE   READINESS GATES
prometheus-operator-58fc7fbbd-rrnx8   2/2     Running   0          25m   10.1.215.41    ip-172-31-18-25   <none>           <none>
node-exporter-l8z2b                   2/2     Running   0          25m   172.31.18.25   ip-172-31-18-25   <none>           <none>
prometheus-adapter-557648f58c-2h47x   1/1     Running   0          25m   10.1.215.45    ip-172-31-18-25   <none>           <none>
kube-state-metrics-54d8bdf4db-7ndvx   3/3     Running   0          25m   10.1.215.44    ip-172-31-18-25   <none>           <none>
alertmanager-main-0                   2/2     Running   0          25m   10.1.215.42    ip-172-31-18-25   <none>           <none>
prometheus-k8s-0                      3/3     Running   1          25m   10.1.215.46    ip-172-31-18-25   <none>           <none>
grafana-7c9bc466d8-2dt2m              1/1     Running   0          25m   10.1.215.43    ip-172-31-18-25   <none>           <none>
ubuntu@ip-172-31-18-25:~$ 
```
