### PR TITLE
This probably shouldn't be running on the actual master branch

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,8 +1,6 @@
 name: cla-check
 
 on:
-  push:
-    branches: [master, default]
   pull_request:
     branches: [master, default]
 


### PR DESCRIPTION
This is running on the push to master and failing due to:
```
Run canonical/has-signed-canonical-cla@1.1.4
Installing python3-launchpadlib

Error: Cannot read property 'commits_url' of undefined
```

I don't think it's meant to be run on push, only PR.
