### PR TITLE
fix instructions for joining microk8s group and cleanup build docs

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -1,13 +1,26 @@
-# Building the snap from source
+# Building and testing MicroK8s
 
-[Building a snap](https://snapcraft.io/docs/snapcraft-overview) is done by running `snapcraft` on the root of the project.
-A VM managed by Multipass is spawned to contain the build process. If you don’t have Multipass installed,
-snapcraft will first prompt for its automatic installation.
+## Building the snap from source
 
-Alternatively, you can build the snap in an LXC container.
-Snapcraft and LXD are needed in this case:
-```
+To build the MicroK8s snap, you need to install Snapcraft.
+
+```shell
 sudo snap install snapcraft --classic
+```
+
+[Building a snap](https://snapcraft.io/docs/snapcraft-overview) is done by running `snapcraft` in the root of the project. Snapcraft spawn a VM managed by [Multipass](https://multipass.run/) and builds MicroK8s inside of it. If you don’t have Multipass installed, snapcraft will first prompt for its automatic installation.
+
+After `snapcraft` finishes, you can install the newly compiled snap:
+
+```shell
+sudo snap install microk8s_*_amd64.snap --classic --dangerous
+```
+
+## Building the snap using LXD
+
+Alternatively, you can build the snap in an LXC container. This is useful if you are working in a virtual machine without nested virtualization. Snapcraft and LXD are needed in this case:
+
+```shell
 sudo snap install lxd
 sudo apt-get remove lxd* -y
 sudo apt-get remove lxc* -y
@@ -16,56 +29,61 @@ sudo usermod -a -G lxd ${USER}
 ```
 
 Build the snap with:
-```
+
+```shell
 git clone http://github.com/ubuntu/microk8s
 cd ./microk8s/
 snapcraft --use-lxd
 ```
 
-Install the newly compiled snap:
-```
+Finally, install it with:
+
+```shell
 sudo snap install microk8s_*_amd64.snap --classic --dangerous
 ```
 
 ## Building a custom MicroK8s package
 
-To produce a custom build with specific component versions we cannot use the snapcraft build process on the host OS. We need to
-[prepare an LXC](https://forum.snapcraft.io/t/how-to-create-a-lxd-container-for-snap-development/4658)
-container with Ubuntu 16:04 and snapcraft:
-```
+To produce a custom build with specific component versions you cannot use the snapcraft build process on the host OS. You need to
+[prepare an LXC](https://forum.snapcraft.io/t/how-to-create-a-lxd-container-for-snap-development/4658) container with Ubuntu 16:04 and snapcraft:
+
+```shell
 lxc launch ubuntu:16.04 --ephemeral test-build
 lxc exec test-build -- snap install snapcraft --classic
 lxc exec test-build -- apt update
 lxc exec test-build -- git clone https://github.com/ubuntu/microk8s
 ```
 
-We can then set the following environment variables prior to building:
- - KUBE_VERSION: kubernetes release to package. Defaults to latest stable.
- - ETCD_VERSION: version of etcd.
- - CNI_VERSION: version of CNI tools.
- - KUBE_TRACK: kubernetes release series (e.g., 1.10) to package. Defaults to latest stable.
- - ISTIO_VERSION: istio release.
- - KNATIVE_SERVING_VERSION: Knative Serving release.
- - KNATIVE_EVENTING_VERSION: Knative Eventing release.
- - RUNC_COMMIT: the commit hash from which to build runc
- - CONTAINERD_COMMIT: the commit hash from which to build containerd
- - KUBERNETES_REPOSITORY: build the kubernetes binaries from this repository instead of getting them from upstream
- - KUBERNETES_COMMIT: commit to be used from KUBERNETES_REPOSITORY for building the kubernetes binaries
+You can then set the following environment variables prior to building:
 
+- KUBE_VERSION: Kubernetes release to package. Defaults to latest stable.
+- ETCD_VERSION: version of etcd.
+- CNI_VERSION: version of CNI tools.
+- KUBE_TRACK: Kubernetes release series (e.g., 1.10) to package. Defaults to latest stable.
+- ISTIO_VERSION: istio release.
+- KNATIVE_SERVING_VERSION: Knative Serving release.
+- KNATIVE_EVENTING_VERSION: Knative Eventing release.
+- RUNC_COMMIT: the commit hash from which to build runc.
+- CONTAINERD_COMMIT: the commit hash from which to build containerd
+- KUBERNETES_REPOSITORY: build the Kubernetes binaries from this repository instead of getting them from upstream
+- KUBERNETES_COMMIT: commit to be used from KUBERNETES_REPOSITORY for building the Kubernetes binaries
 
-For building we prepend the variables we need as well as `SNAPCRAFT_BUILD_ENVIRONMENT=host` so the current LXC container is used. For example to build the MicroK8s snap for Kubernetes v1.9.6 we:
-```
+For building you prepend the variables you need as well as `SNAPCRAFT_BUILD_ENVIRONMENT=host` so the current LXC container is used. For example to build the MicroK8s snap for Kubernetes v1.9.6, run:
+
+```shell
 lxc exec test-build -- sh -c "cd microk8s && SNAPCRAFT_BUILD_ENVIRONMENT=host KUBE_VERSION=v1.9.6 snapcraft"
 ```
 
-The produced snap is inside the ephemeral LXC container, we need to copy it to the host:
-```
+The produced snap is inside the ephemeral LXC container, you need to copy it to the host:
+
+```shell
 lxc file pull test-build/root/microk8s/microk8s_v1.9.6_amd64.snap .
 ```
 
-#### Installing the snap
-```
-snap install microk8s_latest_amd64.snap --classic --dangerous
+After copying it, you can install it with:
+
+```shell
+snap install microk8s_*_amd64.snap --classic --dangerous
 ```
 
 ## Assembling the Calico CNI manifest
@@ -74,51 +92,59 @@ The calico CNI manifest can be found under `upgrade-scripts/000-switch-to-calico
 Building the manifest is subject to the upstream calico project k8s installation process.
 At the time of the v3.13.2 release. The `calico.yaml` manifest is a slightly modified version of:
 `https://docs.projectcalico.org/manifests/calico.yaml`:
-- CALICO_IPV4POOL_CIDR was set to "10.1.0.0/16"
-- CNI_NET_DIR was set to "/var/snap/microk8s/current/args/cni-network"
+
+- `CALICO_IPV4POOL_CIDR` was set to "10.1.0.0/16"
+- `CNI_NET_DIR` was set to "/var/snap/microk8s/current/args/cni-network"
 - We set the following mount paths:
-  1. var-run-calico to /var/snap/microk8s/current/var/run/calico
-  1. var-lib-calico to /var/snap/microk8s/current/var/lib/calico
-  1. cni-bin-dir to /var/snap/microk8s/current/opt/cni/bin
-  1. cni-net-dir to /var/snap/microk8s/current/args/cni-network
-  1. host-local-net-dir to /var/snap/microk8s/current/var/lib/cni/networks
-  1. policysync to /var/snap/microk8s/current/var/run/nodeagent
+  1. `var-run-calico` to `/var/snap/microk8s/current/var/run/calico`
+  1. `var-lib-calico` to `/var/snap/microk8s/current/var/lib/calico`
+  1. `cni-bin-dir` to `/var/snap/microk8s/current/opt/cni/bin`
+  1. `cni-net-dir` to `/var/snap/microk8s/current/args/cni-network`
+  1. `host-local-net-dir` to `/var/snap/microk8s/current/var/lib/cni/networks`
+  1. `policysync` to `/var/snap/microk8s/current/var/run/nodeagent`
 - We enabled vxlan following the instructions in [the official docs.](https://docs.projectcalico.org/getting-started/kubernetes/installation/config-options#switching-from-ip-in-ip-to-vxlan)
-- FELIX_LOGSEVERITYSCREEN was set to "error"
-- we set the IP autodetection method to
-```dtd
-            - name: IP_AUTODETECTION_METHOD
+- `FELIX_LOGSEVERITYSCREEN` was set to "error"
+- We set the IP autodetection method to
+
+  ```dtd
+              - name: IP_AUTODETECTION_METHOD
               value: "first-found"
-```
+  ```
 
 ## Running the tests locally
 
-The `test-addons.py` and `test-upgrade.py` files under the `tests` directory are the two main files of out test suite.
-Running the tests is done with pytest:
-```
-pytest -s test-addons.py
-pytest -s test-upgrade.py
-```
-
 To successfully run the tests you need to install:
+
 1. From your distribution's repository:
    - python3
    - pytest
    - pip3
    - docker.io
+   - tox
 1. From pip3:
    - requests
    - pyyaml
    - sh
 
-For example on ubuntu 18.04 to get these dependencies you would:
-```
-apt-get install python3-pip docker.io -y
+On Ubuntu 20.04, for example, run the following commands to get these dependencies.
+
+```shell
+sudo apt install python3-pip docker.io tox -y
 pip3 install -U pytest requests pyyaml sh
 ```
 
-## References
+First, run the static analysis using Tox. Run the following command in the root of the project.
 
-- https://snapcraft.io/docs/snapcraft-overview
-- https://forum.snapcraft.io/t/how-to-create-a-lxd-container-for-snap-development/4658
-- https://docs.projectcalico.org/getting-started/kubernetes/installation/config-options#switching-from-ip-in-ip-to-vxlan
+```shell
+tox -e lint
+```
+
+Then, use the "Building the snap from source" instructions to build the snap and install it locally. The tests check this locally installed MicroK8s instance. 
+
+Finally, run the tests themselves. The `test-addons.py` and `test-upgrade.py` files under the `tests` directory are the two main files of our test suite. Running the tests is done with pytest:
+
+```shell
+cd tests/
+pytest -s test-addons.py
+pytest -s test-upgrade.py
+```

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -9,7 +9,7 @@ exit_if_no_permissions() {
     echo "    sudo usermod -a -G microk8s $USER" >&2
     echo "    sudo chown -f -R $USER ~/.kube" >&2
     echo "" >&2
-    echo "The new group will be available on the user's next login." >&2
+    echo "After this, reload the user groups either via a reboot or by running 'newgrp microk8s'." >&2
     exit 1
   fi
 }

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -151,7 +151,9 @@ def exit_if_no_permission():
         print("")
         print("    sudo usermod -a -G microk8s {}".format(user))
         print("")
-        print("The new group will be available on the user's next login.")
+        print(
+            "After this, reload the user groups either via a reboot or by running 'newgrp microk8s'."
+        )
         exit(1)
 
 

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -150,6 +150,7 @@ def exit_if_no_permission():
         )
         print("")
         print("    sudo usermod -a -G microk8s {}".format(user))
+        print("    sudo chown -f -R $USER ~/.kube")
         print("")
         print(
             "After this, reload the user groups either via a reboot or by running 'newgrp microk8s'."


### PR DESCRIPTION
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.

Fixes https://github.com/ubuntu/microk8s/issues/2011

This PR

* Suggests using `newgrp` or a reboot after adding your user to a group. logging out and back in doesn't always work. https://github.com/ubuntu/microk8s/issues/2011
* Suggests changing ownership of ~/.kube when joinging microk8s group in the python utils too. (This was already the case in the bash utils)
* Cleans up the build docs
  * Makes it clear that the tests require building and installing the snap.
  * Update tests to Ubuntu 20.04 and add sudo to install commands.
  * General cleanup and markdown linting.
  * Removed the "references" sections since all links were already part of the body.