### PR TITLE
[1.20] Fix linkerd addon

### DIFF
--- a/microk8s-resources/actions/enable.linkerd.sh
+++ b/microk8s-resources/actions/enable.linkerd.sh
@@ -12,7 +12,7 @@ ARCH=$(arch)
 
 # check if linkerd cli is already in the system.  Download if it doesn't exist.
 if [ ! -f "${SNAP_DATA}/bin/linkerd" ]; then
-  LINKERD_VERSION="${LINKERD_VERSION:-v2.9.0}"
+  LINKERD_VERSION="${LINKERD_VERSION:-v2.9.2}"
   echo "Fetching Linkerd2 version $LINKERD_VERSION."
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
   LINKERD_VERSION=$(echo $LINKERD_VERSION | sed 's/v//g')

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -102,7 +102,7 @@ microk8s-addons:
 
     - name: "linkerd"
       description: "Linkerd is a service mesh for Kubernetes and other frameworks"
-      version: "2.9.0"
+      version: "2.9.2"
       check_status: "pod/linkerd-controller"
       supported_architectures:
       - amd64


### PR DESCRIPTION
Please reference the issue this PR is fixing, or provide a description of the problem addressed.
Fixes #1979. linkerd 2.9.0 is not available for download.
*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
