### PR TITLE
Do not ship openfaas on arm64

### DIFF
--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -204,7 +204,6 @@ microk8s-addons:
       version: "6.2.2"
       check_status: "pod/gateway"
       supported_architectures:
-        - arm64
         - amd64
 
     - name: "openebs"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -506,6 +506,9 @@ parts:
         # OpenEBS support
         rm "actions/enable.openebs.sh"
         rm "actions/disable.openebs.sh"        
+        # OpenFaaS support
+        rm "actions/enable.openfaas.sh"
+        rm "actions/disable.openfaas.sh"
       fi
 
       echo "Creating inspect hook"

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -360,7 +360,8 @@ class TestAddons(object):
         microk8s_disable("portainer")
 
     @pytest.mark.skipif(
-        platform.machine() != "x86_64", reason="OpenFaaS tests are only relevant in x86 architectures"
+        platform.machine() != "x86_64",
+        reason="OpenFaaS tests are only relevant in x86 architectures",
     )
     def test_openfaas(self):
         """
@@ -412,6 +413,10 @@ class TestAddons(object):
         check_call("/snap/bin/microk8s.dbctl --debug backup -o backupfile".split())
         check_call("/snap/bin/microk8s.dbctl --debug restore backupfile.tar.gz".split())
 
+    @pytest.mark.skipif(
+        platform.machine() != "x86_64",
+        reason="OpenEBS tests are only relevant in x86 architectures",
+    )
     def test_openebs(self):
         """
         Sets up and validates openebs.

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -359,6 +359,9 @@ class TestAddons(object):
         print("Disabling Portainer")
         microk8s_disable("portainer")
 
+    @pytest.mark.skipif(
+        platform.machine() != "x86_64", reason="OpenFaaS tests are only relevant in x86 architectures"
+    )
     def test_openfaas(self):
         """
         Sets up and validates OpenFaaS.


### PR DESCRIPTION
The manifests produced by the openfaas addon are amd64 specific. They have:
```
      nodeSelector:
        beta.kubernetes.io/arch: amd64
```
