### PR TITLE
#fixes 719 - adds support to build on armhf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tests/__pycache__
 /installer/build/
 .tox_env/
 __pycache__/
+microk8s_*.txt #Remote build log

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -15,7 +15,7 @@ kubeconfig = "--kubeconfig=" + os.path.expandvars("${SNAP_DATA}/credentials/clie
 
 def get_current_arch():
     # architecture mapping
-    arch_mapping = {"aarch64": "arm64", "x86_64": "amd64"}
+    arch_mapping = {'aarch64': 'arm64', 'armv7l': 'armhf', 'x86_64': 'amd64'}
 
     return arch_mapping[platform.machine()]
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -185,10 +185,25 @@ parts:
   etcd:
     plugin: dump
     source: build-scripts/
+    build-snaps: [go]
     override-build: |
       . ./set-env-variables.sh
-      curl -LO https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-$KUBE_ARCH.tar.gz
-      tar -xzvf etcd-*.tar.gz --strip-components=1
+      case ${SNAPCRAFT_ARCH_TRIPLET%%-*} in
+      x86_64|aarch64)
+        echo "Supported arch by etcd - use official binary"
+        curl -LO https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-$KUBE_ARCH.tar.gz
+        tar -xzvf etcd-*.tar.gz --strip-components=1
+        ;;
+      *)
+        echo "Unsupported arch by etcd - build from sources"
+        curl -LO https://github.com/etcd-io/etcd/archive/${ETCD_VERSION}.tar.gz
+        tar -xzf *.tar.gz
+        cd etcd-*
+        go mod vendor
+        ./build
+        cp -av bin/* ../
+        echo "End of build"
+      esac
       snapcraftctl build
     stage:
       - etcd
@@ -452,9 +467,9 @@ parts:
       cp $KUBE_SNAP_ROOT/microk8s-resources/wrappers/* .
 
       cp -r $KUBE_SNAP_ROOT/microk8s-resources/actions .
-      if [ "${ARCH}" = "arm64" ]
+      if [ "${ARCH}" != "amd64" ]
       then
-        # Some actions are not available on arm64
+        # Some actions are only available on amd64
         # Nvidia support
         rm "actions/enable.gpu.sh"
         rm "actions/disable.gpu.sh"
@@ -509,7 +524,7 @@ parts:
     override-build: |
       set -eu
       ARCH=$(dpkg --print-architecture)
-      if ! [ "${ARCH}" = "arm64" ]
+      if [ "${ARCH}" = "amd64" ]
       then
         snapcraftctl build
       else
@@ -523,7 +538,7 @@ parts:
     override-build: |
       set -eu
       ARCH=$(dpkg --print-architecture)
-      if ! [ "${ARCH}" = "arm64" ]
+      if [ "${ARCH}" = "amd64" ]
       then
         snapcraftctl build
       else
@@ -537,7 +552,7 @@ parts:
     override-build: |
       set -eu
       ARCH=$(dpkg --print-architecture)
-      if ! [ "${ARCH}" = "arm64" ]
+      if [ "${ARCH}" = "amd64" ]
       then
         snapcraftctl build
       else
@@ -551,7 +566,7 @@ parts:
     override-build: |
       set -eu
       ARCH=$(dpkg --print-architecture)
-      if ! [ "${ARCH}" = "arm64" ]
+      if [ "${ARCH}" = "amd64" ]
       then
         snapcraftctl build
       else


### PR DESCRIPTION
This is a continuation of the work for #719 .

After splitting the remote build support this patch adds just the capability to build locally on armrf or remotely with `snapcraft remote-build `

The mayor change beyond fixing the check on x86 only plugins was to allow building etcd from sources when no binary is available. This way the version matches on all platforms but the official binary is used when available.

The built result is functional and I am able to add nodes successfully. If there are additional tests needed before a platform is added please let me know.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
