### PR TITLE
Reload cni when refreshing

### DIFF
--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -44,8 +44,8 @@ do
         exit 1
     fi
 
-    # every 3 seconds
-    sleep 3
+    # every 5 seconds
+    sleep 5
     if [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
       getent group microk8s >/dev/null 2>&1
     then
@@ -64,7 +64,12 @@ do
         then
             echo "CSR change detected. Reconfiguring the kube-apiserver"
             rm -rf .srl
-            snapctl restart microk8s.daemon-kubelite
+            snapctl stop microk8s.daemon-kubelite
+            snapctl stop microk8s.daemon-containerd
+            kill_all_container_shims
+            snapctl start microk8s.daemon-containerd
+            snapctl start microk8s.daemon-kubelite
+            start_all_containers
             restart_attempt=$[$restart_attempt+1]
         else
             restart_attempt=0
@@ -78,9 +83,45 @@ do
     then
       echo "Setting up the CNI"
       if (is_apiserver_ready)  &&
-         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" apply -f "${SNAP_DATA}/args/cni-network/cni.yaml"
+         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m apply -f "${SNAP_DATA}/args/cni-network/cni.yaml"
       then
         touch "${SNAP_DATA}/var/lock/cni-loaded"
+      fi
+    fi
+
+    # Calico reload deployment
+    if ! [ -e "${SNAP_DATA}/var/lock/no-cni-reload" ] &&
+       [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
+       [ -e "${SNAP_DATA}/var/lock/ha-cluster" ] &&
+       [ -e "${SNAP_DATA}/var/lock/cni-loaded" ] &&
+       [ -e "${SNAP_DATA}/var/lock/no-flanneld" ] &&
+       [ -e "${SNAP_DATA}/var/lock/cni-needs-reload" ]
+    then
+      echo "Reloading the calico CNI"
+      if (is_apiserver_ready)  &&
+         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m describe -n kube-system daemonset.apps/calico-node &&
+         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m describe -n kube-system deployment.apps/calico-kube-controllers &&
+         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m rollout restart -n kube-system daemonset.apps/calico-node &&
+         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m rollout restart -n kube-system deployment.apps/calico-kube-controllers
+      then
+        rm "${SNAP_DATA}/var/lock/cni-needs-reload"
+      fi
+    fi
+
+    # Cilium reload deployment
+    if ! [ -e "${SNAP_DATA}/var/lock/no-cni-reload" ] &&
+       ! [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
+       [ -e "${SNAP_DATA}/var/lock/no-flanneld" ] &&
+       [ -e "${SNAP_DATA}/var/lock/cni-needs-reload" ]
+    then
+      echo "Reloading the cilium CNI"
+      if (is_apiserver_ready)  &&
+         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m describe -n kube-system daemonset.apps/cilium &&
+         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m describe -n kube-system deployment.apps/cilium-operator &&
+         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m rollout restart -n kube-system daemonset.apps/cilium  &&
+         "$SNAP/kubectl" "--kubeconfig=$SNAP_DATA/credentials/client.config" --request-timeout 2m rollout restart -n kube-system deployment.apps/cilium-operator
+      then
+        rm "${SNAP_DATA}/var/lock/cni-needs-reload"
       fi
     fi
 

--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -12,6 +12,8 @@ then
     exit 0
 fi
 
+exit_if_no_permissions
+
 PARSED=$(getopt --options=lho: --longoptions=help,output: --name "$@" -- "$@")
 eval set -- "$PARSED"
 while true; do
@@ -41,6 +43,7 @@ then
     echo 'Failed to start microk8s services. Check snapd logs with "journalctl -u snapd.service"'
     exit 1
 else
+    start_all_containers
     if run_with_sudo test -e ${SNAP_DATA}/var/lock/stopped.lock
     then
         # Mark the api server as starting

--- a/microk8s-resources/wrappers/microk8s-stop.wrapper
+++ b/microk8s-resources/wrappers/microk8s-stop.wrapper
@@ -13,6 +13,8 @@ then
     exit 0
 fi
 
+exit_if_no_permissions
+
 FORCE=false
 PARSED=$(getopt --options=lho: --longoptions=force,help,output: --name "$@" -- "$@")
 eval set -- "$PARSED"
@@ -42,5 +44,6 @@ then
     echo 'Failed to stop microk8s services. Check snapd logs with "journalctl -u snapd.service"'
     exit 1
 else
+    kill_all_container_shims
     run_with_sudo touch ${SNAP_DATA}/var/lock/stopped.lock
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -532,6 +532,12 @@ then
   fi
 fi
 
+# if we are refreshing in a no-flanneld we need to restart the CNI pods because they mount parts of $SNAP_DATA
+if [ -e "${SNAP_DATA}/var/lock/no-flanneld" ]
+then
+  touch "${SNAP_DATA}/var/lock/cni-needs-reload"
+fi
+
 if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
    [ -e "${SNAP_DATA}/var/lock/ha-cluster" ]
 then

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -55,3 +55,5 @@ if $SNAP/sbin/ip link show cni0
 then
   $SNAP/sbin/ip link delete cni0
 fi
+
+kill_all_container_shims

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,11 @@ apps:
     daemon: simple
   daemon-containerd:
     command: run-containerd-with-args
-    daemon: simple
+    daemon: notify
+    # when stopped send only sigterm
+    # https://forum.snapcraft.io/t/process-lifecycle-on-snap-refresh/140/37
+    stop-mode: sigterm
+    restart-condition: always
     plugs: [kubernetes-support]
   daemon-kubelite:
     command: run-kubelite-with-args


### PR DESCRIPTION
Set the containerd daemon type to notification. This does not stop the containers when containerd restarts. During a refresh we have to make sure the CNI pods get restarted because they mount locations of $SNAP_DATA.


Fixes: https://github.com/ubuntu/microk8s/issues/2290