### PR TITLE
coredns: allow privilege escalation

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -659,3 +659,11 @@ is_first_boot() {
     return 0
   fi
 }
+
+is_apparmor_enabled() {
+  if [ grep Y /sys/module/apparmor/parameters/enabled > /dev/null 2>&1 ]; then
+    return 1
+  else
+    return 0
+  fi
+}

--- a/microk8s-resources/actions/enable.dns.sh
+++ b/microk8s-resources/actions/enable.dns.sh
@@ -39,8 +39,10 @@ fi
 
 echo "Applying manifest"
 ALLOWESCALATION="false"
-if grep  -e ubuntu /proc/version | grep 16.04 &> /dev/null
+if is_apparmor_enabled
 then
+  # the NoNewPrivileges flag is not playing well with AppArmor, which would
+  # prevent profile transitions when the flag is set.
   ALLOWESCALATION="true"
 fi
 declare -A map


### PR DESCRIPTION
Setting this flag to "true" causes runc not to set the NO_NEW_PRIVS
flag on the coredns. The reason why we don't want the NO_NEW_PRIVS flag
set on our process is that this flag does not play well with AppArmor,
and having it set prevents a process from switching to a different
AppArmor profile.
