### PR TITLE
Remove debug flags from dqlite and raft builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,8 +105,6 @@ parts:
     build-attributes: [no-patchelf]
     source-type: git
     plugin: autotools
-    configflags:
-      - --enable-debug
     stage-packages:
       - libuv1
     organize:
@@ -149,8 +147,6 @@ parts:
     build-attributes: [no-patchelf]
     source-type: git
     plugin: autotools
-    configflags:
-      - --enable-debug
     stage-packages:
       - libuv1
     build-packages:


### PR DESCRIPTION
We do not need these debug flags anymore.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
