### PR TITLE
Handle containerd refreshes/restarts

### DIFF
--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -53,7 +53,8 @@ do
       chgrp microk8s -R ${SNAP_DATA}/var/kubernetes/backend || true
     fi
 
-    if ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
+    if ! [ -e "${SNAP_DATA}/var/lock/no-network-change-monitor" ] &&
+       ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
        ip route | grep default &> /dev/null
     then
       if snapctl services microk8s.daemon-kubelite | grep active &> /dev/null
@@ -64,6 +65,12 @@ do
             echo "CSR change detected. Reconfiguring the kube-apiserver"
             rm -rf .srl
             snapctl restart microk8s.daemon-kubelite
+            # we need to restart containers to pickup the new certificates
+            snapctl stop microk8s.daemon-containerd
+            systemctl kill snap.microk8s.daemon-containerd.service --signal=SIGKILL &>/dev/null || true
+            snapctl start microk8s.daemon-containerd
+            start_all_containers
+
             restart_attempt=$[$restart_attempt+1]
         else
             restart_attempt=0

--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -12,6 +12,8 @@ then
     exit 0
 fi
 
+exit_if_no_permissions
+
 PARSED=$(getopt --options=lho: --longoptions=help,output: --name "$@" -- "$@")
 eval set -- "$PARSED"
 while true; do

--- a/microk8s-resources/wrappers/microk8s-stop.wrapper
+++ b/microk8s-resources/wrappers/microk8s-stop.wrapper
@@ -13,6 +13,8 @@ then
     exit 0
 fi
 
+exit_if_no_permissions
+
 FORCE=false
 PARSED=$(getopt --options=lho: --longoptions=force,help,output: --name "$@" -- "$@")
 eval set -- "$PARSED"

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -46,6 +46,14 @@ set -a
 . "${SNAP_DATA}/args/${app}-env"
 set +a
 
+# clean leftover container state if we just booted
+if (is_first_boot "${SNAP_COMMON}/run/containerd")
+then
+  rm -rf "${SNAP_COMMON}/run/containerd" || true
+fi
+mkdir -p "${SNAP_COMMON}/run/containerd"
+mark_boot_time "${SNAP_COMMON}/run/containerd"
+
 # wait up to two minutes for the default network interface to appear.
 n=0
 until [ $n -ge 20 ]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,9 +23,8 @@ apps:
     daemon: simple
   daemon-containerd:
     command: run-containerd-with-args
-    daemon: notify
+    daemon: simple
     stop-mode: sigterm
-    restart-condition: always
     plugs: [kubernetes-support]
   daemon-kubelite:
     command: run-kubelite-with-args


### PR DESCRIPTION
With this work:
- Containerd is handled as a "simple" daemon. Since we have "stop-mode: sigterm" in a refresh/restart only the containerd process gets terminated, the workload containers are kept as they were.
- We mark when containerd starts in the `last-start-date` file. This way we can detect if we start after a reboot, in which case we clean the container state leftover.
- The `microk8s stop/start` command require now sudo or a user in the microk8s group.