### PR TITLE
Added linux os selection.

### DIFF
--- a/microk8s-resources/actions/dashboard.yaml
+++ b/microk8s-resources/actions/dashboard.yaml
@@ -199,6 +199,8 @@ spec:
             secretName: kubernetes-dashboard-certs
         - name: tmp-volume
           emptyDir: {}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       serviceAccountName: kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
@@ -270,5 +272,7 @@ spec:
       volumes:
         - name: tmp-volume
           emptyDir: {}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
 
 ---    


### PR DESCRIPTION
If windows node exists in the cluster, enable addon dashboard gives ImagePullBackOff error.

v1.0.4: Pulling from kubernetesui/metrics-scraper
no matching manifest for windows/amd64 10.0.19042 in the manifest list entries

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
