### PR TITLE
Fix Kubeflow CI dependency installation

### DIFF
--- a/.github/workflows/test-kubeflow.yaml
+++ b/.github/workflows/test-kubeflow.yaml
@@ -72,9 +72,9 @@ jobs:
         export JUJU_DATA=/var/snap/microk8s/current/juju/share/juju
         sudo apt update
         sudo apt install -y libssl-dev python3-setuptools firefox-geckodriver
-        sudo pip3 install pytest sh kfp requests pyyaml selenium
         git clone https://github.com/juju-solutions/bundle-kubeflow.git
         cd bundle-kubeflow
+        sudo pip3 install -r requirements.txt -r test-requirements.txt
         sudo microk8s status --wait-ready
         sudo microk8s kubectl -n kube-system rollout status ds/calico-node
         trap 'sudo pkill -f svc/pipelines-api' SIGINT SIGTERM EXIT
@@ -185,9 +185,9 @@ jobs:
           export JUJU_DATA=/var/snap/microk8s/current/juju/share/juju
           sudo apt update
           sudo apt install -y libssl-dev python3-setuptools firefox-geckodriver
-          sudo pip3 install pytest sh kfp requests pyyaml selenium
           git clone https://github.com/juju-solutions/bundle-kubeflow.git
           cd bundle-kubeflow
+          sudo pip3 install -r requirements.txt -r test-requirements.txt
           sudo microk8s status --wait-ready
           sudo microk8s kubectl -n kube-system rollout status ds/calico-node
           trap 'sudo pkill -f svc/pipelines-api' SIGINT SIGTERM EXIT


### PR DESCRIPTION
The bundle-kubeflow repo now has requirements.txt and test-requirements.txt, which should be used instead of manually installing test dependencies.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
