### PR TITLE
Create sym link to SNAP_COMMON

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -96,6 +96,14 @@ then
   refresh_opt_in_local_config "kubelet-cgroups" "/systemd/system.slice" kubelet
 fi
 
+if [ -L /var/lib/kubelet ]
+then
+  echo "\`/var/lib/kubelet\` is a symbolic link"
+  ls -l /var/lib/kubelet
+else
+  echo "\`/var/lib/kubelet\` already exists. CSI add-ons have to point to $SNAP_COMMON for kubelet."
+fi
+
 ## Kube-proxy configuration
 # Check if we advertise an address. If we do we do not need to wait for a default network interface.
 if ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -14,11 +14,11 @@ cp -r ${SNAP}/default-args ${SNAP_DATA}/args
 # Sym link the host's /var/lib/kubelet to the Snap's.  This will be fixed with layouts when
 # this Snap is strictly confined.  Warn if there's already a directory.
 if ! test -d /var/lib/kubelet
-do
+then
   ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kubelet
 else
   echo "\`/var/lib/kubectl\` already exists.  This might cause odd behaviour."
-done
+fi
 
 # Create the certificates
 mkdir ${SNAP_DATA}/certs

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -17,7 +17,7 @@ if ! test -d /var/lib/kubelet
 then
   ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kubelet
 else
-  echo "\`/var/lib/kubectl\` already exists.  This might cause odd behaviour."
+  echo "\`/var/lib/kubelet\` already exists.  This might cause odd behaviour."
 fi
 
 # Create the certificates

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -13,11 +13,12 @@ cp -r ${SNAP}/default-args ${SNAP_DATA}/args
 
 # Sym link the host's /var/lib/kubelet to the Snap's.  This will be fixed with layouts when
 # this Snap is strictly confined.  Warn if there's already a directory.
-if ! test -d /var/lib/kubelet
+if ! [ -e /var/lib/kubelet ] &&
+   ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kubelet
 then
-  ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kubelet
+  echo "\`/var/lib/kubelet\` linked to $SNAP_COMMON"
 else
-  echo "\`/var/lib/kubelet\` already exists.  This might cause odd behaviour."
+  echo "\`/var/lib/kubelet\` already exists.  Will not be linking to $SNAP_COMMON"
 fi
 
 # Create the certificates

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -11,6 +11,15 @@ source $SNAP/actions/common/utils.sh
 
 cp -r ${SNAP}/default-args ${SNAP_DATA}/args
 
+# Sym link the host's /var/lib/kubelet to the Snap's.  This will be fixed with layouts when
+# this Snap is strictly confined.  Warn if there's already a directory.
+if ! test -d /var/lib/kubelet
+do
+  ln -s $SNAP_COMMON/var/lib/kubelet /var/lib/kubelet
+else
+  echo "\`/var/lib/kubectl\` already exists.  This might cause odd behaviour."
+done
+
 # Create the certificates
 mkdir ${SNAP_DATA}/certs
 # Allow the ability to add external IPs to the csr, by moving the csr.conf.template to SNAP_DATA
@@ -107,4 +116,3 @@ rm -rf "$SNAP_DATA"/args/cni-network/*
 cp "$RESOURCES/calico.yaml" "$SNAP_DATA/args/cni-network/cni.yaml"
 mkdir -p "$SNAP_DATA/opt/cni/bin/"
 cp -R "$SNAP"/opt/cni/bin/* "$SNAP_DATA"/opt/cni/bin/
-

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -17,7 +17,7 @@ snapctl stop ${SNAP_NAME}.daemon-docker 2>&1 || true
 # this Snap is strictly confined.
 if test -L /var/lib/kubelet
 then
-  unlink /var/lib/kubelet
+  unlink /var/lib/kubelet || true
 fi
 
 pod_cidr="$(cat $SNAP_DATA/args/kubelet | grep "pod-cidr" | tr "=" " "| gawk '{print $2}')"

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -16,9 +16,9 @@ snapctl stop ${SNAP_NAME}.daemon-docker 2>&1 || true
 # Sym link the host's /var/lib/kubelet to the Snap's.  This will be fixed with layouts when
 # this Snap is strictly confined.
 if test -L /var/lib/kubelet
-do
+then
   unlink /var/lib/kubelet
-done
+fi
 
 pod_cidr="$(cat $SNAP_DATA/args/kubelet | grep "pod-cidr" | tr "=" " "| gawk '{print $2}')"
 if [ -z "$pod_cidr" ]

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -13,6 +13,13 @@ else
 fi
 snapctl stop ${SNAP_NAME}.daemon-docker 2>&1 || true
 
+# Sym link the host's /var/lib/kubelet to the Snap's.  This will be fixed with layouts when
+# this Snap is strictly confined.
+if test -L /var/lib/kubelet
+do
+  unlink /var/lib/kubelet
+done
+
 pod_cidr="$(cat $SNAP_DATA/args/kubelet | grep "pod-cidr" | tr "=" " "| gawk '{print $2}')"
 if [ -z "$pod_cidr" ]
 then


### PR DESCRIPTION
To stop hard coded host mounts from using the wrong directory.