### PR TITLE
Feature/upgrade jaeger

### DIFF
--- a/microk8s-resources/actions/jaeger/operator.yaml
+++ b/microk8s-resources/actions/jaeger/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: jaeger-operator
       containers:
         - name: jaeger-operator
-          image: jaegertracing/jaeger-operator:1.14.0
+          image: jaegertracing/jaeger-operator:1.21.3
           ports:
             - containerPort: 8383
               name: metrics

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -95,7 +95,7 @@ microk8s-addons:
 
     - name: "jaeger"
       description: "Kubernetes Jaeger operator with its simple config"
-      version: "1.14.0"
+      version: "1.21.3"
       check_status: "pod/jaeger-operator"
       supported_architectures:
         - amd64
@@ -110,7 +110,7 @@ microk8s-addons:
 
     - name: "cilium"
       description: "SDN, fast with full network policy"
-      version: "1.6"
+      version: "1.8"
       check_status: "pod/cilium"
       supported_architectures:
         - amd64


### PR DESCRIPTION
Upgrades Jaeger Operator to 1.21.3

Small typo fix on the Cilium version in the addon-list.

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
