### PR TITLE
Fix linting github-action job

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install tox
           sudo snap install node --classic
           sudo npm install --save-dev --save-exact -g prettier


### PR DESCRIPTION
Make sure apt-get update is called before apt-get install to refresh the apt list.
`check formatting` github-action job fails with this.
` Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/p/python-virtualenv/python3-virtualenv_20.0.17-1ubuntu0.3_all.deb  404  Not Found [IP: 52.252.75.106 80]`

Calling `apt-get update` may fix this.

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
