### PR TITLE
Upgrade kube prometheus 0.8.0

### DIFF
--- a/microk8s-resources/actions/enable.prometheus.sh
+++ b/microk8s-resources/actions/enable.prometheus.sh
@@ -21,7 +21,7 @@ do_prerequisites() {
 get_kube_prometheus () {
   if [  ! -d "${SNAP_DATA}/kube-prometheus" ]
   then
-    KUBE_PROMETHEUS_VERSION="v0.7.0"
+    KUBE_PROMETHEUS_VERSION="v0.8.0"
     KUBE_PROMETHEUS_ERSION=$(echo $KUBE_PROMETHEUS_VERSION | sed 's/v//g')
     echo "Fetching kube-prometheus version $KUBE_PROMETHEUS_VERSION."
     run_with_sudo mkdir -p "${SNAP_DATA}/kube-prometheus"
@@ -35,11 +35,11 @@ get_kube_prometheus () {
   fi
 }
 
-use_multiarch_images() {
-  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-state-metrics:v1.9.7@gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics:v1.9.8@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
-  run_with_sudo $SNAP/bin/sed -i 's@app.kubernetes.io/version: v1.9.7@app.kubernetes.io/version: v1.9.8@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
-
-}
+#use_multiarch_images() {
+#  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-state-metrics:v1.9.7@gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics:v1.9.8@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
+#  run_with_sudo $SNAP/bin/sed -i 's@app.kubernetes.io/version: v1.9.7@app.kubernetes.io/version: v1.9.8@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
+#
+#}
 
 
 set_replicas_to_one() {
@@ -66,10 +66,48 @@ enable_prometheus() {
 done 
 }
 
+add_loki_datasource() {
+   cat <<EOF | base64 -w0
+{
+    "apiVersion": 1,
+    "datasources": [
+        {
+            "access": "proxy",
+            "editable": false,
+            "name": "prometheus",
+            "orgId": 1,
+            "type": "prometheus",
+            "url": "http://prometheus-k8s.monitoring.svc:9090",
+            "version": 1
+        },
+        {
+           "name": "loki",
+           "type": "loki",
+           "access": proxy,
+           "url": "http://loki.monitoring.svc:3100",
+           "version": 1,
+           "editable": false,
+           "orgId": 1,
+        }
+    ]
+}
+EOF
+
+return $?
+
+}
+
+update_grafana_datasource() {
+  DS=$(add_loki_datasource)
+  run_with_sudo $SNAP/bin/sed -i "s@datasources.yaml:.*@datasources.yaml: $DS@g" ${SNAP_DATA}/kube-prometheus/manifests/grafana-dashboardDatasources.yaml
+}
+
+
 do_prerequisites
 get_kube_prometheus
 set_replicas_to_one
-use_multiarch_images
+#use_multiarch_images
+update_grafana_datasource
 enable_prometheus
 
 echo "The Prometheus operator is enabled (user/pass: admin/admin)"

--- a/microk8s-resources/actions/enable.prometheus.sh
+++ b/microk8s-resources/actions/enable.prometheus.sh
@@ -35,12 +35,6 @@ get_kube_prometheus () {
   fi
 }
 
-#use_multiarch_images() {
-#  run_with_sudo $SNAP/bin/sed -i 's@quay.io/coreos/kube-state-metrics:v1.9.7@gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics:v1.9.8@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
-#  run_with_sudo $SNAP/bin/sed -i 's@app.kubernetes.io/version: v1.9.7@app.kubernetes.io/version: v1.9.8@g' ${SNAP_DATA}/kube-prometheus/manifests/kube-state-metrics-deployment.yaml
-#
-#}
-
 
 set_replicas_to_one() {
   # alert manager must be set to 1 replica
@@ -94,7 +88,6 @@ add_loki_datasource() {
 EOF
 
 return $?
-
 }
 
 update_grafana_datasource() {
@@ -106,7 +99,6 @@ update_grafana_datasource() {
 do_prerequisites
 get_kube_prometheus
 set_replicas_to_one
-#use_multiarch_images
 update_grafana_datasource
 enable_prometheus
 


### PR DESCRIPTION
### This PR consist of the following enhancements:

* Add `Loki` default datasource to Grafana.  This can help add Loki seemlessly without having to manually change Grafana dashboard.
* Upgrade to kube-prometheus 0.8.0.
* Cleaned up some scripts which modifies the images that supports `arm64` architecture.

The snap was tested on both `arm64` and `amd64` Architecture.
*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
