### PR TITLE
Bundle kubectl with Windows installer and set kubectl as brew requirement for MacOS

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -43,6 +43,12 @@ jobs:
         file-url: https://github.com/canonical/multipass/releases/download/v1.5.0/multipass-1.5.0+win-win64.exe
         file-name: multipass.exe
         location: ${{ github.workspace }}/installer/windows
+    - name: Download kubectl
+      uses: carlosperate/download-file-action@v1.0.3
+      with:
+        file-url: https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/windows/amd64/kubectl.exe
+        file-name: kubectl.exe
+        location: ${{ github.workspace }}/installer/windows
     - name: Create installer
       run: makensis.exe ${{ github.workspace }}/installer/windows/microk8s.nsi
     - name: Upload installer

--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -207,6 +207,8 @@ def kubectl(args) -> int:
         return Windows(args).kubectl()
     if platform == "darwin":
         return MacOS(args).kubectl()
+    else:
+        return Linux(args).kubectl()
 
 
 def dashboard_proxy() -> None:

--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -165,7 +165,7 @@ def install(args) -> None:
             raise provider_error
 
     instance = vm_provider_class(echoer=echo)
-    instance.launch_instance(vars(args))
+    instance.launch_instance(vars(args).update({"kubeconfig": aux.get_kubectl_directory()}))
     echo.info("MicroK8s is up and running. See the available commands with `microk8s --help`.")
 
 

--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -50,6 +50,9 @@ def cli(ctx, help):
             run(ctx.args)
             stop()
             exit(0)
+        elif ctx.args[0] == "kubectl":
+            kubectl(ctx.args[1:])
+            exit()
         elif ctx.args[0] == "dashboard-proxy":
             dashboard_proxy()
             exit(0)
@@ -189,6 +192,13 @@ def uninstall() -> None:
     instance = vm_provider_class(echoer=echo)
     instance.destroy()
     echo.info("Thank you for using MicroK8s!")
+
+
+def kubectl(args) -> None:
+    if platform == "win32":
+        Windows(args).kubectl()
+    if platform == "darwin":
+        MacOS(args).kubectl()
 
 
 def dashboard_proxy() -> None:

--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -165,7 +165,9 @@ def install(args) -> None:
             raise provider_error
 
     instance = vm_provider_class(echoer=echo)
-    instance.launch_instance(vars(args).update({"kubeconfig": aux.get_kubectl_directory()}))
+    spec = vars(args)
+    spec.update({"kubeconfig": aux.get_kubectl_directory()})
+    instance.launch_instance(spec)
     echo.info("MicroK8s is up and running. See the available commands with `microk8s --help`.")
 
 

--- a/installer/cli/microk8s.py
+++ b/installer/cli/microk8s.py
@@ -51,8 +51,7 @@ def cli(ctx, help):
             stop()
             exit(0)
         elif ctx.args[0] == "kubectl":
-            kubectl(ctx.args[1:])
-            exit()
+            exit(kubectl(ctx.args[1:]))
         elif ctx.args[0] == "dashboard-proxy":
             dashboard_proxy()
             exit(0)
@@ -196,11 +195,11 @@ def uninstall() -> None:
     echo.info("Thank you for using MicroK8s!")
 
 
-def kubectl(args) -> None:
+def kubectl(args) -> int:
     if platform == "win32":
-        Windows(args).kubectl()
+        return Windows(args).kubectl()
     if platform == "darwin":
-        MacOS(args).kubectl()
+        return MacOS(args).kubectl()
 
 
 def dashboard_proxy() -> None:

--- a/installer/common/auxiliary.py
+++ b/installer/common/auxiliary.py
@@ -11,23 +11,6 @@ from shutil import disk_usage
 logger = logging.getLogger(__name__)
 
 
-def get_kubectl_directory() -> str:
-    """
-    Get the correct directory to put the kubeconfig
-    file in.  This is then read by the installed
-    kubectl and won't interfere with one in the user's
-    home.
-
-    :return: None
-    """
-    if getattr(sys, "frozen", None):
-        d =  os.path.dirname(sys.executable)
-    else:
-        d = os.path.dirname(os.path.abspath(__file__))
-
-    return os.path.join(d, "kubectl")
-
-
 class Auxiliary(ABC):
     """
     Base OS auxiliary class.
@@ -62,13 +45,29 @@ class Auxiliary(ABC):
         """
         return self._free_space() > self.minimum_disk
 
+    def get_kubectl_directory(self) -> str:
+        """
+        Get the correct directory to put the kubeconfig
+        file in.  This is then read by the installed
+        kubectl and won't interfere with one in the user's
+        home.
+
+        :return: None
+        """
+        if getattr(sys, "frozen", None):
+            d =  os.path.dirname(sys.executable)
+        else:
+            d = os.path.dirname(os.path.abspath(__file__))
+
+        return os.path.join(d, "kubectl")
+
     def kubectl(self) -> None:
         """
         Run kubectl on the host, with the generated kubeconf.
 
         :return: None
         """
-        kctl_dir = get_kubectl_directory()
+        kctl_dir = self.get_kubectl_directory()
         subprocess.check_output(
             [
                 os.path.join(kctl_dir, "kubectl.exe"),

--- a/installer/common/auxiliary.py
+++ b/installer/common/auxiliary.py
@@ -2,9 +2,8 @@ import ctypes
 import logging
 import os
 import subprocess
-import sys
 
-from abc import ABC, abstractclassmethod
+from abc import ABC
 from os.path import realpath
 from shutil import disk_usage
 

--- a/installer/common/auxiliary.py
+++ b/installer/common/auxiliary.py
@@ -67,6 +67,7 @@ class Auxiliary(ABC):
 
         :return: None
         """
+        import pdb; pdb.set_trace()
         kctl_dir = self.get_kubectl_directory()
         subprocess.check_output(
             [

--- a/installer/common/auxiliary.py
+++ b/installer/common/auxiliary.py
@@ -61,20 +61,22 @@ class Auxiliary(ABC):
 
         return os.path.join(d, "kubectl")
 
-    def kubectl(self) -> None:
+    def kubectl(self) -> int:
         """
         Run kubectl on the host, with the generated kubeconf.
 
         :return: None
         """
-        import pdb; pdb.set_trace()
         kctl_dir = self.get_kubectl_directory()
-        subprocess.check_output(
-            [
-                os.path.join(kctl_dir, "kubectl.exe"),
-                "--kubeconfig={}".format(os.path.join(kctl_dir, "config"))
-            ] + self._args
-        )
+        try:
+            exit_code = subprocess.check_call(
+                [
+                    os.path.join(kctl_dir, "kubectl.exe"),
+                    "--kubeconfig={}".format(os.path.join(kctl_dir, "config"))
+                ] + self._args,
+            )
+        finally:
+            return exit_code
 
 
 class Windows(Auxiliary):

--- a/installer/common/auxiliary.py
+++ b/installer/common/auxiliary.py
@@ -68,7 +68,6 @@ class Auxiliary(ABC):
         """
         return get_kubeconfig_path()
 
-
     def kubectl(self) -> int:
         """
         Run kubectl on the host, with the generated kubeconf.
@@ -80,11 +79,12 @@ class Auxiliary(ABC):
             exit_code = subprocess.check_call(
                 [
                     os.path.join(kctl_dir, "kubectl"),
-                    "--kubeconfig={}".format(self.get_kubeconfig_path())
-                ] + self._args,
+                    "--kubeconfig={}".format(self.get_kubeconfig_path()),
+                ]
+                + self._args,
             )
         except subprocess.CalledProcessError as e:
-            return(e.returncode)
+            return e.returncode
         else:
             return exit_code
 

--- a/installer/common/auxiliary.py
+++ b/installer/common/auxiliary.py
@@ -75,7 +75,9 @@ class Auxiliary(ABC):
                     "--kubeconfig={}".format(os.path.join(kctl_dir, "config"))
                 ] + self._args,
             )
-        finally:
+        except subprocess.CalledProcessError as e:
+            return(e.returncode)
+        else:
             return exit_code
 
 

--- a/installer/common/auxiliary.py
+++ b/installer/common/auxiliary.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractclassmethod
 from os.path import realpath
 from shutil import disk_usage
 
-from .file_utils import get_kubeconfig_path
+from .file_utils import get_kubeconfig_path, get_kubectl_directory
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +55,7 @@ class Auxiliary(ABC):
 
         :return: String
         """
-        if getattr(sys, "frozen", None):
-            d =  os.path.dirname(sys.executable)
-        else:
-            d = os.path.dirname(os.path.abspath(__file__))
-
-        return os.path.join(d, "kubectl")
+        return get_kubectl_directory()
 
     def get_kubeconfig_path(self) -> str:
         """
@@ -84,7 +79,7 @@ class Auxiliary(ABC):
         try:
             exit_code = subprocess.check_call(
                 [
-                    os.path.join(kctl_dir, "kubectl.exe"),
+                    os.path.join(kctl_dir, "kubectl"),
                     "--kubeconfig={}".format(self.get_kubeconfig_path())
                 ] + self._args,
             )

--- a/installer/common/file_utils.py
+++ b/installer/common/file_utils.py
@@ -96,6 +96,7 @@ def get_kubeconfig_path():
 
 def clear_kubeconfig():
     """Clean kubeconfig file."""
-    shutil.rmtree(
-        os.path.dirname(get_kubeconfig_path())
-    )
+    if os.path.isdir(get_kubeconfig_path()):
+        shutil.rmtree(
+            os.path.dirname(get_kubeconfig_path())
+        )

--- a/installer/common/file_utils.py
+++ b/installer/common/file_utils.py
@@ -68,7 +68,7 @@ def get_kubectl_directory() -> str:
     """
     if sys.platform == "win32":
         if getattr(sys, "frozen", None):
-            d =  os.path.dirname(sys.executable)
+            d = os.path.dirname(sys.executable)
         else:
             d = os.path.dirname(os.path.abspath(__file__))
 
@@ -81,22 +81,12 @@ def get_kubectl_directory() -> str:
 def get_kubeconfig_path():
     """Return a MicroK8s specific kubeconfig path."""
     if sys.platform == "win32":
-        return os.path.join(
-            os.environ.get('LocalAppData'),
-            "MicroK8s",
-            "config"
-        )
+        return os.path.join(os.environ.get('LocalAppData'), "MicroK8s", "config")
     else:
-        return os.path.join(
-            os.path.expanduser('~'),
-            ".microk8s",
-            "config"
-        )
+        return os.path.join(os.path.expanduser('~'), ".microk8s", "config")
 
 
 def clear_kubeconfig():
     """Clean kubeconfig file."""
     if os.path.isdir(get_kubeconfig_path()):
-        shutil.rmtree(
-            os.path.dirname(get_kubeconfig_path())
-        )
+        shutil.rmtree(os.path.dirname(get_kubeconfig_path()))

--- a/installer/common/file_utils.py
+++ b/installer/common/file_utils.py
@@ -67,14 +67,12 @@ def get_kubeconfig_path():
     else:
         return os.path.join(
             os.path.expanduser('~'),
-            ".microk8s.kubeconfig"
+            ".microk8s",
+            "config"
         )
 
 def clear_kubeconfig():
     """Clean kubeconfig file."""
-    if sys.platform == "win32":
-        shutil.rmtree(
-            os.path.dirname(get_kubeconfig_path())
-        )
-    else:
-        os.remove(get_kubeconfig_path())
+    shutil.rmtree(
+        os.path.dirname(get_kubeconfig_path())
+    )

--- a/installer/common/file_utils.py
+++ b/installer/common/file_utils.py
@@ -17,6 +17,7 @@
 import hashlib
 import logging
 import os
+import shutil
 import sys
 
 if sys.version_info < (3, 6):
@@ -54,3 +55,26 @@ def is_dumb_terminal():
     is_stdout_tty = os.isatty(1)
     is_term_dumb = os.environ.get("TERM", "") == "dumb"
     return not is_stdout_tty or is_term_dumb
+
+def get_kubeconfig_path():
+    """Return a MicroK8s specific kubeconfig path."""
+    if sys.platform == "win32":
+        return os.path.join(
+            os.environ.get('LocalAppData'),
+            "MicroK8s",
+            "config"
+        )
+    else:
+        return os.path.join(
+            os.path.expanduser('~'),
+            ".microk8s.kubeconfig"
+        )
+
+def clear_kubeconfig():
+    """Clean kubeconfig file."""
+    if sys.platform == "win32":
+        shutil.rmtree(
+            os.path.dirname(get_kubeconfig_path())
+        )
+    else:
+        os.remove(get_kubeconfig_path())

--- a/installer/common/file_utils.py
+++ b/installer/common/file_utils.py
@@ -18,7 +18,6 @@ import hashlib
 import logging
 import os
 import shutil
-import subprocess
 import sys
 
 if sys.version_info < (3, 6):

--- a/installer/common/file_utils.py
+++ b/installer/common/file_utils.py
@@ -18,6 +18,7 @@ import hashlib
 import logging
 import os
 import shutil
+import subprocess
 import sys
 
 if sys.version_info < (3, 6):
@@ -56,6 +57,27 @@ def is_dumb_terminal():
     is_term_dumb = os.environ.get("TERM", "") == "dumb"
     return not is_stdout_tty or is_term_dumb
 
+
+def get_kubectl_directory() -> str:
+    """
+    Get the correct directory to install kubectl into,
+    we can then call this when running `microk8s kubectl`
+    without interfering with any systemwide install.
+
+    :return: String
+    """
+    if sys.platform == "win32":
+        if getattr(sys, "frozen", None):
+            d =  os.path.dirname(sys.executable)
+        else:
+            d = os.path.dirname(os.path.abspath(__file__))
+
+        return os.path.join(d, "kubectl")
+    else:
+        full_path = shutil.which("kubectl")
+        return os.path.dirname(full_path)
+
+
 def get_kubeconfig_path():
     """Return a MicroK8s specific kubeconfig path."""
     if sys.platform == "win32":
@@ -70,6 +92,7 @@ def get_kubeconfig_path():
             ".microk8s",
             "config"
         )
+
 
 def clear_kubeconfig():
     """Clean kubeconfig file."""

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -24,6 +24,7 @@ from typing import Dict
 from typing import Optional, Sequence
 
 from . import errors
+from ..common.auxiliary import get_kubectl_directory
 from ._multipass._instance_info import InstanceInfo
 
 logger = logging.getLogger(__name__)
@@ -157,13 +158,11 @@ class Provider(abc.ABC):
                 raise
 
     def _copy_kubeconfig_to_kubectl(self):
-        if getattr(sys, "frozen", False):
-            install_directory = os.path.dirname(sys.executable)
-        else:
-            install_directory = os.path.dirname(os.path.abspath(__file__))
+        kubeconfig_dir = get_kubectl_directory()
         kubeconfig = self.run(command=["microk8s", "config"], hide_output=True)
+
         if sys.platform == "win32":
-            with open(os.path.join(install_directory, "kubectl", "config"), "wb") as f:
+            with open(os.path.join(kubeconfig_dir, "config"), "wb") as f:
                 f.write(kubeconfig)
         if sys.platform == "darwin":
             pass  # TODO

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -157,9 +157,11 @@ class Provider(abc.ABC):
                 raise
 
     def _copy_kubeconfig_to_kubectl(self):
-        install_directory = os.path.basename(os.path.abspath(__file__))
+        if getattr(sys, "frozen", False):
+            install_directory = os.path.basename(sys.executable)
+        else:
+            install_directory = os.path.basename(os.path.abspath(__file__))
         kubeconfig = self.run(command=["microk8s", "config"], hide_output=True)
-        import pdb; pdb.set_trace()
         if sys.platform == "win32":
             with open(os.path.join(install_directory, "kubectl", "config"), "w") as f:
                 f.write(kubeconfig)

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -154,7 +154,6 @@ class Provider(abc.ABC):
         with open(kubeconfig_path, "wb") as f:
             f.write(kubeconfig)
 
-
     def _setup_microk8s(self, specs: Dict) -> None:
         self.run("snap install microk8s --classic --channel {}".format(specs['channel']).split())
         if sys.platform == "win32":

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -24,7 +24,6 @@ from typing import Dict
 from typing import Optional, Sequence
 
 from . import errors
-from ..common.auxiliary import get_kubectl_directory
 from ._multipass._instance_info import InstanceInfo
 
 logger = logging.getLogger(__name__)
@@ -136,7 +135,7 @@ class Provider(abc.ABC):
             self._check_connectivity()
             # We need to setup MicroK8s and scan for cli commands
             self._setup_microk8s(specs)
-            self._copy_kubeconfig_to_kubectl()
+            self._copy_kubeconfig_to_kubectl(specs)
 
     def _check_connectivity(self) -> None:
         """Check that the VM can access the internet."""
@@ -157,8 +156,8 @@ class Provider(abc.ABC):
             else:
                 raise
 
-    def _copy_kubeconfig_to_kubectl(self):
-        kubeconfig_dir = get_kubectl_directory()
+    def _copy_kubeconfig_to_kubectl(self, specs: Dict):
+        kubeconfig_dir = specs.get("kubeconfig")
         kubeconfig = self.run(command=["microk8s", "config"], hide_output=True)
 
         if sys.platform == "win32":

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -158,9 +158,9 @@ class Provider(abc.ABC):
 
     def _copy_kubeconfig_to_kubectl(self):
         if getattr(sys, "frozen", False):
-            install_directory = os.path.basename(sys.executable)
+            install_directory = os.path.dirname(sys.executable)
         else:
-            install_directory = os.path.basename(os.path.abspath(__file__))
+            install_directory = os.path.dirname(os.path.abspath(__file__))
         kubeconfig = self.run(command=["microk8s", "config"], hide_output=True)
         if sys.platform == "win32":
             with open(os.path.join(install_directory, "kubectl", "config"), "w") as f:

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -163,7 +163,7 @@ class Provider(abc.ABC):
             install_directory = os.path.dirname(os.path.abspath(__file__))
         kubeconfig = self.run(command=["microk8s", "config"], hide_output=True)
         if sys.platform == "win32":
-            with open(os.path.join(install_directory, "kubectl", "config"), "w") as f:
+            with open(os.path.join(install_directory, "kubectl", "config"), "wb") as f:
                 f.write(kubeconfig)
         if sys.platform == "darwin":
             pass  # TODO

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -148,9 +148,8 @@ class Provider(abc.ABC):
         kubeconfig_path = specs.get("kubeconfig")
         kubeconfig = self.run(command=["microk8s", "config"], hide_output=True)
 
-        if sys.platform == "win32":  # We don't want to make $HOME for *nix systems.
-            if not os.path.isdir(os.path.dirname(kubeconfig_path)):
-                os.mkdir(os.path.dirname(kubeconfig_path))
+        if not os.path.isdir(os.path.dirname(kubeconfig_path)):
+            os.mkdir(os.path.dirname(kubeconfig_path))
 
         with open(kubeconfig_path, "wb") as f:
             f.write(kubeconfig)

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -158,7 +158,8 @@ class Provider(abc.ABC):
 
     def _copy_kubeconfig_to_kubectl(self):
         install_directory = os.path.basename(os.path.abspath(__file__))
-        kubeconfig = self.run("microk8s config".split())
+        kubeconfig = self._run(command=["microk8s", "config"], hide_output=True)
+        import pdb; pdb.set_trace()
         if sys.platform == "win32":
             with open(os.path.join(install_directory, "kubectl", "config"), "w") as f:
                 f.write(kubeconfig)

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -158,7 +158,7 @@ class Provider(abc.ABC):
 
     def _copy_kubeconfig_to_kubectl(self):
         install_directory = os.path.basename(os.path.abspath(__file__))
-        kubeconfig = self.run("microk8s config")
+        kubeconfig = self.run("microk8s config".split())
         if sys.platform == "win32":
             with open(os.path.join(install_directory, "kubectl", "config"), "w") as f:
                 f.write(kubeconfig)

--- a/installer/vm_providers/_base_provider.py
+++ b/installer/vm_providers/_base_provider.py
@@ -158,7 +158,7 @@ class Provider(abc.ABC):
 
     def _copy_kubeconfig_to_kubectl(self):
         install_directory = os.path.basename(os.path.abspath(__file__))
-        kubeconfig = self._run(command=["microk8s", "config"], hide_output=True)
+        kubeconfig = self.run(command=["microk8s", "config"], hide_output=True)
         import pdb; pdb.set_trace()
         if sys.platform == "win32":
             with open(os.path.join(install_directory, "kubectl", "config"), "w") as f:
@@ -196,7 +196,7 @@ class Provider(abc.ABC):
             return self._cached_home_directory
 
         command = ["printenv", "HOME"]
-        run_output = self._run(command=command, hide_output=True)
+        run_output = self.run(command=command, hide_output=True)
 
         # Shouldn't happen, but due to _run()'s return type as being Optional,
         # we need to check for it anyways for mypy.

--- a/installer/vm_providers/_multipass/_multipass.py
+++ b/installer/vm_providers/_multipass/_multipass.py
@@ -128,10 +128,10 @@ class Multipass(Provider):
         self._multipass_cmd = MultipassCommand(platform=sys.platform)
         self._instance_info: Optional[InstanceInfo] = None
 
-    def create(self) -> None:
+    def create(self, specs: Dict) -> None:
         """Create the multipass instance and setup the build environment."""
         self.echoer.info("Launching a VM.")
-        self.launch_instance()
+        self.launch_instance(specs)
         self._instance_info = self._get_instance_info()
 
     def destroy(self) -> None:
@@ -151,16 +151,16 @@ class Multipass(Provider):
         # TODO add instance check.
 
         # check if file exists in instance
-        self._run(command=["test", "-f", name])
+        self.run(command=["test", "-f", name])
 
         # copy file from instance
         source = "{}:{}".format(self.instance_name, name)
         self._multipass_cmd.copy_files(source=source, destination=destination)
         if delete:
-            self._run(command=["rm", name])
+            self.run(command=["rm", name])
 
     def shell(self) -> None:
-        self._run(command=["/bin/bash"])
+        self.run(command=["/bin/bash"])
 
     def _get_instance_info(self) -> InstanceInfo:
         instance_info_raw = self._multipass_cmd.info(

--- a/installer/windows/microk8s.nsi
+++ b/installer/windows/microk8s.nsi
@@ -190,10 +190,14 @@ Section "Uninstall"
     ExecWait "$INSTDIR\microk8s.exe uninstall"
     Delete $INSTDIR\uninstall.exe
     Delete $INSTDIR\microk8s.exe
+    Delete $INSTDIR\kubectl\kubectl.exe
+    Delete $INSTDIR\kubectl\config
+    RMDir $INSTDIR\kubectl
     RMDir $INSTDIR
 
     DeleteRegKey HKLM \
         "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 
     EnVar::DeleteValue "path" "$INSTDIR"
+    EnVar::DeleteValue "path" "$INSTDIR\kubectl"
 SectionEnd

--- a/installer/windows/microk8s.nsi
+++ b/installer/windows/microk8s.nsi
@@ -4,7 +4,7 @@
 !include "Sections.nsh"
 
 !define PRODUCT_NAME "MicroK8s"
-!define PRODUCT_VERSION "2.0.0"
+!define PRODUCT_VERSION "2.1.0"
 !define PRODUCT_PUBLISHER "Canonical"
 !define MUI_ICON ".\microk8s.ico"
 !define MUI_HEADERIMAGE

--- a/installer/windows/microk8s.nsi
+++ b/installer/windows/microk8s.nsi
@@ -103,9 +103,14 @@ Section "Add 'microk8s' to PATH" add_to_path_id
     EnVar::AddValue "path" "$INSTDIR"
 SectionEnd
 
+Section /o "Add 'kubectl' to PATH" add_kubectl_to_path_id
+    EnVar::AddValue "path" "$INSTDIR\kubectl"
+SectionEnd
+
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
     !insertmacro MUI_DESCRIPTION_TEXT ${multipass_id} "REQUIRED: If already installed, will be unticked and skipped.$\n$\nSee https://multipass.run for more."
     !insertmacro MUI_DESCRIPTION_TEXT ${add_to_path_id} "Add the 'microk8s' executable to PATH.$\n$\nThis will allow you to run the command 'microk8s' in cmd and PowerShell in any directory."
+    !insertmacro MUI_DESCRIPTION_TEXT ${add_kubectl_to_path_id} "Add the 'kubectl' executable to PATH.$\n$\nThis will set the bundled 'kubectl' as system default."
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 Function .onInit

--- a/installer/windows/microk8s.nsi
+++ b/installer/windows/microk8s.nsi
@@ -191,7 +191,6 @@ Section "Uninstall"
     Delete $INSTDIR\uninstall.exe
     Delete $INSTDIR\microk8s.exe
     Delete $INSTDIR\kubectl\kubectl.exe
-    Delete $INSTDIR\kubectl\config
     RMDir $INSTDIR\kubectl
     RMDir $INSTDIR
 

--- a/installer/windows/microk8s.nsi
+++ b/installer/windows/microk8s.nsi
@@ -71,6 +71,17 @@ Section "Multipass (Required)" multipass_id
     endMultipass:
 SectionEnd
 
+Section "Kubectl (Required)" kubectl_id
+    SectionIn RO
+    beginKubectl:
+        SetOutPath $INSTDIR
+        File "kubectl.exe"
+        CopyFiles "$INSTDIR\kubectl.exe" "$INSTDIR\kubectl\kubectl.exe"
+        Delete "$INSTDIR\kubectl.exe"
+        Goto endKubectl
+    endKubectl:
+SectionEnd
+
 Section -Install
     SectionIn RO
     SetOutPath $INSTDIR


### PR DESCRIPTION
To address the complaint that file manipulation (e.g. `microk8s kubectl apply -f ./pod.yaml`) is difficult with the installers.

This difficultly is caused by files being referenced on the host, which are not then made available inside the VM running MicroK8s.  The most pragmatic fix for this is appears to be running kubectl on the host pointing at the MicroK8s kubeconfig file, which is written to the host every time `microk8s install` is run.  This does not overwrite or merge with `.kube/config` in order to give the "black box" feel of MicroK8s on Linux.  When `microk8s kubectl` is run, the command is no longer passed into the VM, rather run on the host with `--kubeconfig` to point to the aforementioned written file.

For Windows, we bundle `kubectl` with the NSIS installer and place it into the MicroK8s install directory, within a subdirectory to allow user choice of being added to PATH during install.

For MacOS, `kubernetes-cli` is added as a requirement to the brew file.  I think it's fair to assume that this would usually already be installed in most cases but, if not, brew will install it along side MicroK8s.
