### PR TITLE
Fix CSI init race condition

### DIFF
--- a/build-scripts/patches/0003-Fix-CSI-initialization-conflict.patch
+++ b/build-scripts/patches/0003-Fix-CSI-initialization-conflict.patch
@@ -1,0 +1,51 @@
+From 06848ba08ce2737e9d25ba26d799aba608815b7b Mon Sep 17 00:00:00 2001
+From: Darren Shepherd <darren@rancher.com>
+Date: Fri, 30 Aug 2019 11:22:18 -0700
+Subject: [PATCH] Fix CSI initialization conflict
+
+CSI is used by both the kubelet and kube-controller-manager.  Both
+components will initialize the csiPlugin with different VolumeHost
+objects.  The csiPlugin will then assign a global variable for
+the node info manager.  It is then possible that the kubelet gets
+the credentials of the kube-controller-manager and that will cause
+CSI to fail.
+---
+ pkg/volume/csi/csi_plugin.go | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/pkg/volume/csi/csi_plugin.go b/pkg/volume/csi/csi_plugin.go
+index 7fb89f688ba..b973176892e 100644
+--- a/pkg/volume/csi/csi_plugin.go
++++ b/pkg/volume/csi/csi_plugin.go
+@@ -238,21 +238,25 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {
+ 	}
+ 
+ 	// Initializing the label management channels
+-	nim = nodeinfomanager.NewNodeInfoManager(host.GetNodeName(), host, migratedPlugins)
++	localNim := nodeinfomanager.NewNodeInfoManager(host.GetNodeName(), host, migratedPlugins)
+ 
+ 	if utilfeature.DefaultFeatureGate.Enabled(features.CSINodeInfo) &&
+ 		utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) {
+ 		// This function prevents Kubelet from posting Ready status until CSINode
+ 		// is both installed and initialized
+-		if err := initializeCSINode(host); err != nil {
++		if err := initializeCSINode(host, localNim); err != nil {
+ 			return errors.New(log("failed to initialize CSINode: %v", err))
+ 		}
+ 	}
+ 
++	if _, ok := host.(volume.KubeletVolumeHost); ok {
++		nim = localNim
++	}
++
+ 	return nil
+ }
+ 
+-func initializeCSINode(host volume.VolumeHost) error {
++func initializeCSINode(host volume.VolumeHost, nim nodeinfomanager.Interface) error {
+ 	kvh, ok := host.(volume.KubeletVolumeHost)
+ 	if !ok {
+ 		klog.V(4).Info("Cast from VolumeHost to KubeletVolumeHost failed. Skipping CSINode initialization, not running on kubelet")
+-- 
+2.25.1
+


### PR DESCRIPTION
Introduce a patch to kubernetes to handle a CSI initialization race condition. Read more on the issue at https://github.com/k3s-io/k3s/issues/287
