### PR TITLE
Bump default Windows install track to 1.20/stable

### DIFF
--- a/installer/windows/microk8s.nsi
+++ b/installer/windows/microk8s.nsi
@@ -146,7 +146,7 @@ Function "ConfigureVm"
         ${NSD_CreateLabel} 42% 50 50u 10u "Snap Track"
         Pop $VmConfigureDialogTrackLabel
 
-        ${NSD_CreateText} 42% 67.5 50u 10u "1.18/stable"
+        ${NSD_CreateText} 42% 67.5 50u 10u "1.20/stable"
         Pop $VmConfigureDialogTrack
 
         ${NSD_CreateLabel} 8% 102.5 100% 10u "These are the minimum recommended parameters for the VM running ${PRODUCT_NAME}"


### PR DESCRIPTION
Maybe we can find a way to do this automatically?