### PR TITLE
Remove invalid hooks

### DIFF
--- a/snap/hooks/start
+++ b/snap/hooks/start
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -eux
-
-source $SNAP/actions/common/utils.sh
-
-start_all_containers

--- a/snap/hooks/stop
+++ b/snap/hooks/stop
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -eux
-
-source $SNAP/actions/common/utils.sh
-
-snapctl stop microk8s --disable
-kill_all_container_shims


### PR DESCRIPTION
LP builds are failing post-build review because of these.  They're not needed as we use microk8s start / stop anyway.