### PR TITLE
Feature/contd141

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -21,6 +21,7 @@ jobs:
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
+          sudo snap install lxd
       - name: Install snapcraft
         run: sudo snap install snapcraft --classic
       - name: Build snap

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Create snap package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checking out repo
@@ -21,7 +21,6 @@ jobs:
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
-          sudo snap install lxd
       - name: Install snapcraft
         run: sudo snap install snapcraft --classic
       - name: Build snap

--- a/build-scripts/set-env-variables.sh
+++ b/build-scripts/set-env-variables.sh
@@ -16,8 +16,8 @@ export CNI_VERSION="${CNI_VERSION:-v0.7.1}"
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v0.13.0}"
 export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v0.13.0}"
 # RUNC commit matching the containerd release commit
-# Tag 1.3.7
-export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-8fba4e9a7d01810a393d5d25a3621dc101981175}"
+# Tag 1.4.1
+export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-c623d1b36f09f8ef6536a057bd658b3aa8632828}"
 # Release v1.0.0-rc92
 export RUNC_COMMIT="${RUNC_COMMIT:-ff819c7e9184c13b7c2607fe6c30ae19403a7aff}"
 # Set this to the kubernetes fork you want to build binaries from

--- a/build-scripts/set-env-variables.sh
+++ b/build-scripts/set-env-variables.sh
@@ -16,8 +16,8 @@ export CNI_VERSION="${CNI_VERSION:-v0.7.1}"
 export KNATIVE_SERVING_VERSION="${KNATIVE_SERVING_VERSION:-v0.13.0}"
 export KNATIVE_EVENTING_VERSION="${KNATIVE_EVENTING_VERSION:-v0.13.0}"
 # RUNC commit matching the containerd release commit
-# Tag 1.4.1
-export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-c623d1b36f09f8ef6536a057bd658b3aa8632828}"
+# Tag 1.4.3
+export CONTAINERD_COMMIT="${CONTAINERD_COMMIT:-269548fa27e0089a8b8278fc4fc781d7f65a939b}"
 # Release v1.0.0-rc92
 export RUNC_COMMIT="${RUNC_COMMIT:-ff819c7e9184c13b7c2607fe6c30ae19403a7aff}"
 # Set this to the kubernetes fork you want to build binaries from


### PR DESCRIPTION
Wanting to test cgroups v2 support which would need containerd >= 1.4  so i replicated the pr from @Richard87 (#1695)  in Issue #651. On this codebase which is currently K8s 1.20
 I am trying to test this on a ubuntu 20:10 Pi cluster, unfortunately the artifacts from the github action checks output an amd64 compatible snap. It needs an arm64 snap 😞 
