### PR TITLE
Build libuv v1.18.0 in the snap

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   pull_request:
-    branches: 
+    branches:
       - master
 
 jobs:
@@ -14,48 +14,44 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checking out repo
-      uses: actions/checkout@v2
-    - name: Install lxd
-      run: |
-        sudo snap install lxd
-        sudo /snap/bin/lxd.migrate -yes
-        sudo /snap/bin/lxd waitready
-        sudo /snap/bin/lxd init --auto
-        sudo usermod --append --groups lxd $USER
-    - name: Install snapcraft
-      run: sudo snap install snapcraft --classic
-    - name: Build snap
-      run: |
-        sg lxd -c 'snapcraft --use-lxd'
-        sudo mv microk8s*.snap microk8s.snap
-    - name: Uploading snap
-      uses: actions/upload-artifact@v1
-      with:
-        name: microk8s.snap
-        path: microk8s.snap
-    - name: Running upgrade path test
-      run: |
-        set -x
-        sudo apt-get install python3-setuptools
-        sudo pip3 install --upgrade pip
-        sudo pip3 install -U pytest sh
-        sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade-path.py
-        sudo snap remove microk8s --purge
-    - name: Running addons tests
-      run: |
-        set -x
-        sudo snap install *.snap --classic --dangerous
-        ./tests/smoke-test.sh
-        export UNDER_TIME_PRESSURE="True"
-        export SKIP_PROMETHEUS="False"
-        (cd tests; pytest -s verify-branches.py)
-        (cd tests; sudo -E pytest -s -ra test-addons.py)
-        sudo snap remove microk8s --purge
-    - name: Running upgrade tests
-      run: |
-        set -x
-        export UNDER_TIME_PRESSURE="True"
-        sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade.py
-
-        
+      - name: Checking out repo
+        uses: actions/checkout@v2
+      - name: Install lxd
+        run: |
+          sudo lxd init --auto
+          sudo usermod --append --groups lxd $USER
+          sg lxd -c 'lxc version'
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
+      - name: Build snap
+        run: |
+          sg lxd -c 'snapcraft --use-lxd'
+          sudo mv microk8s*.snap microk8s.snap
+      - name: Uploading snap
+        uses: actions/upload-artifact@v1
+        with:
+          name: microk8s.snap
+          path: microk8s.snap
+      - name: Running upgrade path test
+        run: |
+          set -x
+          sudo apt-get install python3-setuptools
+          sudo pip3 install --upgrade pip
+          sudo pip3 install -U pytest sh
+          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade-path.py
+          sudo snap remove microk8s --purge
+      - name: Running addons tests
+        run: |
+          set -x
+          sudo snap install *.snap --classic --dangerous
+          ./tests/smoke-test.sh
+          export UNDER_TIME_PRESSURE="True"
+          export SKIP_PROMETHEUS="False"
+          (cd tests; pytest -s verify-branches.py)
+          (cd tests; sudo -E pytest -s -ra test-addons.py)
+          sudo snap remove microk8s --purge
+      - name: Running upgrade tests
+        run: |
+          set -x
+          export UNDER_TIME_PRESSURE="True"
+          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade.py

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -2,11 +2,11 @@ name: Build MicroK8s snap on PR and push to master
 
 on:
   push:
-    branches:
-      - master
+    paths-ignore:
+      - "docs/**"
   pull_request:
-    branches:
-      - master
+    paths-ignore:
+      - "docs/**"
 
 jobs:
   build:
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get install python3-setuptools
           sudo pip3 install --upgrade pip
           sudo pip3 install -U pytest sh
-          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade-path.py
+          sudo -E UPGRADE_MICROK8S_FROM=1.20/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade-path.py
           sudo snap remove microk8s --purge
       - name: Running addons tests
         run: |
@@ -54,4 +54,4 @@ jobs:
         run: |
           set -x
           export UNDER_TIME_PRESSURE="True"
-          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade.py
+          sudo -E UPGRADE_MICROK8S_FROM=1.20/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade.py

--- a/.github/workflows/test-kubeflow.yaml
+++ b/.github/workflows/test-kubeflow.yaml
@@ -3,10 +3,10 @@ name: Test Kubeflow
 on:
   push:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   build:
@@ -14,29 +14,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checking out repo
-      uses: actions/checkout@v2
+      - name: Checking out repo
+        uses: actions/checkout@v2
 
-    - name: Install lxd
-      run: |
-        set -eux
-        sudo snap install lxd
-        sudo lxd.migrate -yes
-        sudo lxd waitready
-        sudo lxd init --auto
-        sudo usermod --append --groups lxd $USER
+      - name: Install lxd
+        run: |
+          sudo lxd init --auto
+          sudo usermod --append --groups lxd $USER
+          sg lxd -c 'lxc version'
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
 
-    - name: Install snapcraft
-      run: sudo snap install snapcraft --classic
+      - name: Build snap
+        run: sg lxd -c 'snapcraft --use-lxd'
 
-    - name: Build snap
-      run: sg lxd -c 'snapcraft --use-lxd'
-
-    - name: Uploading snap
-      uses: actions/upload-artifact@v2
-      with:
-        name: microk8s.snap
-        path: ./microk8s*.snap
+      - name: Uploading snap
+        uses: actions/upload-artifact@v2
+        with:
+          name: microk8s.snap
+          path: ./microk8s*.snap
 
   test-actions:
     name: Actions
@@ -45,79 +41,79 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Download built snap
-      uses: actions/download-artifact@v2
-      with:
-        name: microk8s.snap
+      - name: Download built snap
+        uses: actions/download-artifact@v2
+        with:
+          name: microk8s.snap
 
-    - name: Install snap
-      run: |
-        set -eux
-        sudo snap install ./microk8s*.snap --classic --dangerous
-        sudo usermod --append --groups microk8s $USER
-        sudo microk8s status --wait-ready
-        sudo microk8s kubectl -n kube-system rollout status ds/calico-node
-        sudo snap install juju-helpers --classic
+      - name: Install snap
+        run: |
+          set -eux
+          sudo snap install ./microk8s*.snap --classic --dangerous
+          sudo usermod --append --groups microk8s $USER
+          sudo microk8s status --wait-ready
+          sudo microk8s kubectl -n kube-system rollout status ds/calico-node
+          sudo snap install juju-helpers --classic
 
-    - name: Enable kubeflow
-      timeout-minutes: 45
-      run: sg microk8s -c 'microk8s enable kubeflow --debug --bundle=edge --ignore-min-mem --password=hunter2'
+      - name: Enable kubeflow
+        timeout-minutes: 45
+        run: sg microk8s -c 'microk8s enable kubeflow --debug --bundle=edge --ignore-min-mem --password=hunter2'
 
-    - name: Test kubeflow
-      run: |
-        set -eux
-        export JUJU_DATA=/var/snap/microk8s/current/juju/share/juju
-        sudo apt update
-        sudo apt install -y libssl-dev python3-setuptools firefox-geckodriver
-        git clone https://github.com/juju-solutions/bundle-kubeflow.git
-        cd bundle-kubeflow
-        sudo pip3 install -r requirements.txt -r test-requirements.txt
-        sudo microk8s status --wait-ready
-        sudo microk8s kubectl -n kube-system rollout status ds/calico-node
-        trap 'sudo pkill -f svc/pipelines-api' SIGINT SIGTERM EXIT
-        sudo microk8s kubectl -n kubeflow port-forward svc/pipelines-api 8888:8888 &
-        (i=30; while ! curl localhost:8888 ; do ((--i)) || exit; sleep 1; done)
-        sudo -E pytest -vvs -m edge -k 'not kubectl'
-        sudo -E pytest -vvs -m edge -k 'kubectl'
+      - name: Test kubeflow
+        run: |
+          set -eux
+          export JUJU_DATA=/var/snap/microk8s/current/juju/share/juju
+          sudo apt update
+          sudo apt install -y libssl-dev python3-setuptools firefox-geckodriver
+          git clone https://github.com/juju-solutions/bundle-kubeflow.git
+          cd bundle-kubeflow
+          sudo pip3 install -r requirements.txt -r test-requirements.txt
+          sudo microk8s status --wait-ready
+          sudo microk8s kubectl -n kube-system rollout status ds/calico-node
+          trap 'sudo pkill -f svc/pipelines-api' SIGINT SIGTERM EXIT
+          sudo microk8s kubectl -n kubeflow port-forward svc/pipelines-api 8888:8888 &
+          (i=30; while ! curl localhost:8888 ; do ((--i)) || exit; sleep 1; done)
+          sudo -E pytest -vvs -m edge -k 'not kubectl'
+          sudo -E pytest -vvs -m edge -k 'kubectl'
 
-    - name: Get MicroK8s pods
-      run: sudo microk8s kubectl get pods -A
-      if: failure()
+      - name: Get MicroK8s pods
+        run: sudo microk8s kubectl get pods -A
+        if: failure()
 
-    - name: Describe MicroK8s pods
-      run: sudo microk8s kubectl describe pods -nkubeflow
-      if: failure()
+      - name: Describe MicroK8s pods
+        run: sudo microk8s kubectl describe pods -nkubeflow
+        if: failure()
 
-    - name: Get pipeline logs
-      run: |
-        set -eux
-        pods=$(sudo microk8s kubectl get -nkubeflow pods -l workflows.argoproj.io/completed="true" -o custom-columns=:metadata.name --no-headers)
-        for pod in $pods; do
-          containers=$(sudo microk8s kubectl get -nkubeflow pods -o jsonpath="{.spec.containers[*].name}" $pod)
-          for container in $containers; do
-            sudo microk8s kubectl logs -nkubeflow --timestamps $pod -c $container
-            printf '\n'
+      - name: Get pipeline logs
+        run: |
+          set -eux
+          pods=$(sudo microk8s kubectl get -nkubeflow pods -l workflows.argoproj.io/completed="true" -o custom-columns=:metadata.name --no-headers)
+          for pod in $pods; do
+            containers=$(sudo microk8s kubectl get -nkubeflow pods -o jsonpath="{.spec.containers[*].name}" $pod)
+            for container in $containers; do
+              sudo microk8s kubectl logs -nkubeflow --timestamps $pod -c $container
+              printf '\n'
+            done
+            printf '\n\n'
           done
-          printf '\n\n'
-        done
-      if: failure()
+        if: failure()
 
-    - name: Generate inspect tarball
-      run: >
-        sudo microk8s inspect |
-        grep -Po "Report tarball is at \K.+" |
-        sudo xargs -I {} mv {} inspection-report-${{ strategy.job-index }}.tar.gz
-      if: failure()
+      - name: Generate inspect tarball
+        run: >
+          sudo microk8s inspect |
+          grep -Po "Report tarball is at \K.+" |
+          sudo xargs -I {} mv {} inspection-report-${{ strategy.job-index }}.tar.gz
+        if: failure()
 
-    - name: Upload inspect tarball
-      uses: actions/upload-artifact@v2
-      with:
-        name: inspection-report-actions
-        path: ./inspection-report-${{ strategy.job-index }}.tar.gz
-      if: failure()
+      - name: Upload inspect tarball
+        uses: actions/upload-artifact@v2
+        with:
+          name: inspection-report-actions
+          path: ./inspection-report-${{ strategy.job-index }}.tar.gz
+        if: failure()
 
   test-aws:
     name: AWS
@@ -129,95 +125,95 @@ jobs:
       matrix:
         bundle: [full, lite]
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Download built snap
-      uses: actions/download-artifact@v2
-      with:
-        name: microk8s.snap
+      - name: Download built snap
+        uses: actions/download-artifact@v2
+        with:
+          name: microk8s.snap
 
-    - name: Install dependencies
-      run: |
-        set -eux
-        sudo snap install juju --classic
-        sudo snap install juju-wait --classic
-
-    - name: Bootstrap onto AWS
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      run: |
-        set -eux
-        juju autoload-credentials --client aws
-        juju bootstrap aws/us-east-1 uk8saws --config test-mode=true --model-default test-mode=true
-        juju deploy ubuntu --constraints 'cores=4 mem=16G root-disk=60G'
-        juju wait -vw
-
-    - name: Copy snap to AWS instance
-      run: juju scp ./microk8s*.snap ubuntu/0:~/microk8s.snap
-
-    - name: Install snap
-      run: |
-        juju ssh ubuntu/0 <<EOF
+      - name: Install dependencies
+        run: |
           set -eux
-          sudo snap install ./microk8s*.snap --classic --dangerous
-          sudo usermod --append --groups microk8s ubuntu
-          sudo snap install juju-helpers --classic
-        EOF
+          sudo snap install juju --classic
+          sudo snap install juju-wait --classic
 
-    - name: Enable kubeflow
-      timeout-minutes: 45
-      run: |
-        juju ssh ubuntu/0 <<EOF
+      - name: Bootstrap onto AWS
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
           set -eux
-          export KUBEFLOW_BUNDLE=${{ matrix.bundle }}
-          export KUBEFLOW_DEBUG=true
-          export KUBEFLOW_IGNORE_MIN_MEM=true
-          export KUBEFLOW_AUTH_PASSWORD=hunter2
-          microk8s enable kubeflow
-        EOF
+          juju autoload-credentials --client aws
+          juju bootstrap aws/us-east-1 uk8saws --config test-mode=true --model-default test-mode=true
+          juju deploy ubuntu --constraints 'cores=4 mem=16G root-disk=60G'
+          juju wait -vw
 
-    - name: Test kubeflow
-      run: |
-        juju ssh ubuntu/0 <<EOF
-          set -eux
-          export JUJU_DATA=/var/snap/microk8s/current/juju/share/juju
-          sudo apt update
-          sudo apt install -y libssl-dev python3-setuptools firefox-geckodriver
-          git clone https://github.com/juju-solutions/bundle-kubeflow.git
-          cd bundle-kubeflow
-          sudo pip3 install -r requirements.txt -r test-requirements.txt
-          sudo microk8s status --wait-ready
-          sudo microk8s kubectl -n kube-system rollout status ds/calico-node
-          trap 'sudo pkill -f svc/pipelines-api' SIGINT SIGTERM EXIT
-          microk8s kubectl -n kubeflow port-forward svc/pipelines-api 8888:8888 &
-          (i=30; while ! curl localhost:8888 ; do ((--i)) || exit; sleep 1; done)
-          pytest -vvs -m ${{ matrix.bundle }} -k 'not kubectl'
-          pytest -vvs -m ${{ matrix.bundle }} -k 'kubectl'
-        EOF
+      - name: Copy snap to AWS instance
+        run: juju scp ./microk8s*.snap ubuntu/0:~/microk8s.snap
 
-    - name: Get MicroK8s pods
-      run: juju ssh ubuntu/0 sudo microk8s kubectl get pods -A --sort-by=.metadata.name
-      if: failure()
+      - name: Install snap
+        run: |
+          juju ssh ubuntu/0 <<EOF
+            set -eux
+            sudo snap install ./microk8s*.snap --classic --dangerous
+            sudo usermod --append --groups microk8s ubuntu
+            sudo snap install juju-helpers --classic
+          EOF
 
-    - name: Describe MicroK8s pods
-      run: juju ssh ubuntu/0 sudo microk8s kubectl describe pods -nkubeflow
-      if: failure()
+      - name: Enable kubeflow
+        timeout-minutes: 45
+        run: |
+          juju ssh ubuntu/0 <<EOF
+            set -eux
+            export KUBEFLOW_BUNDLE=${{ matrix.bundle }}
+            export KUBEFLOW_DEBUG=true
+            export KUBEFLOW_IGNORE_MIN_MEM=true
+            export KUBEFLOW_AUTH_PASSWORD=hunter2
+            microk8s enable kubeflow
+          EOF
 
-    - name: Generate inspect tarball
-      run: |
-        juju ssh ubuntu/0 <<EOF
-          sudo microk8s inspect | \
-            grep -Po "Report tarball is at \K.+" | \
-            sudo xargs -I {} mv {} inspection-report-${{ strategy.job-index }}.tar.gz
-        EOF
-        juju scp ubuntu/0:~/inspection-report-${{ strategy.job-index }}.tar.gz .
-      if: failure()
+      - name: Test kubeflow
+        run: |
+          juju ssh ubuntu/0 <<EOF
+            set -eux
+            export JUJU_DATA=/var/snap/microk8s/current/juju/share/juju
+            sudo apt update
+            sudo apt install -y libssl-dev python3-setuptools firefox-geckodriver
+            git clone https://github.com/juju-solutions/bundle-kubeflow.git
+            cd bundle-kubeflow
+            sudo pip3 install -r requirements.txt -r test-requirements.txt
+            sudo microk8s status --wait-ready
+            sudo microk8s kubectl -n kube-system rollout status ds/calico-node
+            trap 'sudo pkill -f svc/pipelines-api' SIGINT SIGTERM EXIT
+            microk8s kubectl -n kubeflow port-forward svc/pipelines-api 8888:8888 &
+            (i=30; while ! curl localhost:8888 ; do ((--i)) || exit; sleep 1; done)
+            pytest -vvs -m ${{ matrix.bundle }} -k 'not kubectl'
+            pytest -vvs -m ${{ matrix.bundle }} -k 'kubectl'
+          EOF
 
-    - name: Upload inspect tarball
-      uses: actions/upload-artifact@v2
-      with:
-        name: inspection-report-aws
-        path: ./inspection-report-${{ strategy.job-index }}.tar.gz
-      if: failure()
+      - name: Get MicroK8s pods
+        run: juju ssh ubuntu/0 sudo microk8s kubectl get pods -A --sort-by=.metadata.name
+        if: failure()
+
+      - name: Describe MicroK8s pods
+        run: juju ssh ubuntu/0 sudo microk8s kubectl describe pods -nkubeflow
+        if: failure()
+
+      - name: Generate inspect tarball
+        run: |
+          juju ssh ubuntu/0 <<EOF
+            sudo microk8s inspect | \
+              grep -Po "Report tarball is at \K.+" | \
+              sudo xargs -I {} mv {} inspection-report-${{ strategy.job-index }}.tar.gz
+          EOF
+          juju scp ubuntu/0:~/inspection-report-${{ strategy.job-index }}.tar.gz .
+        if: failure()
+
+      - name: Upload inspect tarball
+        uses: actions/upload-artifact@v2
+        with:
+          name: inspection-report-aws
+          path: ./inspection-report-${{ strategy.job-index }}.tar.gz
+        if: failure()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,15 +101,24 @@ apps:
     command: microk8s-dbctl.wrapper
 
 parts:
+  libuv:
+    source: https://github.com/libuv/libuv
+    source-tag: v1.18.0
+    build-attributes: [no-patchelf]
+    source-type: git
+    plugin: autotools
+    organize:
+      usr/lib/: lib/
+    prime:
+      - lib/libuv*so*
+
   raft:
+    after:
+      - libuv
     source: https://github.com/canonical/raft
     build-attributes: [no-patchelf]
     source-type: git
     plugin: autotools
-    configflags:
-      - --enable-debug
-    stage-packages:
-      - libuv1
     organize:
       usr/lib/: lib/
       include/: usr/include/
@@ -146,16 +155,12 @@ parts:
     after:
       - raft
       - sqlite
+      - libuv
     source: https://github.com/canonical/dqlite
     build-attributes: [no-patchelf]
     source-type: git
     plugin: autotools
-    configflags:
-      - --enable-debug
-    stage-packages:
-      - libuv1
     build-packages:
-      - libuv1-dev
       - pkg-config
     organize:
       usr/lib/: lib/


### PR DESCRIPTION
Raft now requires libuv v1.18.0 to build. As this is not available in core we need to build it.
