### PR TITLE
Increase the controller and scheuler lease to one minute

### DIFF
--- a/microk8s-resources/default-args/kube-controller-manager
+++ b/microk8s-resources/default-args/kube-controller-manager
@@ -6,3 +6,4 @@
 --address=127.0.0.1
 --use-service-account-credentials
 --leader-elect-lease-duration=60s
+--leader-elect-renew-deadline=30s

--- a/microk8s-resources/default-args/kube-controller-manager
+++ b/microk8s-resources/default-args/kube-controller-manager
@@ -5,3 +5,4 @@
 --cluster-signing-key-file=${SNAP_DATA}/certs/ca.key
 --address=127.0.0.1
 --use-service-account-credentials
+--leader-elect-lease-duration=60s

--- a/microk8s-resources/default-args/kube-scheduler
+++ b/microk8s-resources/default-args/kube-scheduler
@@ -1,3 +1,4 @@
 --kubeconfig=${SNAP_DATA}/credentials/scheduler.config
 --address=127.0.0.1
 --leader-elect-lease-duration=60s
+--leader-elect-renew-deadline=30s

--- a/microk8s-resources/default-args/kube-scheduler
+++ b/microk8s-resources/default-args/kube-scheduler
@@ -1,2 +1,3 @@
 --kubeconfig=${SNAP_DATA}/credentials/scheduler.config
 --address=127.0.0.1
+--leader-elect-lease-duration=60s


### PR DESCRIPTION
kube-controller-manager and kube-scheduler need to elect a leader. They do so by tring to update the "lease" which is an entry on the datastore (dqlite or etcd). The controller that manages to update the "lease" becomes the leader. The leader will periodically try to update the "lease" so it does not expire. By default the lease duration is 15 secs and it gets refreshed on the 10th second 
 (--leader-elect-lease-duration duration     Default: 15s and --leader-elect-renew-deadline duration     Default: 10s). If a leader fails to update the lease it panics, see [1].

On stressed systems we may not get enough time to update the lease so kubelite crashes. The ideal fix is for the kube-scheduler and kube-controller-manager to step down gracefully. This will need some upstream work. For now we can offer this mitigation where we in crease the lease to 60s. The leader will have 50secs to update its lease instead of the default 5secs.


[1] https://github.com/kubernetes/kubernetes/blob/e640a01219736dd051dc3a9b8ac4630ec18b6b25/cmd/kube-controller-manager/app/controllermanager.go#L276

