### PR TITLE
Fix subprocess calls in xable scripts

### DIFF
--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -255,7 +255,9 @@ def xable(action: str, addons: list, xabled_addons: list):
             else:
                 addon, *args = addon.split(':')
                 wait_for_ready(timeout=30)
-                subprocess.run([str(actions / ('%s.%s.sh' % (action, addon)))] + args)
+                p = subprocess.run([str(actions / ('%s.%s.sh' % (action, addon)))] + args)
+                if p.returncode:
+                    sys.exit(p.returncode)
                 wait_for_ready(timeout=30)
 
     # The new way of xabling addons, that allows for unix-style argument passing,
@@ -285,8 +287,11 @@ def xable(action: str, addons: list, xabled_addons: list):
         wait_for_ready(timeout=30)
         script = [str(actions / ('%s.%s.sh' % (action, addon)))]
         if args:
-            subprocess.run(script + args)
+            p = subprocess.run(script + args)
         else:
-            subprocess.run(script + list(addons[1:]))
+            p = subprocess.run(script + list(addons[1:]))
+
+        if p.returncode:
+            sys.exit(p.returncode)
 
         wait_for_ready(timeout=30)


### PR DESCRIPTION
The click wrapper was ignoring the exit status from addons that it wrapped.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
