### PR TITLE
Hotfix: remove redundant requirements to fix brew install

### DIFF
--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -1,6 +1,5 @@
 urllib3==1.24.2
 click~=7.0
-jsonschema==2.5.1
 progressbar33==2.4
 requests==2.20.0
 requests_unixsocket==0.1.5

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -7,7 +7,5 @@ requests_unixsocket==0.1.5
 pysha3==1.0.2; python_version < '3.6'
 simplejson==3.8.2
 toml==0.10.0
-wheel
 pyinstaller
-setuptools<45.0.0  # https://github.com/pypa/setuptools/issues/1963
 https://pyyaml.org/download/pyyaml/PyYAML-5.3.1-cp38-cp38-win_amd64.whl; sys_platform == 'win32'

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -11,7 +11,6 @@ setup(
     packages=['cli', 'common', 'vm_providers', 'vm_providers._multipass', 'vm_providers.repo'],
     install_requires=[
         'click~=7.0',
-        'jsonschema==2.5.1',
         'progressbar33==2.4',
         'requests==2.20.0',
         'requests_unixsocket==0.1.5',

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -10,7 +10,6 @@ setup(
     description='MicroK8s is a small, fast, single-package Kubernetes for developers, IoT and edge',
     packages=['cli', 'common', 'vm_providers', 'vm_providers._multipass', 'vm_providers.repo'],
     install_requires=[
-        'setuptools',
         'click~=7.0',
         'jsonschema==2.5.1',
         'progressbar33==2.4',
@@ -19,7 +18,6 @@ setup(
         'simplejson==3.8.2',
         'toml==0.10.0',
         'urllib3==1.24.2',
-        'wheel',
     ],
     platforms='any',
     entry_points={


### PR DESCRIPTION
Fixing https://github.com/ubuntu/microk8s/issues/1882

With the release of Python 3.9.1 via brew, a (luckily no longer used) dependency was failing to build.  I have removed that and MicroK8s now builds on macOS Big Sur and Catalina (see https://github.com/ubuntu/homebrew-microk8s/runs/1684157733, note that the jobs fail but that's after MicroK8s is installed).

Note this is live already due to https://github.com/ubuntu/homebrew-microk8s/blob/master/Formula/microk8s.rb already pointing to the installer-2.0.3 tag.
