### PR TITLE
Increase serviceIP Range (#1917)

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -370,7 +370,7 @@ produce_certs() {
 
     # Generate apiserver CA
     if ! [ -f ${SNAP_DATA}/certs/ca.crt ]; then
-        ${SNAP}/usr/bin/openssl req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/ca.key -subj "/CN=10.152.183.1" -out ${SNAP_DATA}/certs/ca.crt
+        ${SNAP}/usr/bin/openssl req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/ca.key -subj "/CN=10.152.0.1" -out ${SNAP_DATA}/certs/ca.crt
     fi
 
     # Generate front proxy CA

--- a/microk8s-resources/certs/csr.conf.template
+++ b/microk8s-resources/certs/csr.conf.template
@@ -23,7 +23,7 @@ DNS.3 = kubernetes.default.svc
 DNS.4 = kubernetes.default.svc.cluster
 DNS.5 = kubernetes.default.svc.cluster.local
 IP.1 = 127.0.0.1
-IP.2 = 10.152.183.1
+IP.2 = 10.152.0.1
 #MOREIPS
 
 [ v3_ext ]

--- a/microk8s-resources/default-args/containerd-env
+++ b/microk8s-resources/default-args/containerd-env
@@ -9,7 +9,7 @@
 # as specified in /var/snap/microk8s/current/args/kube-proxy and
 # /var/snap/microk8s/current/args/kube-apiserver
 #
-# NO_PROXY=10.1.0.0/16,10.152.183.0/24
+# NO_PROXY=10.1.0.0/16,10.152.0.0/16
 #
 # Remember to restart MicroK8s after editing this file:
 #

--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -1,5 +1,5 @@
 --cert-dir=${SNAP_DATA}/certs
---service-cluster-ip-range=10.152.183.0/24
+--service-cluster-ip-range=10.152.0.0/16
 --authorization-mode=AlwaysAllow
 --service-account-key-file=${SNAP_DATA}/certs/serviceaccount.key
 --client-ca-file=${SNAP_DATA}/certs/ca.crt

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -448,7 +448,7 @@ then
   snapctl restart ${SNAP_NAME}.daemon-flanneld
 fi
 
-if grep -e "\-\-cluster-cidr=10.152.183.0/24" ${SNAP_DATA}/args/kube-proxy
+if grep -e "\-\-cluster-cidr=10.152.0.0/16" ${SNAP_DATA}/args/kube-proxy
 then
   refresh_opt_in_config cluster-cidr 10.1.0.0/16 kube-proxy
   snapctl restart ${SNAP_NAME}.daemon-proxy


### PR DESCRIPTION
Updated service cluster IP range from 10.152.183.0/24 to 10.152.0.0/16, which increases the number of service IPs

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
