### PR TITLE
Do not re-issue certificates on clusters

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -702,4 +702,3 @@ mark_boot_time() {
   now=$(date +%s)
   echo "$now" > "$1"/last-start-date
 }
-

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -53,7 +53,8 @@ do
       chgrp microk8s -R ${SNAP_DATA}/var/kubernetes/backend || true
     fi
 
-    if ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
+    if ! [ -e "${SNAP_DATA}/var/lock/no-cert-reissue" ] &&
+       ! grep -E "(--advertise-address|--bind-address)" $SNAP_DATA/args/kube-apiserver &> /dev/null &&
        ip route | grep default &> /dev/null
     then
       if snapctl services microk8s.daemon-kubelite | grep active &> /dev/null

--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -111,6 +111,10 @@ clean_cluster() {
   then
     run_with_sudo rm -rf "$SNAP_DATA/bin/"
   fi
+
+  if [ -e "${SNAP_DATA}/var/lock/no-cert-reissue" ]
+    rm -rf "${SNAP_DATA}/var/lock/no-cert-reissue"
+  fi
 }
 
 apply_cni() {

--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -113,7 +113,7 @@ clean_cluster() {
   fi
 
   if [ -e "${SNAP_DATA}/var/lock/no-cert-reissue" ]
-    rm -rf "${SNAP_DATA}/var/lock/no-cert-reissue"
+    run_with_sudo rm -rf "${SNAP_DATA}/var/lock/no-cert-reissue"
   fi
 }
 

--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -113,6 +113,7 @@ clean_cluster() {
   fi
 
   if [ -e "${SNAP_DATA}/var/lock/no-cert-reissue" ]
+  then
     run_with_sudo rm -rf "${SNAP_DATA}/var/lock/no-cert-reissue"
   fi
 }

--- a/scripts/cluster/agent.py
+++ b/scripts/cluster/agent.py
@@ -24,6 +24,7 @@ from .common.utils import (
     get_cluster_agent_port,
     try_initialise_cni_autodetect_for_clustering,
     service,
+    mark_no_cert_reissue,
 )
 
 from flask import Flask, jsonify, request, Response
@@ -319,6 +320,8 @@ def join_node_etcd():
     else:
         kubelet_args = read_kubelet_args_file()
 
+    mark_no_cert_reissue()
+
     return jsonify(
         ca=ca,
         etcd=etcd_ep,
@@ -608,6 +611,7 @@ def join_node_dqlite():
     cluster_cert, cluster_key = get_cluster_certs()
     # Make sure calico can autodetect the right interface for packet routing
     try_initialise_cni_autodetect_for_clustering(node_addr, apply_cni=True)
+    mark_no_cert_reissue()
 
     return jsonify(
         ca=get_cert("ca.crt"),

--- a/scripts/cluster/common/utils.py
+++ b/scripts/cluster/common/utils.py
@@ -298,5 +298,3 @@ def unmark_no_cert_reissue():
     lock_file = "{}/var/lock/no-cert-reissue".format(snap_data)
     if os.path.exists(lock_file):
         os.unlink(lock_file)
-
-

--- a/scripts/cluster/common/utils.py
+++ b/scripts/cluster/common/utils.py
@@ -276,3 +276,27 @@ def service(operation, service_name):
         subprocess.check_call(
             "snapctl {} microk8s.daemon-{}".format(operation, service_name).split()
         )
+
+
+def mark_no_cert_reissue():
+    """
+    Mark a node as being part of a cluster that should not re-issue certs
+    on network changes
+    """
+    snap_data = os.environ.get("SNAP_DATA")
+    lock_file = "{}/var/lock/no-cert-reissue".format(snap_data)
+    open(lock_file, "a").close()
+    os.chmod(lock_file, 0o700)
+
+
+def unmark_no_cert_reissue():
+    """
+    Unmark a node as being part of a cluster. The node should now re-issue certs
+    on network changes
+    """
+    snap_data = os.environ.get("SNAP_DATA")
+    lock_file = "{}/var/lock/no-cert-reissue".format(snap_data)
+    if os.path.exists(lock_file):
+        os.unlink(lock_file)
+
+

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -989,6 +989,7 @@ def join_dqlite(connection_parts, verify=False):
     try_initialise_cni_autodetect_for_clustering(master_ip, apply_cni=False)
     mark_no_cert_reissue()
 
+
 def join_etcd(connection_parts, verify=True):
     """
     Configure node to join an etcd cluster.

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -95,7 +95,9 @@ class VM:
         cmd_prefix = "/snap/bin/lxc exec {}  -- script -e -c".format(self.vm_name).split()
         cmd = ["rm -rf /var/tmp/microk8s.snap"]
         subprocess.check_output(cmd_prefix + cmd)
-        cmd = "lxc file push {} {}/var/tmp/microk8s.snap".format(channel_or_snap, self.vm_name).split()
+        cmd = "lxc file push {} {}/var/tmp/microk8s.snap".format(
+            channel_or_snap, self.vm_name
+        ).split()
         subprocess.check_output(cmd)
         cmd = ["snap install /var/tmp/microk8s.snap --classic --dangerous"]
         subprocess.check_output(cmd_prefix + cmd)
@@ -135,9 +137,7 @@ class VM:
         )
         subprocess.check_call(
             "/snap/bin/multipass exec {}  -- sudo "
-            "snap install /var/tmp/microk8s.snap --classic --dangerous".format(
-                self.vm_name
-            ).split()
+            "snap install /var/tmp/microk8s.snap --classic --dangerous".format(self.vm_name).split()
         )
 
     def run(self, cmd):


### PR DESCRIPTION
When in a cluster you do not want to re-issue certificates due to a network change. We place a lock file indicating if the certs should be reissued or not. Some work has gone into the tests to make sure this lock exists.