### PR TITLE
enable containerd cgroupV2 if detect os cgroupV2 enabled

### DIFF
--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -50,11 +50,11 @@ oom_score = 0
     # In this example, 'runc' is the RuntimeHandler string to match.
     [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
       # runtime_type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
-      runtime_type = "io.containerd.runc.v1"
+      runtime_type = "${RUNTIME_TYPE}"
 
     [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime]
       # runtime_type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
-      runtime_type = "io.containerd.runc.v1"
+      runtime_type = "${RUNTIME_TYPE}"
 
       [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-container-runtime.options]
         BinaryName = "nvidia-container-runtime"

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -30,13 +30,16 @@ app=containerd
 
 
 RUNTIME="runc"
+RUNTIME_TYPE="io.containerd.runc.v1"
 SNAPSHOTTER=$(snapshotter)
 
-sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g;s@${SNAPSHOTTER}@'"${SNAPSHOTTER}"'@g;s@${RUNTIME}@'"${RUNTIME}"'@g' $SNAP_DATA/args/containerd-template.toml > $SNAP_DATA/args/containerd.toml
-
-if ! mount | grep -q 'cgroup2 on /sys/fs/cgroup'; then
-  sed -i 's@runtime_type = "io.containerd.runc.v1"@runtime_type = "io.containerd.runc.v2"@g' $SNAP_DATA/args/containerd.toml
+if mount | grep -q 'cgroup2 on /sys/fs/cgroup'; then
+  RUNTIME_TYPE="io.containerd.runc.v2"
 fi
+
+sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g;s@${SNAPSHOTTER}@'"${SNAPSHOTTER}"'@g;s@${RUNTIME}@'"${RUNTIME}"'@g' $SNAP_DATA/args/containerd-template.toml > $SNAP_DATA/args/containerd.toml
+sed -i 's@${RUNTIME_TYPE}@'"${RUNTIME_TYPE}"'@g' $SNAP_DATA/args/containerd.toml
+
 
 run_flanneld="$(is_service_expected_to_start flanneld)"
 if [ "${run_flanneld}" == "1" ]

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -34,6 +34,10 @@ SNAPSHOTTER=$(snapshotter)
 
 sed 's@${SNAP}@'"${SNAP}"'@g;s@${SNAP_DATA}@'"${SNAP_DATA}"'@g;s@${SNAPSHOTTER}@'"${SNAPSHOTTER}"'@g;s@${RUNTIME}@'"${RUNTIME}"'@g' $SNAP_DATA/args/containerd-template.toml > $SNAP_DATA/args/containerd.toml
 
+if ! mount | grep -q 'cgroup2 on /sys/fs/cgroup'; then
+  sed -i 's@runtime_type = "io.containerd.runc.v1"@runtime_type = "io.containerd.runc.v2"@g' $SNAP_DATA/args/containerd.toml
+fi
+
 run_flanneld="$(is_service_expected_to_start flanneld)"
 if [ "${run_flanneld}" == "1" ]
 then

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -182,8 +182,9 @@ function suggest_fixes {
       fi
     fi
   fi
-
-  if ! mount | grep -q 'cgroup2 on /sys/fs/cgroup'; then
+  
+  if ! mount | grep -q 'cgroup/memory'; then
+    if ! mount | grep -q 'cgroup2 on /sys/fs/cgroup'; then
       printf -- '\033[0;33mWARNING: \033[0m The memory cgroup is not enabled. \n'
       printf -- 'The cluster may not be functioning properly. Please ensure cgroups are enabled \n'
       printf -- 'See for example: https://microk8s.io/docs/install-alternatives#heading--arm \n'

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -183,10 +183,15 @@ function suggest_fixes {
     fi
   fi
 
-  if ! mount | grep -q 'cgroup/memory'; then
-    printf -- '\033[0;33mWARNING: \033[0m The memory cgroup is not enabled. \n'
-    printf -- 'The cluster may not be functioning properly. Please ensure cgroups are enabled \n'
-    printf -- 'See for example: https://microk8s.io/docs/install-alternatives#heading--arm \n'
+  if ! mount | grep -q 'cgroup2 on /sys/fs/cgroup'; then
+      printf -- '\033[0;33mWARNING: \033[0m The memory cgroup is not enabled. \n'
+      printf -- 'The cluster may not be functioning properly. Please ensure cgroups are enabled \n'
+      printf -- 'See for example: https://microk8s.io/docs/install-alternatives#heading--arm \n'
+    else
+      printf -- 'cgroups2 enabled \n'
+    fi
+  else
+      printf -- 'cgroups enabled \n'
   fi
 
   # Fedora Specific Checks


### PR DESCRIPTION
Detect if the `os` is running `cgroupV2` and if so enable `containerd` `cgroupV2`. 

Also enhance inspect to correctly report this `cgroup` version.

Fixes #2054.

duplicate PR of #2052 Closed that as it was committed under incorrect emailaddress.

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
