### PR TITLE
upgrade linkerd to v2.10.2

### DIFF
--- a/microk8s-resources/actions/disable.linkerd.sh
+++ b/microk8s-resources/actions/disable.linkerd.sh
@@ -10,6 +10,7 @@ ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30 >/dev/null
 echo "Removing linkerd control plane"
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 "$SNAP_DATA/bin/linkerd" "--kubeconfig=${SNAP_DATA}/credentials/client.config" install "--ignore-cluster" | $KUBECTL delete -f -
+"$SNAP_DATA/bin/linkerd" "--kubeconfig=${SNAP_DATA}/credentials/client.config" viz uninstall | $KUBECTL delete -f -
 echo "Deleting linkerd binary."
 run_with_sudo rm -f "$SNAP_DATA/bin/linkerd"
 

--- a/microk8s-resources/actions/enable.linkerd.sh
+++ b/microk8s-resources/actions/enable.linkerd.sh
@@ -12,7 +12,7 @@ ARCH=$(arch)
 
 # check if linkerd cli is already in the system.  Download if it doesn't exist.
 if [ ! -f "${SNAP_DATA}/bin/linkerd" ]; then
-  LINKERD_VERSION="${LINKERD_VERSION:-v2.9.4}"
+  LINKERD_VERSION="${LINKERD_VERSION:-v2.10.2}"
   echo "Fetching Linkerd2 version $LINKERD_VERSION."
   run_with_sudo mkdir -p "$SNAP_DATA/bin"
   LINKERD_VERSION=$(echo $LINKERD_VERSION | sed 's/v//g')
@@ -29,6 +29,9 @@ KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 sleep 5
 ${SNAP}/microk8s-status.wrapper --wait-ready --timeout 30 >/dev/null
 
-
+# Enable linkerd control plane
 "$SNAP_DATA/bin/linkerd" "--kubeconfig=$SNAP_DATA/credentials/client.config" install "${argz[@]}" | $KUBECTL apply -f -
+echo "Installing linkerd viz extension"
+# Enable linkerd visualization extension
+"$SNAP_DATA/bin/linkerd" "--kubeconfig=$SNAP_DATA/credentials/client.config" viz install | $KUBECTL apply -f -
 echo "Linkerd is starting"

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -106,7 +106,7 @@ microk8s-addons:
 
     - name: "linkerd"
       description: "Linkerd is a service mesh for Kubernetes and other frameworks"
-      version: "2.9.4"
+      version: "2.10.1"
       check_status: "pod/linkerd-controller"
       supported_architectures:
         - amd64

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -106,7 +106,7 @@ microk8s-addons:
 
     - name: "linkerd"
       description: "Linkerd is a service mesh for Kubernetes and other frameworks"
-      version: "2.10.1"
+      version: "2.10.2"
       check_status: "pod/linkerd-controller"
       supported_architectures:
         - amd64


### PR DESCRIPTION
### Upgrade Linkerd to v2.10.2
This PR follows the new plugin feature of Linkerd.  Visualizations are now part of the plugin and is separated from the control plane.
This PR will install the visualization like it used to.


*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
