### PR TITLE
fix go dqlite build.

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install tox
           sudo snap install node --classic
           sudo npm install --save-dev --save-exact -g prettier

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -182,7 +182,10 @@ parts:
       snap refresh go --channel=1.15/stable || true
       go version
       export GOPATH=${SNAPCRAFT_STAGE}
-      CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/usr/include/" CGO_LDFLAGS="-L${SNAPCRAFT_STAGE}/lib" go get -tags libsqlite3 github.com/canonical/go-dqlite/cmd/dqlite
+      export CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/usr/include/" 
+      export CGO_LDFLAGS="-L${SNAPCRAFT_STAGE}/lib" 
+      export CGO_LDFLAGS_ALLOW="-Wl,-z,now"
+      go get -tags libsqlite3 github.com/canonical/go-dqlite/cmd/dqlite
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
       cp $GOPATH/bin/dqlite $SNAPCRAFT_PART_INSTALL/bin/
 


### PR DESCRIPTION
This PR fixes the go-dqlite build by adding the

`export CGO_LDFLAGS_ALLOW="-Wl,-z,now"`  Refer to https://github.com/canonical/dqlite/issues/308

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
