### PR TITLE
snap: add kernel-module-control plug to the apiserver

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -234,6 +234,7 @@ apps:
     command: apiservice-kicker
     daemon: simple
     plugs:
+    - kernel-module-control
     - network-bind
     - network-observe
     - network-control


### PR DESCRIPTION
This gets rid of these two AppArmor errors:

    AVC apparmor="DENIED" operation="capable" profile="snap.microk8s.daemon-apiserver-kicker" pid=46846 comm="ip" capability=16  capname="sys_module"
    AVC apparmor="DENIED" operation="capable" profile="snap.microk8s.daemon-apiserver-kicker" pid=36170 comm="ifconfig" capability=16  capname="sys_module"

