### PR TITLE
Fixes #1829

### DIFF
--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -87,7 +87,7 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - ingress-controller-leader-nginx
+  - ingress-controller-leader-public
   verbs:
   - create
   - update


### PR DESCRIPTION
The resourceName has changed from `ingress-controller-leader-nginx` to `ingress-controller-leader-public`.  This only happens when `RBAC` is enabled.