### PR TITLE
snap: remove patches section from snapcraft file

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -449,11 +449,6 @@ passthrough:
       bind-file: $SNAP_COMMON/etc/service/enabled/felix/supervise/lock
 
 parts:
-  patches:
-    plugin: dump
-    source: patches/
-    prime: ["-*"]
-
   raft:
     source: https://github.com/canonical/raft
     build-attributes: [no-patchelf]


### PR DESCRIPTION
All patches were removed in commit
478e80939311416292e7c10d12bd0a5a9fed6a8a, and snapcraft now complains
that the path is not found.
