### PR TITLE
Update Addon kube prometheus  to v0.7.0

### DIFF
--- a/microk8s-resources/actions/enable.prometheus.sh
+++ b/microk8s-resources/actions/enable.prometheus.sh
@@ -21,7 +21,7 @@ do_prerequisites() {
 get_kube_prometheus () {
   if [  ! -d "${SNAP_DATA}/kube-prometheus" ]
   then
-    KUBE_PROMETHEUS_VERSION="v0.6.0"
+    KUBE_PROMETHEUS_VERSION="v0.7.0"
     KUBE_PROMETHEUS_ERSION=$(echo $KUBE_PROMETHEUS_VERSION | sed 's/v//g')
     echo "Fetching kube-prometheus version $KUBE_PROMETHEUS_VERSION."
     run_with_sudo mkdir -p "${SNAP_DATA}/kube-prometheus"

--- a/microk8s-resources/actions/enable.prometheus.sh
+++ b/microk8s-resources/actions/enable.prometheus.sh
@@ -37,12 +37,9 @@ get_kube_prometheus () {
 
 use_multiarch_images() {
   # Use multi-arch kube-state-metrics
-  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-state-metrics:v1.9.5@gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics:v1.9.7@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
-  # use kube-rbac-proxy multi-arch
-  # This is the same image used in the master branch of kube-prometheus
-  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-rbac-proxy:v0.4.1@quay.io/brancz/kube-rbac-proxy:v0.8.0@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
-  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-rbac-proxy:v0.4.1@quay.io/brancz/kube-rbac-proxy:v0.8.0@g' ${SNAP_DATA}/kube-prometheus/manifests/node-exporter-daemonset.yaml
-  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-rbac-proxy:v0.4.1@quay.io/brancz/kube-rbac-proxy:v0.8.0@g' ${SNAP_DATA}/kube-prometheus/manifests/setup/prometheus-operator-deployment.yaml
+  # According to this comment https://github.com/prometheus-community/helm-charts/issues/373#issuecomment-784031428, kube-state-metrics v1.9.8 in quay.io is multi-arch
+  # so upgrading it to 1.9.8 for now.
+  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-state-metrics:v1.9.7@quay.io/coreos/kube-state-metrics:v1.9.8@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
 }
 
 

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -80,7 +80,7 @@ microk8s-addons:
 
     - name: "prometheus"
       description: "Prometheus operator for monitoring and logging"
-      version: "v0.6.0"
+      version: "v0.7.0"
       check_status: "pod/prometheus-k8s-0"
       supported_architectures:
         - amd64


### PR DESCRIPTION
### Kube-prometheus v0.7.0

Closes #2059

Contains the following upgrades:

* Grafana v7.3.4
* Prometheus v2.22.1

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
