### PR TITLE
Change openfaas flags to enable auth by default

### DIFF
--- a/microk8s-resources/actions/enable.openfaas.sh
+++ b/microk8s-resources/actions/enable.openfaas.sh
@@ -16,7 +16,7 @@ echo ""
 echo "Enabling OpenFaaS"
 
 OPERATOR=false
-AUTH=false
+AUTH=true
 VALUES=""
 
 for i in "$@"
@@ -26,8 +26,8 @@ case $i in
     OPERATOR=true
     shift # past argument
     ;;
-    --auth)
-    AUTH=true
+    --no-auth)
+    AUTH=false
     shift # past argument
     ;;
     -f=*|--values=*)
@@ -77,4 +77,3 @@ fi
 
 # print a final help message
 echo "OpenFaaS has been installed"
-


### PR DESCRIPTION
**What**
- Change `--auth` flag to `--no-auth` flag and set the AUTH varialbe to
  true by default. This enables basic auth by default. At the end of the
  installation, the helm message will print the instructions required to
  retrieve the password value.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.

I treid to submit the CLA but I don't know who to put into the "Please add the Canonical Project Manager or contact" field.