### PR TITLE
Back Port Kubeflow 1.3 to 1.20

### DIFF
--- a/.github/workflows/test-kubeflow.yaml
+++ b/.github/workflows/test-kubeflow.yaml
@@ -70,15 +70,19 @@ jobs:
           sudo apt install -y libssl-dev python3-pip firefox-geckodriver
           git clone https://github.com/juju-solutions/bundle-kubeflow.git
           cd bundle-kubeflow
-          git reset --hard 5e0b6fcb
+          git reset --hard 369c5eb
           sudo pip3 install -r requirements.txt -r test-requirements.txt
           sudo microk8s status --wait-ready
           sudo microk8s kubectl -n kube-system rollout status ds/calico-node
-          trap 'sudo pkill -f svc/pipelines-api' SIGINT SIGTERM EXIT
-          sudo microk8s kubectl -n kubeflow port-forward svc/pipelines-api 8888:8888 &
+          trap 'sudo pkill -f svc/kfp-api' SIGINT SIGTERM EXIT
+          sudo microk8s kubectl -n kubeflow port-forward svc/kfp-api 8888:8888 &
           (i=30; while ! curl localhost:8888 ; do ((--i)) || exit; sleep 1; done)
           sudo -E pytest -vvs -m edge -k 'not kubectl'
           sudo -E pytest -vvs -m edge -k 'kubectl'
+
+      - name: Juju status
+        run: sg microk8s -c 'microk8s juju status'
+        if: failure()
 
       - name: Get MicroK8s pods
         run: sudo microk8s kubectl get pods -A
@@ -188,12 +192,17 @@ jobs:
             sudo pip3 install -r requirements.txt -r test-requirements.txt
             sudo microk8s status --wait-ready
             sudo microk8s kubectl -n kube-system rollout status ds/calico-node
-            trap 'sudo pkill -f svc/pipelines-api' SIGINT SIGTERM EXIT
-            microk8s kubectl -n kubeflow port-forward svc/pipelines-api 8888:8888 &
+            trap 'sudo pkill -f svc/kfp-api' SIGINT SIGTERM EXIT
+            microk8s kubectl -n kubeflow port-forward svc/kfp-api 8888:8888 &
             (i=30; while ! curl localhost:8888 ; do ((--i)) || exit; sleep 1; done)
-            pytest -vvs -m ${{ matrix.bundle }} -k 'not kubectl'
-            pytest -vvs -m ${{ matrix.bundle }} -k 'kubectl'
+            pytest -vvs -m ${{ matrix.bundle }} -k 'not kubectl and not selenium'
+            pytest -vvs -m ${{ matrix.bundle }} -k kubectl
+            pytest -vvs -m ${{ matrix.bundle }} -k selenium
           EOF
+
+      - name: Juju status
+        run: juju ssh ubuntu/0 microk8s juju status
+        if: failure()
 
       - name: Get MicroK8s pods
         run: juju ssh ubuntu/0 sudo microk8s kubectl get pods -A --sort-by=.metadata.name

--- a/microk8s-resources/actions/enable.kubeflow.sh
+++ b/microk8s-resources/actions/enable.kubeflow.sh
@@ -387,7 +387,7 @@ def get_hostname() -> str:
             die=False,
         )
         pub_ip = json.loads(output)["status"]["loadBalancer"]["ingress"][0]["ip"]
-        return "%s.xip.io" % pub_ip
+        return "%s.nip.io" % pub_ip
     except (KeyError, subprocess.CalledProcessError):
         print("WARNING: Unable to determine hostname, defaulting to localhost")
         return "localhost"
@@ -431,7 +431,7 @@ def print_info(hostname, password):
 @click.command()
 @click.option(
     "--bundle",
-    default="cs:kubeflow-252",
+    default="cs:kubeflow-264",
     help="The Kubeflow bundle to deploy. Can be one of full, lite, edge, or a charm store URL.",
 )
 @click.option(
@@ -475,11 +475,11 @@ def kubeflow(bundle, channel, debug, hostname, ignore_min_mem, no_proxy, passwor
     # user to specify a full charm store URL if they'd like, such as
     # `cs:kubeflow-lite-123`.
     if bundle == "full":
-        bundle = "cs:kubeflow-252"
+        bundle = "cs:kubeflow-264"
     elif bundle == "lite":
-        bundle = "cs:kubeflow-lite-37"
+        bundle = "cs:kubeflow-lite-48"
     elif bundle == "edge":
-        bundle = "cs:kubeflow-edge-34"
+        bundle = "cs:kubeflow-edge-44"
     else:
         bundle = bundle
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -564,7 +564,7 @@ parts:
 
   juju:
     plugin: dump
-    source: https://launchpad.net/juju/2.8/2.8.6/+download/juju-2.8.6-k8s.tar.xz
+    source: https://launchpad.net/juju/2.8/2.8.10/+download/juju-2.8.10-k8s.tar.xz
     source-type: tar
     organize:
       juju: bin/juju


### PR DESCRIPTION
This commit includes the following changes:

* Lock Kubeflow tests to particular revision (#2089)

* Improve Kubeflow addon teardown

* Removes cluster-scoped resources during teardown

* Fix pip3 not found CI failure

* Update Kubeflow addon to 1.3

* Change from xip.io to nip.io

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
