### PR TITLE
snap: grant kubectl access to networking

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,9 @@ plugs:
   docker-privileged:
     interface: docker-support
     privileged-containers: true
+  docker-unprivileged:
+    interface: docker-support
+    privileged-containers: false
   k8s-kubelet:
     interface: kubernetes-support
     flavor: kubelet
@@ -308,6 +311,7 @@ apps:
     command: microk8s-kubectl.wrapper
     completer: kubectl.bash
     plugs:
+    - docker-unprivileged
     - dot-kube
     - home-read-all
     - firewall-control


### PR DESCRIPTION
The kubectl program opens a socket to communicate with localhost.
For the time being, let's use the docker-support interface to provide
this access. It may be that this interface is overkill and that kubectl
requires much less permissions, but that will be tracked separately.
