### PR TITLE
Remove password prompt in Kubeflow addon

### DIFF
--- a/microk8s-resources/actions/enable.kubeflow.sh
+++ b/microk8s-resources/actions/enable.kubeflow.sh
@@ -226,6 +226,7 @@ def get_hostname():
 @click.password_option(
     envvar='KUBEFLOW_AUTH_PASSWORD',
     default=get_random_pass,
+    prompt=False,
     help='The Kubeflow dashboard password.',
 )
 def kubeflow(bundle, channel, debug, hostname, ignore_min_mem, no_proxy, password):


### PR DESCRIPTION
You can still manually set it with the `--password` flag, but if that flag is not passed in, a randomly-generated password will be used without prompting the user. The generated password will still be displayed to the user at the end of the script.