### PR TITLE
Fixes for Centos7 support

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
         run: |
           echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      # DONT'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
+      # DO NOT FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADDRESSED!
       - name: Running upgrade path test
         run: |
           set -x

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -32,24 +32,12 @@ jobs:
         with:
           name: microk8s.snap
           path: microk8s.snap
-#      - name: Running upgrade path test
-#        run: |
-#          set -x
-#          sudo apt-get install python3-setuptools
-#          sudo pip3 install --upgrade pip
-#          sudo pip3 install -U pytest sh
-#          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade-path.py
-#          sudo snap remove microk8s --purge
       - name: Running addons tests
         run: |
           set -x
-#          sudo apt-get -y install open-iscsi
-#          sudo systemctl enable iscsid
           sudo snap install *.snap --classic --dangerous
-#          ./tests/smoke-test.sh
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
-#          (cd tests; pytest -s verify-branches.py)
           (cd tests; sudo -E pytest -s -ra test-addons.py)
           sudo snap remove microk8s --purge
       - name: Running upgrade tests

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           name: microk8s.snap
           path: microk8s.snap
+      # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
+      - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file
+        run: |
+          echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+      # DONT'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
       - name: Running addons tests
         run: |
           set -x

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -37,15 +37,24 @@ jobs:
         run: |
           echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       # DONT'T FORGET TO REMOVE CODE ABOVE WHEN ISSUE IS ADRESSED!
-      - name: Running addons tests
+      - name: Running upgrade path test
         run: |
           set -x
-          sudo snap install *.snap --classic --dangerous
           sudo apt-get install python3-setuptools
           sudo pip3 install --upgrade pip
           sudo pip3 install -U pytest sh
+          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade-path.py
+          sudo snap remove microk8s --purge
+      - name: Running addons tests
+        run: |
+          set -x
+          sudo apt-get -y install open-iscsi
+          sudo systemctl enable iscsid
+          sudo snap install *.snap --classic --dangerous
+          ./tests/smoke-test.sh
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
+          (cd tests; pytest -s verify-branches.py)
           (cd tests; sudo -E pytest -s -ra test-addons.py)
           sudo snap remove microk8s --purge
       - name: Running upgrade tests

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -36,6 +36,9 @@ jobs:
         run: |
           set -x
           sudo snap install *.snap --classic --dangerous
+          sudo apt-get install python3-setuptools
+          sudo pip3 install --upgrade pip
+          sudo pip3 install -U pytest sh
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
           (cd tests; sudo -E pytest -s -ra test-addons.py)

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -32,24 +32,24 @@ jobs:
         with:
           name: microk8s.snap
           path: microk8s.snap
-      - name: Running upgrade path test
-        run: |
-          set -x
-          sudo apt-get install python3-setuptools
-          sudo pip3 install --upgrade pip
-          sudo pip3 install -U pytest sh
-          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade-path.py
-          sudo snap remove microk8s --purge
+#      - name: Running upgrade path test
+#        run: |
+#          set -x
+#          sudo apt-get install python3-setuptools
+#          sudo pip3 install --upgrade pip
+#          sudo pip3 install -U pytest sh
+#          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade-path.py
+#          sudo snap remove microk8s --purge
       - name: Running addons tests
         run: |
           set -x
-          sudo apt-get -y install open-iscsi
-          sudo systemctl enable iscsid
+#          sudo apt-get -y install open-iscsi
+#          sudo systemctl enable iscsid
           sudo snap install *.snap --classic --dangerous
-          ./tests/smoke-test.sh
+#          ./tests/smoke-test.sh
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"
-          (cd tests; pytest -s verify-branches.py)
+#          (cd tests; pytest -s verify-branches.py)
           (cd tests; sudo -E pytest -s -ra test-addons.py)
           sudo snap remove microk8s --purge
       - name: Running upgrade tests

--- a/microk8s-resources/actions/disable.ha-cluster.sh
+++ b/microk8s-resources/actions/disable.ha-cluster.sh
@@ -33,7 +33,7 @@ then
   echo "Disabling HA will reset your cluster in a clean state."
   echo "Any running workloads will be stopped and any cluster configuration will be lost."
   echo "As this is a single node cluster and this is a destructive operation,"
-  echo "please use the \'--force\' flag."
+  echo "please use the '--force' flag."
   exit 2
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -321,6 +321,7 @@ parts:
   containerd:
     build-snaps: [go]
     after: [iptables]
+    build-attributes: [no-patchelf]
     source: build-scripts/
     plugin: dump
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -321,7 +321,6 @@ parts:
   containerd:
     build-snaps: [go]
     after: [iptables]
-    build-attributes: [no-patchelf]
     source: build-scripts/
     plugin: dump
     build-packages:
@@ -368,7 +367,6 @@ parts:
       - libnss-mymachines
       - conntrack
       - libssl1.0.0
-      - coreutils
     stage:
       - -sbin/xtables-multi
       - -sbin/iptables*
@@ -388,7 +386,14 @@ parts:
       - hostname
       - squashfs-tools
       - tar
+      - coreutils
       - diffutils
+      - iproute2
+      - ethtool
+      - libatm1
+      - net-tools
+      - util-linux
+      - zfsutils-linux
 
   cluster-agent:
     plugin: python
@@ -418,14 +423,6 @@ parts:
       - openssl
       - file
       - dpkg
-    stage-packages:
-      - ethtool
-      - libatm1
-      - net-tools
-      - util-linux
-      - zfsutils-linux
-      - iproute2
-      - python3-click
     source: .
     prime:
       - -README*

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -321,7 +321,7 @@ parts:
   containerd:
     build-snaps: [go]
     after: [iptables]
-    build-attributes: [no-patchelf]
+    # build-attributes: [no-patchelf]
     source: build-scripts/
     plugin: dump
     build-packages:
@@ -391,9 +391,9 @@ parts:
       - diffutils
       - iproute2
       - ethtool
-      - libatm1
       - net-tools
       - util-linux
+      - libatm1
       - zfsutils-linux
 
   cluster-agent:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -396,7 +396,6 @@ parts:
       - -sbin/iptables*
       - -lib/xtables
 
-
   bash-utils:
     source: snap
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -320,8 +320,8 @@ parts:
 
   containerd:
     build-snaps: [go]
-    after: [iptables]
-    # build-attributes: [no-patchelf]
+    after: [iptables, runc]
+    build-attributes: [no-patchelf]
     source: build-scripts/
     plugin: dump
     build-packages:
@@ -334,15 +334,6 @@ parts:
       go version
       export GOPATH=$(realpath ../go)
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
-
-      # Build runc
-      go get -d github.com/opencontainers/runc
-      (
-        cd $GOPATH/src/github.com/opencontainers/runc
-        git checkout ${RUNC_COMMIT}
-        make BUILDTAGS='seccomp apparmor'
-      )
-      cp $GOPATH/src/github.com/opencontainers/runc/runc $SNAPCRAFT_PART_INSTALL/bin/
 
       # Build containerd
       rm -rf $GOPATH
@@ -372,6 +363,40 @@ parts:
       - -sbin/xtables-multi
       - -sbin/iptables*
       - -lib/xtables
+
+  runc:
+    build-snaps: [go]
+    after: [iptables]
+    #build-attributes: [no-patchelf]
+    source: build-scripts/
+    plugin: dump
+    build-packages:
+      - btrfs-tools
+      - libseccomp-dev
+    override-build: |
+      set -eux
+      . $SNAPCRAFT_PART_SRC/set-env-variables.sh
+      snap refresh go --channel=1.15/stable || true
+      go version
+      export GOPATH=$(realpath ../go)
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+
+      # Build runc
+      go get -d github.com/opencontainers/runc
+      (
+        cd $GOPATH/src/github.com/opencontainers/runc
+        git checkout ${RUNC_COMMIT}
+        make BUILDTAGS='seccomp apparmor'
+      )
+      cp $GOPATH/src/github.com/opencontainers/runc/runc $SNAPCRAFT_PART_INSTALL/bin/
+
+      # Assemble the snap
+      snapcraftctl build
+    stage:
+      - -sbin/xtables-multi
+      - -sbin/iptables*
+      - -lib/xtables
+
 
   bash-utils:
     source: snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -367,7 +367,6 @@ parts:
   runc:
     build-snaps: [go]
     after: [iptables]
-    #build-attributes: [no-patchelf]
     source: build-scripts/
     plugin: dump
     build-packages:

--- a/tests/lxc/install-deps/images_centos-7
+++ b/tests/lxc/install-deps/images_centos-7
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+yum install epel-release -y
+yum install sudo -y
+yum install snapd -y
+systemctl enable --now snapd.socket
+ln -s /var/lib/snapd/snap /snap
+yum install python3-pip  -y
+yum install docker -y
+pip3 install -U pytest requests pyyaml sh
+
+# wait for the snapd seeding to take place!
+n=0
+until [ $n -ge 7 ]
+do
+  sudo snap install core18 && break  # substitute your command here
+  n=$[$n+1]
+  sleep 10
+done

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -71,7 +71,7 @@ class TestAddons(object):
 
         assert expected == {a["name"]: a["status"] for a in status["addons"]}
 
-    def _test_basic(self):
+    def test_basic(self):
         """
         Sets up and tests dashboard, dns, storage, registry, ingress, metrics server.
 

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -71,7 +71,7 @@ class TestAddons(object):
 
         assert expected == {a["name"]: a["status"] for a in status["addons"]}
 
-    def test_basic(self):
+    def _test_basic(self):
         """
         Sets up and tests dashboard, dns, storage, registry, ingress, metrics server.
 

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -26,7 +26,8 @@ function create_machine() {
   # Allow for the machine to boot and get an IP
   sleep 20
   tar cf - ./tests | lxc exec $NAME -- tar xvf - -C /var/tmp
-  DISTRO_DEPS="${DISTRO//:/_}"
+  DISTRO_DEPS_TMP="${DISTRO//:/_}"
+  DISTRO_DEPS="${DISTRO_DEPS_TMP////-}"
   lxc exec $NAME -- /bin/bash "/var/tmp/tests/lxc/install-deps/$DISTRO_DEPS"
   lxc exec $NAME -- reboot
   sleep 20


### PR DESCRIPTION
Fixes https://github.com/ubuntu/microk8s/issues/2181

- Build runc in its own part and patch-elf it
- Move a number of binaries into a patched-elf part
- Add a centos7 test option (eg `test-distro.sh images_centos-7 latest/edge latest/beta`)
