### PR TITLE
microk8s-resources: simplify the first-boot detection

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -646,37 +646,16 @@ kill_all_container_shims() {
 
 is_first_boot() {
   # Return 0 if this is the first start after the host booted.
-  # The argument $1 is a directory that may contain a last-start-date file
-  # The last-start-date file contains a date in seconds
-  # if that date is prior to the creation date of /proc/1 we assume this is the first
-  # time after the host booted
-  # Note, lxc shares the same /proc/stat as the host
-  if ! [ -e "$1/last-start-date" ] ||
-     ! [ -e /proc/1 ]
+  SENTINEL="/tmp/.containerd-first-book-check"
+  # We rely on the fact that /tmp is cleared at every boot to determine if
+  # this is the first call after boot: if the sentinel file exists, then it
+  # means that no reboot occurred since last check; otherwise, return success
+  # and create the sentinel file for the future check.
+  if [ -f "$SENTINEL" ]
   then
     return 1
   else
-    last_start=$("$SNAP/bin/cat" "$1/last-start-date")
-    if [ -e /proc/stat ] &&
-       grep btime /proc/stat &&
-       ! grep lxc /proc/1/environ
-    then
-      boot_time=$(grep btime /proc/stat | cut -d' ' -f2)
-    else
-      boot_time=$(date -r  /proc/1 +%s)
-    fi
-    echo "Last time service started was $last_start and the host booted at $boot_time"
-    if [ "$last_start" -le "$boot_time" ]
-    then
-      return 0
-    else
-      return 1
-    fi
+    touch "$SENTINEL"
+    return 0
   fi
-}
-
-mark_boot_time() {
-  # place the current time in the "$1"/last-start-date file
-  now=$(date +%s)
-  echo "$now" > "$1"/last-start-date
 }

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -28,12 +28,11 @@ then
 fi
 
 # clean leftover container state if we just booted
-if (is_first_boot "${SNAP_COMMON}/run/containerd")
+if (is_first_boot)
 then
   rm -rf "${SNAP_COMMON}/run/containerd" || true
 fi
 mkdir -p "${SNAP_COMMON}/run/containerd"
-mark_boot_time "${SNAP_COMMON}/run/containerd"
 
 # This is really the only way I could find to get the args passed in correctly.
 declare -a args="($(cat $SNAP_DATA/args/$app))"


### PR DESCRIPTION
The previous code required higher privileges (access to /proc/1/ is
generally not granted to confined applications) and was overcomplicated:
if we only need to know if this is the first execution after boot, then
we can create a sentinel file under /tmp and rely on the fact that /tmp
is cleared after every boot.

