### PR TITLE
Do not test the upgrade of cilium

### DIFF
--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -11,7 +11,6 @@ from validators import (
     validate_metrics_server,
     validate_fluentd,
     validate_jaeger,
-    validate_cilium,
     validate_metallb_config,
 )
 from subprocess import check_call, CalledProcessError, check_output

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -151,6 +151,8 @@ class TestUpgrade(object):
             except CalledProcessError:
                 print('Will not test the jaeger addon')
 
+            # We are not testing cilium because we want to test the upgrade of the default CNI
+            """
             try:
                 enable = microk8s_enable("cilium", timeout_insec=300)
                 assert "Nothing to do for" not in enable
@@ -158,6 +160,7 @@ class TestUpgrade(object):
                 test_matrix['cilium'] = validate_cilium
             except CalledProcessError:
                 print('Will not test the cilium addon')
+            """
             try:
                 ip_ranges = (
                     "192.168.0.105-192.168.0.105,192.168.0.110-192.168.0.111,192.168.1.240/28"


### PR DESCRIPTION
Tow reasons for this:
- We want to test the upgrade of the default CNI as this is what most people will have
- Cilium introduces some flakiness in our tests