### PR TITLE
Go 1.16. And updated k8s patches.

### DIFF
--- a/build-scripts/pre-patches/0001-Kubelite-integration.patch
+++ b/build-scripts/pre-patches/0001-Kubelite-integration.patch
@@ -1,24 +1,24 @@
-From 4fd6fd040bef1b23657541e97a05544e1ec487f8 Mon Sep 17 00:00:00 2001
+From a4411a5cff78419af796e1a46d5c8a988eb8a2fa Mon Sep 17 00:00:00 2001
 From: Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>
 Date: Wed, 3 Mar 2021 18:19:37 +0200
-Subject: [PATCH] Kubelite integration
+Subject: [PATCH 1/1] Kubelite integration
 
 ---
  cmd/kube-apiserver/app/server.go    |  9 ++--
- cmd/kubelet/app/server.go           | 12 +++--
+ cmd/kubelet/app/server.go           | 11 ++--
  cmd/kubelite/app/daemons/daemon.go  | 84 +++++++++++++++++++++++++++++
  cmd/kubelite/app/options/options.go | 79 +++++++++++++++++++++++++++
  cmd/kubelite/app/server.go          | 79 +++++++++++++++++++++++++++
  cmd/kubelite/kubelite.go            | 28 ++++++++++
  pkg/volume/csi/csi_plugin.go        | 10 ++--
- 7 files changed, 291 insertions(+), 10 deletions(-)
+ 7 files changed, 291 insertions(+), 9 deletions(-)
  create mode 100644 cmd/kubelite/app/daemons/daemon.go
  create mode 100644 cmd/kubelite/app/options/options.go
  create mode 100644 cmd/kubelite/app/server.go
  create mode 100644 cmd/kubelite/kubelite.go
 
 diff --git a/cmd/kube-apiserver/app/server.go b/cmd/kube-apiserver/app/server.go
-index f989bc3f..06aa91b3 100644
+index 9fb54ec9a64..ade92c7337b 100644
 --- a/cmd/kube-apiserver/app/server.go
 +++ b/cmd/kube-apiserver/app/server.go
 @@ -106,7 +106,7 @@ func checkNonZeroInsecurePort(fs *pflag.FlagSet) error {
@@ -30,7 +30,7 @@ index f989bc3f..06aa91b3 100644
  	s := options.NewServerRunOptions()
  	cmd := &cobra.Command{
  		Use: "kube-apiserver",
-@@ -141,8 +141,11 @@ cluster's shared state through which all other components interact.`,
+@@ -142,8 +142,11 @@ cluster's shared state through which all other components interact.`,
  			if errs := completedOptions.Validate(); len(errs) != 0 {
  				return utilerrors.NewAggregate(errs)
  			}
@@ -45,7 +45,7 @@ index f989bc3f..06aa91b3 100644
  		Args: func(cmd *cobra.Command, args []string) error {
  			for _, arg := range args {
 diff --git a/cmd/kubelet/app/server.go b/cmd/kubelet/app/server.go
-index 6a60dc32..470fe219 100644
+index 97bb522734d..1a9b6beb7b5 100644
 --- a/cmd/kubelet/app/server.go
 +++ b/cmd/kubelet/app/server.go
 @@ -110,7 +110,7 @@ const (
@@ -57,11 +57,10 @@ index 6a60dc32..470fe219 100644
  	cleanFlagSet := pflag.NewFlagSet(componentKubelet, pflag.ContinueOnError)
  	cleanFlagSet.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
  	kubeletFlags := options.NewKubeletFlags()
-@@ -260,12 +260,16 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
- 			// add the kubelet config controller to kubeletDeps
+@@ -261,7 +261,12 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
  			kubeletDeps.KubeletConfigController = kubeletConfigController
  
--			// set up signal context here in order to be reused by kubelet and docker shim
+ 			// set up signal context here in order to be reused by kubelet and docker shim
 -			ctx := genericapiserver.SetupSignalContext()
 +			runctx := context.Background()
 +			if len(ctx) == 0 {
@@ -70,8 +69,12 @@ index 6a60dc32..470fe219 100644
 +				runctx = ctx[0]
 +			}
  
+ 			// make the kubelet's config safe for logging
+ 			config := kubeletServer.KubeletConfiguration.DeepCopy()
+@@ -272,7 +277,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
+ 			klog.V(5).Infof("KubeletConfiguration: %#v", config)
+ 
  			// run the kubelet
- 			klog.V(5).Infof("KubeletConfiguration: %#v", kubeletServer.KubeletConfiguration)
 -			if err := Run(ctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate); err != nil {
 +			if err := Run(runctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate); err != nil {
  				klog.Fatal(err)
@@ -79,7 +82,7 @@ index 6a60dc32..470fe219 100644
  		},
 diff --git a/cmd/kubelite/app/daemons/daemon.go b/cmd/kubelite/app/daemons/daemon.go
 new file mode 100644
-index 00000000..dbef03cf
+index 00000000000..dbef03cf07e
 --- /dev/null
 +++ b/cmd/kubelite/app/daemons/daemon.go
 @@ -0,0 +1,84 @@
@@ -170,7 +173,7 @@ index 00000000..dbef03cf
 \ No newline at end of file
 diff --git a/cmd/kubelite/app/options/options.go b/cmd/kubelite/app/options/options.go
 new file mode 100644
-index 00000000..80f1d8b0
+index 00000000000..80f1d8b09fc
 --- /dev/null
 +++ b/cmd/kubelite/app/options/options.go
 @@ -0,0 +1,79 @@
@@ -255,7 +258,7 @@ index 00000000..80f1d8b0
 +}
 diff --git a/cmd/kubelite/app/server.go b/cmd/kubelite/app/server.go
 new file mode 100644
-index 00000000..e7452a09
+index 00000000000..e7452a09e3e
 --- /dev/null
 +++ b/cmd/kubelite/app/server.go
 @@ -0,0 +1,79 @@
@@ -340,7 +343,7 @@ index 00000000..e7452a09
 +}
 diff --git a/cmd/kubelite/kubelite.go b/cmd/kubelite/kubelite.go
 new file mode 100644
-index 00000000..667b24f6
+index 00000000000..667b24f68e6
 --- /dev/null
 +++ b/cmd/kubelite/kubelite.go
 @@ -0,0 +1,28 @@
@@ -373,7 +376,7 @@ index 00000000..667b24f6
 +	println("Stopping kubelite")
 +}
 diff --git a/pkg/volume/csi/csi_plugin.go b/pkg/volume/csi/csi_plugin.go
-index 85c1c1f3..b90c8222 100644
+index 85c1c1f3db1..b90c82225f5 100644
 --- a/pkg/volume/csi/csi_plugin.go
 +++ b/pkg/volume/csi/csi_plugin.go
 @@ -237,20 +237,24 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -250,6 +250,7 @@ parts:
       - git
     override-build: |
       set -eux
+      snap refresh go --channel=1.16/stable || true
       . ./set-env-variables.sh
 
       # if "${KUBE_SNAP_BINS}" exist we have to use the binaries from there


### PR DESCRIPTION
K8s 1.21.0-beta.1 enforced golang 1.16 and also caused some patch conflicts.