### PR TITLE
Limit scope of containerd part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -317,15 +317,14 @@ parts:
   containerd:
     build-snaps: [go]
     after: [iptables]
-    source: .
-    source-type: git
+    source: build-scripts/
     plugin: dump
     build-packages:
     - btrfs-tools
     - libseccomp-dev
     override-build: |
       set -eux
-      . $SNAPCRAFT_PROJECT_DIR/build-scripts/set-env-variables.sh
+      . $SNAPCRAFT_PART_SRC/set-env-variables.sh
       snap refresh go --channel=1.15/stable || true
       go version
       export GOPATH=$(realpath ../go)

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -356,6 +356,24 @@ class TestAddons(object):
         print("Disabling traefik")
         microk8s_disable("traefik")
 
+    @pytest.mark.skipif(
+        platform.machine() != 'x86_64', reason="KEDA tests are only relevant in x86 architectures"
+    )
+    @pytest.mark.skipif(
+        os.environ.get('UNDER_TIME_PRESSURE') == 'True',
+        reason="Skipping KEDA tests as we are under time pressure",
+    )
+    def test_keda(self):
+        """
+        Sets up and validates keda.
+        """
+        print("Enabling keda")
+        microk8s_enable("keda")
+        print("Validating keda")
+        validate_keda()
+        print("Disabling keda")
+        microk8s_disable("keda")
+
 
 @pytest.mark.addon_args
 def test_invalid_addon():


### PR DESCRIPTION
Otherwise, it pulls in a version of files such as `enable.kubeflow.sh` that conflicts with what is sitting in the git repo.

For example:

```
Failed to stage: Parts 'containerd' and 'microk8s' have the following files, but with different contents:
    microk8s-resources/actions/enable.kubeflow.sh

Snapcraft offers some capabilities to solve this by use of the following keywords:
    - `filesets`
    - `stage`
    - `snap`
    - `organize`

To learn more about these part keywords, run `snapcraft help plugins`.
```