### PR TITLE
for falco add-on

### DIFF
--- a/microk8s-resources/actions/disable.falco.sh
+++ b/microk8s-resources/actions/disable.falco.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+microk8s helm3  uninstall falcosidekick
+
+microk8s helm3  uninstall falco
+
+NAMESPACE_PTR="sysdig-agent"
+
+MANIFEST_PTR="https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-service.yaml"
+
+KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+
+KUBECTL_DELETE_ARGS="--wait=true --timeout=180s --ignore-not-found=true"
+
+echo "Disabling sysdig-agent"
+
+# unload the the manifests
+$KUBECTL delete $KUBECTL_DELETE_ARGS -n $NAMESPACE_PTR -f "$MANIFEST_PTR" > /dev/null 2>&1
+
+# delete the "sysdigagent" namespace
+$KUBECTL delete $KUBECTL_DELETE_ARGS namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true
+
+echo "sysdigagent is disabled"
+
+
+skip_opt_in_config "audit-log-maxbackup"  kube-apiserver
+skip_opt_in_config "audit-log-maxsize"  kube-apiserver
+skip_opt_in_config "audit-log-maxage"  kube-apiserver
+skip_opt_in_config "audit-policy-file"  kube-apiserver
+skip_opt_in_config "audit-log-path"  kube-apiserver
+skip_opt_in_config "audit-webhook-config-file"  kube-apiserver
+skip_opt_in_config "audit-webhook-batch-max-wait"  kube-apiserver
+
+
+restart_service apiserver
+apiserver=$(wait_for_service apiserver)
+if [[ $apiserver == fail ]]
+then
+	  echo "Kubeapiserver did not start on time. Proceeding."
+fi
+sleep 15
+echo "Falco is disabled"
+

--- a/microk8s-resources/actions/enable.falco.sh
+++ b/microk8s-resources/actions/enable.falco.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+microk8s enable dns
+
+NAMESPACE_PTR="sysdig-agent"
+
+MANIFEST_PTR="https://raw.githubusercontent.com/draios/sysdig-cloud-scripts/master/agent_deploy/kubernetes/sysdig-agent-service.yaml"
+
+KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
+
+microk8s enable helm3
+
+# make sure the "sysdigagent" namespace exists
+$KUBECTL create namespace "$NAMESPACE_PTR" > /dev/null 2>&1 || true
+
+# load the CRD and wait for it to be installed
+$KUBECTL apply -f "$MANIFEST_PTR" -n "$NAMESPACE_PTR"
+
+echo "Enabling Auditlogging using webhook"
+cp "${SNAP}/actions/kube-api-audit" "/var/snap/microk8s/current/args"
+cp "${SNAP}/actions/webhook-config.yaml" "/var/snap/microk8s/current/args"
+echo "Reconfiguring apiserver"
+refresh_opt_in_config "audit-log-maxbackup" "3" kube-apiserver
+refresh_opt_in_config "audit-log-maxsize" "1024" kube-apiserver
+refresh_opt_in_config "audit-log-maxage" "30" kube-apiserver
+refresh_opt_in_config "audit-log-path" "/var/log/kube-apiserver-audit.log" kube-apiserver
+refresh_opt_in_config "audit-policy-file" "/var/snap/microk8s/current/args/kube-api-audit" kube-apiserver
+refresh_opt_in_config "audit-webhook-config-file" "/var/snap/microk8s/current/args/webhook-config.yaml" kube-apiserver
+refresh_opt_in_config "audit-webhook-batch-max-wait" "5s" kube-apiserver
+
+run_with_sudo preserve_env snapctl restart "${SNAP_NAME}.daemon-apiserver"
+
+timeout="120"
+  
+while ! (is_apiserver_ready) 
+do
+  sleep 5
+  now="$(date +%s)"
+  if [[ "$now" > "$(($start_timer + $timeout))" ]] ; then
+    break
+  fi
+done
+
+echo "Auditlogging  is enabled"
+
+microk8s helm3 repo add falcosecurity https://falcosecurity.github.io/charts
+microk8s helm3 repo update 
+microk8s helm3 install falco --set falco.jsonOutput=true --set falco.jsonIncludeOutputProperty=true --set falco.httpOutput.enabled=true --set falco.httpOutput.url="http://falcosidekick:2801/" falcosecurity/falco 
+sleep 15
+echo "Falco is enabled"
+microk8s helm3 install falcosidekick --set config.debug=true falcosecurity/falcosidekick
+echo "Falcosidkick is enabled"

--- a/microk8s-resources/actions/kube-api-audit
+++ b/microk8s-resources/actions/kube-api-audit
@@ -1,0 +1,69 @@
+apiVersion: audit.k8s.io/v1 # This is required.
+kind: Policy
+# Don't generate audit events for all requests in RequestReceived stage.
+omitStages:
+  - "RequestReceived"
+rules:
+  # Log pod changes at RequestResponse level
+  - level: RequestResponse
+    resources:
+    - group: ""
+      # Resource "pods" doesn't match requests to any subresource of pods,
+      # which is consistent with the RBAC policy.
+      resources: ["pods"]
+  # Log "pods/log", "pods/status" at Metadata level
+  - level: Metadata
+    resources:
+    - group: ""
+      resources: ["pods/log", "pods/status"]
+
+  # Don't log requests to a configmap called "controller-leader"
+  - level: None
+    resources:
+    - group: ""
+      resources: ["configmaps"]
+      resourceNames: ["controller-leader"]
+
+  # Don't log watch requests by the "system:kube-proxy" on endpoints or services
+  - level: None
+    users: ["system:kube-proxy"]
+    verbs: ["watch"]
+    resources:
+    - group: "" # core API group
+      resources: ["endpoints", "services"]
+
+  # Don't log authenticated requests to certain non-resource URL paths.
+  - level: None
+    userGroups: ["system:authenticated"]
+    nonResourceURLs:
+    - "/api*" # Wildcard matching.
+    - "/version"
+
+  # Log the request body of configmap changes in kube-system.
+  - level: Request
+    resources:
+    - group: "" # core API group
+      resources: ["configmaps"]
+    # This rule only applies to resources in the "kube-system" namespace.
+    # The empty string "" can be used to select non-namespaced resources.
+    namespaces: ["kube-system"]
+
+  # Log configmap and secret changes in all other namespaces at the Metadata level.
+  - level: Metadata
+    resources:
+    - group: "" # core API group
+      resources: ["secrets", "configmaps"]
+
+  # Log all other resources in core and extensions at the Request level.
+  - level: Request
+    resources:
+    - group: "" # core API group
+    - group: "extensions" # Version of group should NOT be included.
+
+  # A catch-all rule to log all other requests at the Metadata level.
+  - level: Metadata
+    # Long-running requests like watches that fall under this rule will not
+    # generate an audit event in RequestReceived.
+    omitStages:
+      - "RequestReceived"
+

--- a/microk8s-resources/actions/webhook-config.yaml
+++ b/microk8s-resources/actions/webhook-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: falco
+    cluster:
+      server: http://10.152.183.173:7765/k8s_audit
+contexts:
+- context:
+      cluster: falco
+      user: ""
+  name: default-context
+current-context: default-context
+preferences: {}
+users: []

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -198,3 +198,11 @@ microk8s-addons:
       check_status: "pod/keda-operator"
       supported_architectures:
       - amd64
+        
+    - name: "falco"
+      description: "enable falco - for runtime security and audit logs"
+      version: "0.26.2"
+      check_status: "pod/falco"
+      supported_architectures:
+      - arm64
+      - amd64

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -28,6 +28,7 @@ from validators import (
     validate_traefik,
     validate_coredns_config,
     validate_portainer,
+    validate_falco,
 )
 from utils import (
     microk8s_enable,
@@ -395,3 +396,14 @@ class TestAddons(object):
             os.remove('backupfile.tar.gz')
         check_call("/snap/bin/microk8s.dbctl --debug backup -o backupfile".split())
         check_call("/snap/bin/microk8s.dbctl --debug restore backupfile.tar.gz".split())
+
+    def test_falco(self):
+        """
+        Sets up and validates falco.
+        """
+        print("Enabling falco")
+        microk8s_enable("falc")
+        print("Validating falco")
+        validate_keda()
+        print("Disabling falco")
+        microk8s_disable("falco")

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -528,3 +528,10 @@ def validate_portainer():
     Validate portainer
     """
     wait_for_pod_state("", "portainer", "running", label="app.kubernetes.io/name=portainer")
+
+
+def validate_falco():
+    """
+    Validate falco
+    """
+    wait_for_pod_state("", "falco", "running", label="app=falco-k8s-audit")


### PR DESCRIPTION
Hi
Enable n disable add-on scripts are added for  falco and falcosidekick through helm3 . With this add-on user can enable audit-logs in microk8s. falco n falcosidekick extracts in a json format from any anomalies for further debugging