### PR TITLE
Use ClusterFirstWithHostNet as DNS policy for Traefik

### DIFF
--- a/microk8s-resources/actions/traefik.yaml
+++ b/microk8s-resources/actions/traefik.yaml
@@ -29,6 +29,7 @@ spec:
       serviceAccountName: traefik-ingress-controller
       terminationGracePeriodSeconds: 60
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - image: traefik:2.3
           name: traefik-ingress-lb


### PR DESCRIPTION
The Traefik plugin uses `hostNetwork=true` for its pods. It does not, however, specify a `dnsPolicy` which will cause the policy to default to `ClusterFirst`. This does not work when `hostNetwork` is set to `true`. As recommended by [the Kubernetes documentation on DNS](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/), `ClusterFirstWithHostNet` should be explicitly used as the DNS policy.

> For Pods running with hostNetwork, you should explicitly set its DNS policy "ClusterFirstWithHostNet".

This issue is important in order to use Traefik with forward authentication services, or other features that require a lookup of a service in the cluster.

*I have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
