### PR TITLE
Kata containers addon

### DIFF
--- a/microk8s-resources/actions/disable.kata.sh
+++ b/microk8s-resources/actions/disable.kata.sh
@@ -36,7 +36,7 @@ def restart_containerd():
         print("Restarting containerd")
         subprocess.call(['sudo', 'systemctl', 'restart', 'snap.microk8s.daemon-containerd'])
     except (subprocess.CalledProcessError):
-        print("Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manualy." )
+        print("Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manually." )
         sys.exit(3)
 
 

--- a/microk8s-resources/actions/disable.kata.sh
+++ b/microk8s-resources/actions/disable.kata.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import click
+import os
+import subprocess
+import sys
+from tempfile import mkstemp
+from shutil import move, copymode
+from os import fdopen, remove
+
+
+def mark_kata_disabled():
+    try:
+        snapdata_path = os.environ.get("SNAP_DATA")
+        lock_fname = "{}/var/lock/kata.enabled".format(snapdata_path)
+        subprocess.call(['sudo', 'rm', lock_fname])
+    except (subprocess.CalledProcessError):
+        print("Failed to mark the kata addon as disabled." )
+        sys.exit(4)
+
+def delete_runtime_manifest():
+    try:
+        snap_path = os.environ.get("SNAP")
+        manifest = "{}/actions/kata/runtime.yaml".format(snap_path)
+        subprocess.call(["microk8s-kubectl.wrapper", "delete", "-f", manifest])
+    except (subprocess.CalledProcessError):
+        print("Failed to apply the runtime manifest." )
+        sys.exit(5)
+
+
+def restart_containerd():
+    try:
+        print("Restarting containerd")
+        subprocess.call(['sudo', 'systemctl', 'restart', 'snap.microk8s.daemon-containerd'])
+    except (subprocess.CalledProcessError):
+        print("Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manualy." )
+        sys.exit(3)
+
+
+def configure_containerd(kata_path):
+    snapdata_path = os.environ.get("SNAP_DATA")
+    containerd_env_file = "{}/args/containerd-env".format(snapdata_path)
+    #Create temp file
+    fh, abs_path = mkstemp()
+    with fdopen(fh,'w') as tmp_file:
+        with open(containerd_env_file) as conf_file:
+            for line in conf_file:
+                if "KATA_PATH=" in line:
+                  line = "KATA_PATH=\n"
+                tmp_file.write(line)
+
+    copymode(containerd_env_file, abs_path)
+    remove(containerd_env_file)
+    move(abs_path, containerd_env_file)
+
+
+@click.command()
+def kata():
+
+    print("Configuring containerd")
+    configure_containerd(kata_path)
+    restart_containerd()
+    print("Deleting kata runtime manifest")
+    delete_runtime_manifest()
+    mark_kata_disabled()
+
+
+if __name__ == "__main__":
+    kata(prog_name="microk8s disable kata")

--- a/microk8s-resources/actions/disable.kata.sh
+++ b/microk8s-resources/actions/disable.kata.sh
@@ -10,6 +10,9 @@ from os import fdopen, remove
 
 
 def mark_kata_disabled():
+    """
+    Mark the kata addon as enabled by removing the kata.enabled lock
+    """
     try:
         snapdata_path = os.environ.get("SNAP_DATA")
         lock_fname = "{}/var/lock/kata.enabled".format(snapdata_path)
@@ -22,7 +25,7 @@ def delete_runtime_manifest():
     try:
         snap_path = os.environ.get("SNAP")
         manifest = "{}/actions/kata/runtime.yaml".format(snap_path)
-        subprocess.call(["microk8s-kubectl.wrapper", "delete", "-f", manifest])
+        subprocess.call(["{}/microk8s-kubectl.wrapper".format(snap_path), "delete", "-f", manifest])
     except (subprocess.CalledProcessError):
         print("Failed to apply the runtime manifest." )
         sys.exit(5)
@@ -37,7 +40,10 @@ def restart_containerd():
         sys.exit(3)
 
 
-def configure_containerd(kata_path):
+def configure_containerd():
+    """
+    Configure the containerd PATH by removing the kata runtime binary
+    """
     snapdata_path = os.environ.get("SNAP_DATA")
     containerd_env_file = "{}/args/containerd-env".format(snapdata_path)
     #Create temp file
@@ -56,9 +62,12 @@ def configure_containerd(kata_path):
 
 @click.command()
 def kata():
-
+    """
+    Disable the kata runtime. Mark it as disabled, delete the runtimeClassName but do not remove the
+    kata runtime because we do not know if it is used by any other application.
+    """
     print("Configuring containerd")
-    configure_containerd(kata_path)
+    configure_containerd()
     restart_containerd()
     print("Deleting kata runtime manifest")
     delete_runtime_manifest()

--- a/microk8s-resources/actions/enable.kata.sh
+++ b/microk8s-resources/actions/enable.kata.sh
@@ -42,7 +42,7 @@ def restart_containerd():
         print("Restarting containerd")
         subprocess.call(['sudo', 'systemctl', 'restart', 'snap.microk8s.daemon-containerd'])
     except (subprocess.CalledProcessError):
-        print("Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manualy." )
+        print("Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manually." )
         sys.exit(3)
 
 

--- a/microk8s-resources/actions/enable.kata.sh
+++ b/microk8s-resources/actions/enable.kata.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import click
+import os
+import subprocess
+import sys
+from tempfile import mkstemp
+from shutil import move, copymode
+from os import fdopen, remove
+
+
+def mark_kata_enabled():
+    try:
+        snapdata_path = os.environ.get("SNAP_DATA")
+        lock_fname = "{}/var/lock/kata.enabled".format(snapdata_path)
+        subprocess.call(['sudo', 'touch', lock_fname])
+    except (subprocess.CalledProcessError):
+        print("Failed to mark the kata addon as enabled." )
+        sys.exit(4)
+
+def apply_runtime_manifest():
+    try:
+        snap_path = os.environ.get("SNAP")
+        manifest = "{}/actions/kata/runtime.yaml".format(snap_path)
+        subprocess.call(["microk8s-kubectl.wrapper", "apply", "-f", manifest])
+    except (subprocess.CalledProcessError):
+        print("Failed to apply the runtime manifest." )
+        sys.exit(5)
+
+
+def restart_containerd():
+    try:
+        print("Restarting containerd")
+        subprocess.call(['sudo', 'systemctl', 'restart', 'snap.microk8s.daemon-containerd'])
+    except (subprocess.CalledProcessError):
+        print("Failed to restart containerd. Please, yry to 'microk8s stop' and 'microk8s start' manualy." )
+        sys.exit(3)
+
+
+def configure_containerd(kata_path):
+    snapdata_path = os.environ.get("SNAP_DATA")
+    containerd_env_file = "{}/args/containerd-env".format(snapdata_path)
+    #Create temp file
+    fh, abs_path = mkstemp()
+    with fdopen(fh,'w') as tmp_file:
+        with open(containerd_env_file) as conf_file:
+            for line in conf_file:
+                if "KATA_PATH=" in line:
+                  line = "KATA_PATH=\"{}\"\n".format(kata_path)
+                tmp_file.write(line)
+
+    copymode(containerd_env_file, abs_path)
+    remove(containerd_env_file)
+    move(abs_path, containerd_env_file)
+
+
+@click.command()
+@click.option(
+    "--runtime-path",
+    default=None,
+    help="The path to the kata container runtime binaries.",
+)
+def kata(runtime_path):
+
+    if not runtime_path:
+        try:
+            print("Installing kata-containers snap")
+            subprocess.call(['sudo', 'snap', 'install', 'kata-containers', '--classic'])
+            kata_path = "/snap/kata-containers/current/usr/bin/"
+        except (subprocess.CalledProcessError):
+            print("Failed to install kata-containers snap.")
+            print("Use the --runtime-path argument to point to the kata containers runtime binaries.")
+            sys.exit(1)
+    else:
+        kata_path = runtime_path
+
+    if not os.path.exists("{}/kata-containers.runtime".format(kata_path)):
+        print("Kata runtime binaries was not found under {}.".format(kata_path))
+        print("Use the --runtime-path argument to point to the right location.")
+        sys.exit(2)
+
+    configure_containerd(kata_path)
+    restart_containerd()
+    apply_runtime_manifest()
+    mark_kata_enabled()
+
+
+
+if __name__ == "__main__":
+    kata(prog_name="microk8s enable kata")

--- a/microk8s-resources/actions/kata/runtime.yaml
+++ b/microk8s-resources/actions/kata/runtime.yaml
@@ -1,0 +1,5 @@
+apiVersion: node.k8s.io/v1beta1
+kind: RuntimeClass
+metadata:
+  name: kata
+handler: kata

--- a/microk8s-resources/default-args/containerd-env
+++ b/microk8s-resources/default-args/containerd-env
@@ -1,3 +1,8 @@
+# Remember to restart MicroK8s after editing this file:
+#
+# sudo microk8s stop; sudo microk8s start
+#
+
 # To start containerd behind a proxy you need to add an HTTPS_PROXY
 # environment variable in this file. HTTPS_PROXY is of the following form:
 # HTTPS_PROXY=http://username:password@proxy:port/
@@ -11,11 +16,12 @@
 #
 # NO_PROXY=10.1.0.0/16,10.152.183.0/24
 #
-# Remember to restart MicroK8s after editing this file:
+
+# You can set the of the kata containers runtime here.
 #
-# sudo microk8s stop; sudo microk8s start
+# KATA_PATH=
 #
-#
+PATH=$PATH:$KATA_PATH
 
 # Attempt to change the maximum number of open file descriptors
 # this get inherited to the running containers
@@ -26,3 +32,4 @@ ulimit -n 65536 || true
 # this get inherited to the running containers
 #
 ulimit -l 16384 || true
+

--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -62,7 +62,7 @@ oom_score = 0
    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
       runtime_type = "io.containerd.kata.v2"
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
-        BinaryName = "kata-containers.runtime"
+        BinaryName = "kata-runtime"
 
   # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
   [plugins."io.containerd.grpc.v1.cri".cni]

--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -59,6 +59,11 @@ oom_score = 0
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime.options]
         BinaryName = "nvidia-container-runtime"
 
+   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+      runtime_type = "io.containerd.kata.v2"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
+        BinaryName = "kata-containers.runtime"
+
   # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
   [plugins."io.containerd.grpc.v1.cri".cni]
     # bin_dir is the directory in which the binaries for the plugin is kept.

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -221,3 +221,10 @@ microk8s-addons:
       check_status: "pod/openebs-apiserver"
       supported_architectures:
         - amd64
+
+    - name: "kata"
+      description: "Kata Containers is a secure runtime with lightweight VMS"
+      version: "latest/stable"
+      check_status: "${SNAP_DATA}/var/lock/kata.enabled"
+      supported_architectures:
+        - amd64

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -532,3 +532,28 @@ then
   fi
 fi
 
+# Add option to support kata containers
+if [ -e "${SNAP_DATA}/args/containerd-env" ] &&
+   ! grep -e "KATA_PATH" ${SNAP_DATA}/args/containerd-env
+then
+  echo "" >> "${SNAP_DATA}/args/containerd-env"" >> "${SNAP_DATA}/args/containerd-env"
+  echo "# You can set the of the kata containers runtime here." >> "${SNAP_DATA}/args/containerd-env"
+  echo "#" >> "${SNAP_DATA}/args/containerd-env"
+  echo "# KATA_PATH=" >> "${SNAP_DATA}/args/containerd-env"
+  echo "#" >> "${SNAP_DATA}/args/containerd-env"
+  echo "PATH=\$PATH:\$KATA_PATH" >> "${SNAP_DATA}/args/containerd-env"
+fi
+
+# Add option to support kata containers
+if [ -e "${SNAP_DATA}/args/containerd-template.toml" ] &&
+   ! grep -e "io.containerd.kata.v2" ${SNAP_DATA}/args/containerd-template.toml
+then
+  export KATA_HANDLER_BEFORE='[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime]'
+  export KATA_HANDLER_AFTER='
+   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+      runtime_type = "io.containerd.kata.v2"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
+        BinaryName = "kata-containers.runtime"
+        '
+    "$SNAP/bin/sed" -i "@$KATA_HANDLER_BEFORE@$KATA_HANDLER_AFTER@i" ${SNAP_DATA}/args/containerd-template.toml
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -283,6 +283,35 @@ then
   need_controller_restart=true
 fi
 
+# Add option to support kata containers
+if [ -e "${SNAP_DATA}/args/containerd-env" ] &&
+   ! grep -e "KATA_PATH" ${SNAP_DATA}/args/containerd-env
+then
+  echo "" >> "${SNAP_DATA}/args/containerd-env"
+  echo "# You can set the of the kata containers runtime here." >> "${SNAP_DATA}/args/containerd-env"
+  echo "#" >> "${SNAP_DATA}/args/containerd-env"
+  echo "# KATA_PATH=" >> "${SNAP_DATA}/args/containerd-env"
+  echo "#" >> "${SNAP_DATA}/args/containerd-env"
+  echo "PATH=\$PATH:\$KATA_PATH" >> "${SNAP_DATA}/args/containerd-env"
+fi
+
+# Add option to support kata containers
+if [ -e "${SNAP_DATA}/args/containerd-template.toml" ] &&
+   ! grep -e "io.containerd.kata.v2" ${SNAP_DATA}/args/containerd-template.toml
+then
+  KATA_HANDLER_BEFORE='\[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime\]'
+  KATA_HANDLER_AFTER='    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+      runtime_type = "io.containerd.kata.v2"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
+        BinaryName = "kata-runtime"
+        '
+  CD_TOML="${SNAP_DATA}/args/containerd-template.toml"
+  CD_TOML_TMP="${SNAP_DATA}/args/containerd-template.toml.tmp"
+
+  "$SNAP/usr/bin/gawk" -v kata="${KATA_HANDLER_AFTER}" '/'${KATA_HANDLER_BEFORE}'/{print kata }1' ${CD_TOML} > ${CD_TOML_TMP}
+  mv ${CD_TOML_TMP} ${CD_TOML}
+fi
+
 # Securing important directories
 for dir in ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock
 do
@@ -530,30 +559,4 @@ then
       touch "${SNAP_DATA}/var/lock/cni-loaded"
     fi
   fi
-fi
-
-# Add option to support kata containers
-if [ -e "${SNAP_DATA}/args/containerd-env" ] &&
-   ! grep -e "KATA_PATH" ${SNAP_DATA}/args/containerd-env
-then
-  echo "" >> "${SNAP_DATA}/args/containerd-env"" >> "${SNAP_DATA}/args/containerd-env"
-  echo "# You can set the of the kata containers runtime here." >> "${SNAP_DATA}/args/containerd-env"
-  echo "#" >> "${SNAP_DATA}/args/containerd-env"
-  echo "# KATA_PATH=" >> "${SNAP_DATA}/args/containerd-env"
-  echo "#" >> "${SNAP_DATA}/args/containerd-env"
-  echo "PATH=\$PATH:\$KATA_PATH" >> "${SNAP_DATA}/args/containerd-env"
-fi
-
-# Add option to support kata containers
-if [ -e "${SNAP_DATA}/args/containerd-template.toml" ] &&
-   ! grep -e "io.containerd.kata.v2" ${SNAP_DATA}/args/containerd-template.toml
-then
-  export KATA_HANDLER_BEFORE='[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime]'
-  export KATA_HANDLER_AFTER='
-   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
-      runtime_type = "io.containerd.kata.v2"
-      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
-        BinaryName = "kata-containers.runtime"
-        '
-    "$SNAP/bin/sed" -i "@$KATA_HANDLER_BEFORE@$KATA_HANDLER_AFTER@i" ${SNAP_DATA}/args/containerd-template.toml
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -500,6 +500,8 @@ parts:
         rm actions/*.keda.sh
         rm actions/*.openebs.sh
         rm actions/*.openfaas.sh
+        rm -rf "actions/kata"
+        rm actions/*.kata.sh
       fi
 
       # Remove addons that do not work on s390x
@@ -529,6 +531,8 @@ parts:
         rm actions/*.storage.sh
         rm actions/*.portainer.sh
         rm actions/*.linkerd.sh
+        rm -rf "actions/kata"
+        rm actions/*.kata.sh
       fi
 
       echo "Creating inspect hook"

--- a/tests/templates/nginx-kata.yaml
+++ b/tests/templates/nginx-kata.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: kata
+  name: nginx-kata
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: nginx
+    image: nginx
+

--- a/tests/templates/nginx-kata.yaml
+++ b/tests/templates/nginx-kata.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   runtimeClassName: kata
   containers:
-  - name: nginx
-    image: nginx
+    - name: nginx
+      image: nginx
 

--- a/tests/templates/nginx-kata.yaml
+++ b/tests/templates/nginx-kata.yaml
@@ -9,4 +9,3 @@ spec:
   containers:
     - name: nginx
       image: nginx
-

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -30,6 +30,7 @@ from validators import (
     validate_portainer,
     validate_openfaas,
     validate_openebs,
+    validate_kata,
 )
 from utils import (
     microk8s_enable,
@@ -37,6 +38,7 @@ from utils import (
     wait_for_namespace_termination,
     microk8s_disable,
     microk8s_reset,
+    is_container,
 )
 from subprocess import PIPE, STDOUT, CalledProcessError, check_call, run, check_output
 
@@ -449,6 +451,10 @@ class TestAddons(object):
         platform.machine() != "x86_64",
         reason="OpenEBS tests are only relevant in x86 architectures",
     )
+    @pytest.mark.skipif(
+        platform.machine() != "x86_64",
+        reason="OpenEBS tests are only relevant in x86 architectures",
+    )
     def test_openebs(self):
         """
         Sets up and validates openebs.
@@ -464,3 +470,22 @@ class TestAddons(object):
         except CalledProcessError:
             print("Nothing to do, since iscsid is not available")
             return
+
+    @pytest.mark.skipif(
+        platform.machine() != "x86_64",
+        reason="Kata tests are only relevant in x86 architectures",
+    )
+    @pytest.mark.skipif(
+        is_container(),
+        reason="Kata tests are only possible on real hardware",
+    )
+    def test_kata(self):
+        """
+        Sets up and validates kata.
+        """
+        print("Enabling kata")
+        microk8s_enable("kata")
+        print("Validating Kata")
+        validate_kata()
+        print("Disabling kata")
+        microk8s_disable("kata")

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -524,3 +524,15 @@ def validate_openebs():
     output = kubectl("exec openebs-test-busybox -- ls /", timeout_insec=900, err_out="no")
     assert "my-data" in output
     kubectl("delete -f {}".format(manifest))
+
+
+def validate_kata():
+    """
+    Validate Kata
+    """
+    wait_for_installation()
+    here = os.path.dirname(os.path.abspath(__file__))
+    manifest = os.path.join(here, "templates", "nginx-kata.yaml")
+    kubectl("apply -f {}".format(manifest))
+    wait_for_pod_state("", "default", "running", label="app=kata")
+    kubectl("delete -f {}".format(manifest))


### PR DESCRIPTION
[Kata Containers](https://katacontainers.io/), is used to build a secure container runtime with lightweight virtual machines that feel and perform like containers, but provide stronger workload isolation using hardware virtualization technology as a second layer of defense. You can enable kata support with: 

``` microk8s enable kata``` 

The addon adds the `kata` `runtimeClassName` that allows you to specify what workloads should be started in Kata containers. For instance, the following manifest starts nginx in a Kata container:

```
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: kata
  name: nginx-kata
spec:
  runtimeClassName: kata
  containers:
    - name: nginx
      image: nginx
```

By default the addon will install the Kata runtime via the [kata-containers snap](https://snapcraft.io/kata-containers). Alternatively, you can set the path of the where kata runtime is installed using the `--runtime-path` argument. The path you provide should include the `kata-runtime` binary:

```
microk8s enable kata --runtimepath=/path/to/runtime
```

To disable Kata support: 

```
microk8s disable kata
``` 

Note that disabling Kata will not remove the runtime from your system.
