### PR TITLE
Fix brew cask deprecation warning

### DIFF
--- a/installer/vm_providers/_multipass/_multipass_command.py
+++ b/installer/vm_providers/_multipass/_multipass_command.py
@@ -103,14 +103,14 @@ class MultipassCommand:
             install_snaps(["multipass/latest/stable"])
         elif platform == "darwin":
             try:
-                subprocess.check_call(["brew", "cask", "install", "multipass"])
+                subprocess.check_call(["brew", "install", "multipass", "--cask"])
             except subprocess.CalledProcessError:
                 raise errors.ProviderStartError(
                     provider_name=cls.provider_name,
                     error_message="Failed to install multipass using homebrew.\n"
                     "Verify your homebrew installation and try again.\n"
                     "Alternatively, manually install multipass by running"
-                    " 'brew cask install multipass'.",
+                    " 'brew install multipass --cask'.",
                 )
         elif platform == "win32":
             windows_install_multipass(echoer)


### PR DESCRIPTION
During initial install on macOS, if 'multipass' is not installed:

```
➜  ~ microk8s install
Support for 'multipass' needs to be set up. Would you like to do that it now? [y/N]: y
Updating Homebrew...
Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.
```