### PR TITLE
Fix disable kubeflow for 1.20

### DIFF
--- a/microk8s-resources/actions/disable.kubeflow.sh
+++ b/microk8s-resources/actions/disable.kubeflow.sh
@@ -49,7 +49,7 @@ def kubeflow():
     ]
 
     for resource, selector in resources:
-        click.echo(f"Destroying Kubeflow {resource}...")
+        click.echo("Destroying Kubeflow {}...".format(resource))
         try:
             subprocess.check_call(
                 ["microk8s-kubectl.wrapper", "delete", resource, "-ljuju-app" + selector],


### PR DESCRIPTION
The disable.kubeflow action isn't working correctly as our python version in 1.20 does not support fstrings.

This fixes #2263 