### PR TITLE
Fixed duplicated echo in microk8s-reset.wrapper

### DIFF
--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -51,9 +51,6 @@ clean_cluster() {
   echo "Calling clean_cluster"
   # Clean the cluster
 
-  echo "Calling clean_cluster"
-  # Clean the cluster
-
   NSES=$($KUBECTL get ns -o=name | awk -F/ '{print $2}' | paste -s --delimiters=' ')
   for NS in $NSES
   do


### PR DESCRIPTION
### Thank you for making MicroK8s better
Small fix. There was two duplicated echos in microk8s-reset.wrapper at clean_cluster() function.
*Also verify you have:*
* [ x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
