### PR TITLE
Make namenode optional on the s390x calico manifest

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -110,6 +110,10 @@ At the time of the v3.13.2 release. The `calico.yaml` manifest is a slightly mod
               - name: IP_AUTODETECTION_METHOD
               value: "first-found"
   ```
+- In the `cni_network_config` in the calico manifest we also set:
+
+          "nodename_file_optional": true,
+ 
 
 ## Running the tests locally
 

--- a/upgrade-scripts/000-switch-to-calico/resources/calico.s390x.yaml
+++ b/upgrade-scripts/000-switch-to-calico/resources/calico.s390x.yaml
@@ -29,6 +29,7 @@ data:
           "type": "calico",
           "log_level": "info",
           "datastore_type": "kubernetes",
+          "nodename_file_optional": true,
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": __CNI_MTU__,
           "ipam": {


### PR DESCRIPTION
Addresses https://github.com/ubuntu/microk8s/issues/1611#issuecomment-854421793