### PR TITLE
Adds a description for the dbctl command.

### DIFF
--- a/installer/common/definitions.py
+++ b/installer/common/definitions.py
@@ -6,6 +6,7 @@ command_descriptions = {
     'config': "Print the kubeconfig",
     'ctr': "The containerd client",
     'dashboard-proxy': "Enable the Kubernetes dashboard and proxy to host",
+    'dbctl': "Backup and restore the Kubernetes datastore",
     'disable': "Disables running add-ons",
     'enable': "Enables useful add-ons",
     'helm': "The helm client",


### PR DESCRIPTION
I was browsing through the `microk8s --help` commands and couldn't find an entry for dbctl: 

```
$ microk8s --help
Usage: microk8s [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  install         Installs MicroK8s. Use --cpu, --mem, --disk and --channel to configure your setup.
  uninstall       Removes MicroK8s
  add-node        Adds a node to a cluster
  cilium          The cilium client
  config          Print the kubeconfig
  ctr             The containerd client
  dashboard-proxy Enable the Kubernetes dashboard and proxy to host
  dbctl
  disable         Disables running add-ons
  enable          Enables useful add-ons
  helm            The helm client
  helm3           The helm3 client
  inspect         Checks the cluster and gathers logs
  istioctl        The istio client
  join            Joins this instance as a node to a cluster
  juju            The Juju client
  kubectl         The kubernetes client
  leave           Disconnects this node from any cluster it has joined
  linkerd         The linkerd client
  refresh-certs   Refresh the CA certificates in this deployment
  remove-node     Removes a node from the cluster
  reset           Cleans the cluster from all workloads
  start           Starts the kubernetes cluster
  status          Displays the status of the cluster
  stop            Stops the kubernetes cluster
```

Versions:
```
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.14.6
BuildVersion:	18G6042
$ multipass --version
multipass  1.3.0+mac
multipassd 1.3.0+mac
$ microk8s --version
sudo: microk8s.--version: command not found
;-)
```
