### PR TITLE
snap: add some kubectl permissions to microk8s script

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -171,6 +171,9 @@ hooks:
 apps:
   microk8s:
     command: microk8s.wrapper
+    plugs:
+    - docker-unprivileged
+    - network-control
   daemon-etcd:
     command: run-etcd-with-args
     daemon: simple


### PR DESCRIPTION
The microk8s script is internally executing kubectl, and that happens
without switching to the kubectl confinement (see [1] and [2]).
Therefore, we need to add the plugs needed by kubectl to the microk8s
script.

[1] https://forum.snapcraft.io/t/executing-a-child-process-provided-by-the-same-snap/24744
[2] https://forum.snapcraft.io/t/the-right-way-to-to-start-another-app-inside-same-snap/2069

