### PR TITLE
Fixes in kubelite startup script

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -104,8 +104,8 @@ get_opt_in_config() {
     echo "$val"
 }
 
-refresh_opt_in_config() {
-    # add or replace an option inside the config file.
+refresh_opt_in_local_config() {
+    # add or replace an option inside the local config file.
     # Create the file if doesn't exist
     local opt="--$1"
     local value="$2"
@@ -116,6 +116,17 @@ refresh_opt_in_config() {
     else
         run_with_sudo "$SNAP/bin/sed" -i "$ a $replace_line" "$config_file"
     fi
+}
+
+refresh_opt_in_config() {
+    # add or replace an option inside the config file and propagate change.
+    # Create the file if doesn't exist
+    refresh_opt_in_local_config "$1" "$2" "$3"
+
+    local opt="--$1"
+    local value="$2"
+    local config_file="$SNAP_DATA/args/$3"
+    local replace_line="$opt=$value"
 
     if [ -e "${SNAP_DATA}/var/lock/ha-cluster" ]
     then

--- a/microk8s-resources/actions/coredns.yaml
+++ b/microk8s-resources/actions/coredns.yaml
@@ -129,13 +129,6 @@ spec:
             port: 8181
             scheme: HTTP
       dnsPolicy: Default
-      volumes:
-        - name: config-volume
-          configMap:
-            name: coredns
-            items:
-            - key: Corefile
-              path: Corefile
 ---
 apiVersion: v1
 kind: Service

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -55,6 +55,8 @@ then
     # to the previous manual approach of pointing people to the troubleshooting guide.
     iptables -t filter -A FORWARD -s "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
     iptables -t filter -A FORWARD -d "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
+    iptables-nft -t filter -A FORWARD -s "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
+    iptables-nft -t filter -A FORWARD -d "$pod_cidr" -m comment --comment "generated for MicroK8s pods" -j ACCEPT || true
   fi
 fi
 
@@ -83,8 +85,8 @@ if [ -e /proc/$$/cgroup ] &&
  ! grep -e "kubelet-cgroups" $SNAP_DATA/args/kubelet &> /dev/null &&
  [ -e  /sys/fs/cgroup/systemd/system.slice ]
 then
-  refresh_opt_in_config "runtime-cgroups" "/systemd/system.slice" kubelet
-  refresh_opt_in_config "kubelet-cgroups" "/systemd/system.slice" kubelet
+  refresh_opt_in_local_config "runtime-cgroups" "/systemd/system.slice" kubelet
+  refresh_opt_in_local_config "kubelet-cgroups" "/systemd/system.slice" kubelet
 fi
 
 ## Kube-proxy configuration
@@ -131,11 +133,11 @@ then
   fi
 fi
 
-if [ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]
+if ! [ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]
 then
   if ! modprobe br_netfilter
   then
-    refresh_opt_in_config "proxy-mode" "userspace" kube-proxy
+    refresh_opt_in_local_config "proxy-mode" "userspace" kube-proxy
   fi
 fi
 if [ -f /proc/sys/net/bridge/bridge-nf-call-iptables ] &&


### PR DESCRIPTION
1. If we do not have `br_netfilter` loaded try to load it.
2. Fix iptables-nft rule lost in code merges
3. Remove duplicate volumes declaration in coredns manifest