### PR TITLE
Do not restart when vxlan.calico comes up

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -329,13 +329,14 @@ get_default_ip() {
 
 get_ips() {
     local IP_ADDR="$($SNAP/bin/hostname -I)"
+    local CNI_INTERFACE="vxlan.calico"
     if [[ -z "$IP_ADDR" ]]
     then
         echo "none"
     else
-        if $SNAP/sbin/ifconfig cni0 &> /dev/null
+        if $SNAP/sbin/ifconfig "$CNI_INTERFACE" &> /dev/null
         then
-          CNI_IP="$($SNAP/sbin/ip -o -4 addr list cni0 | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
+          CNI_IP="$($SNAP/sbin/ip -o -4 addr list "$CNI_INTERFACE" | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
           local ips="";
           for ip in $IP_ADDR
           do


### PR DESCRIPTION
The apiserver will not restart when the vxlan.calico comes up and the certificate issued will not include the respective IP.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
