### PR TITLE
Fix yaml output of microk8s.status if not running - 1.20 (#2148)

### DIFF
--- a/scripts/wrappers/status.py
+++ b/scripts/wrappers/status.py
@@ -98,7 +98,7 @@ def print_short_yaml(isReady, enabled_addons, disabled_addons):
             print("  {}: disabled".format(disabled["name"]))
     else:
         print(
-            "{:>2} {} {}".format(
+            "{:>2}{} {}".format(
                 "",
                 "message:",
                 "microk8s is not running. Use microk8s inspect for a deeper inspection.",
@@ -135,7 +135,7 @@ def print_yaml(isReady, enabled_addons, disabled_addons):
             print("{:>4}status: disabled".format(""))
     else:
         print(
-            "{:>2} {} {}".format(
+            "{:>2}{} {}".format(
                 "",
                 "message:",
                 "microk8s is not running. Use microk8s inspect for a deeper inspection.",


### PR DESCRIPTION
Fix #2147

Signed-off-by: Karl-Philipp Richter <krichter@posteo.de>

Results in:
```
$ sudo killall -9 kube-apiserver ; microk8s.status --yaml
microk8s:
  running: False
  message: microk8s is not running. Use microk8s inspect for a deeper inspection.
```