### PR TITLE
Use apiserver readyz endpoint 

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -589,3 +589,12 @@ function update_configs {
   $SNAP/microk8s-stop.wrapper || true
   $SNAP/microk8s-start.wrapper
 }
+
+is_apiserver_ready() {
+  if (${SNAP}/usr/bin/curl -L --cert ${SNAP_DATA}/certs/server.crt --key ${SNAP_DATA}/certs/server.key --cacert ${SNAP_DATA}/certs/ca.crt https://127.0.0.1:16443/readyz | grep -z "ok") &> /dev/null
+  then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -52,7 +52,7 @@ do
        ! [ -e "${SNAP_DATA}/var/lock/cni-loaded" ]
     then
       echo "Setting up the CNI"
-      if (${SNAP}/usr/bin/curl -L --cert ${SNAP_DATA}/certs/server.crt --key ${SNAP_DATA}/certs/server.key --cacert ${SNAP_DATA}/certs/ca.crt https://127.0.0.1:16443/readyz | grep -z "ok") &&
+      if (is_apiserver_ready)  &&
          "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" apply -f "${SNAP_DATA}/args/cni-network/cni.yaml"
       then
         touch "${SNAP_DATA}/var/lock/cni-loaded"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -463,7 +463,7 @@ then
   # TODO: this polling is not good enough. We should find a new way to ensure the apiserver is up.
   timeout="120"
   KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
-  while ! ($KUBECTL get all --all-namespaces | grep -z "service/kubernetes") &> /dev/null
+  while ! (is_apiserver_ready) 
   do
     sleep 5
     now="$(date +%s)"
@@ -475,7 +475,8 @@ then
   # if the API server came up try to load the CNI manifest
   now="$(date +%s)"
   if [[ "$now" < "$(($start_timer + $timeout))" ]] ; then
-    if $KUBECTL apply -f "${SNAP_DATA}/args/cni-network/cni.yaml"
+    if (is_apiserver_ready) &&
+        $KUBECTL apply -f "${SNAP_DATA}/args/cni-network/cni.yaml" 
     then
       touch "${SNAP_DATA}/var/lock/cni-loaded"
     fi


### PR DESCRIPTION
In the  `configure` hook of snap, use the `readyz` endpoint to if apiserver is ready.
Fixes: #1831