### PR TITLE
Clean leftover containers after a cold boot

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -667,3 +667,33 @@ kill_all_container_shims() {
     run_with_sudo systemctl kill snap.microk8s.daemon-kubelet.service --signal=SIGKILL &>/dev/null || true
     run_with_sudo systemctl kill snap.microk8s.daemon-containerd.service --signal=SIGKILL &>/dev/null || true
 }
+
+is_first_boot() {
+  # Return 0 if this is the first start after the host booted.
+  # The argument $1 is a directory that may contain a last-start-date file
+  # The last-start-date file contains a date in seconds
+  # if that date is prior to the creation date of /proc/1 we assume this is the first
+  # time after the host booted
+  if ! [ -e "$1/last-start-date" ] ||
+     ! [ -e /proc/1 ]
+  then
+    return 1
+  else
+    last_start=$("$SNAP/bin/cat" "$1/last-start-date")
+    boot_time=$(date -r  /proc/1 +%s)
+    echo "Last time service started was $last_start and the host booted at $boot_time"
+    if [ "$last_start" -le "$boot_time" ]
+    then
+      return 0
+    else
+      return 1
+    fi
+  fi
+}
+
+mark_boot_time() {
+  # place the current time in the "$1"/last-start-date file
+  now=$(date +%s)
+  echo "$now" > "$1"/last-start-date
+}
+

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -40,6 +40,14 @@ then
   sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g;s@${SNAP_COMMON}@'"${SNAP_COMMON}"'@g' $SNAP_DATA/args/flannel-template.conflist > $SNAP_DATA/args/cni-network/flannel.conflist
 fi
 
+# clean leftover container state if we just booted
+if (is_first_boot "${SNAP_COMMON}/run/containerd")
+then
+  rm -rf "${SNAP_COMMON}/run/containerd" || true
+fi
+mkdir -p "${SNAP_COMMON}/run/containerd"
+mark_boot_time "${SNAP_COMMON}/run/containerd"
+
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/$app))"
 set -a


### PR DESCRIPTION
After a cold boot containerd will go over all leftover container entries and will try to revive them. This causes kubelet to not be able to start properly. In this PR we mark when containerd started so we know if this is the first time containerd started after a system boot. If it is a first start we manually remove all container entries since we know they do not run anymore.

Fixes: https://github.com/ubuntu/microk8s/issues/2071