### PR TITLE
Pin versions of pip packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -405,9 +405,9 @@ parts:
     python-version: python3
     source: .
     python-packages:
-      - flask
-      - PyYAML
-      - netifaces
+      - flask == 1.1.2
+      - PyYAML == 5.3.1
+      - netifaces == 0.10.9
     stage-packages:
       - python3-openssl
       - openssl


### PR DESCRIPTION
Pip packages broke the build of ARM64. Pin the pipy packages so we do not have this problem in the future.

Fixes: https://github.com/ubuntu/microk8s/issues/2049

