### PR TITLE
Update microk8s.wrapper: avoid using `ls` that can produce different …

### DIFF
--- a/microk8s-resources/wrappers/microk8s.wrapper
+++ b/microk8s-resources/wrappers/microk8s.wrapper
@@ -4,8 +4,8 @@ set -e
 
 function help() {
     echo "Available subcommands are:"
-    for i in $(ls ${SNAP}/microk8s-*.wrapper | sed 's/microk8s-//g' | sed 's/.wrapper//g'); do
-        echo -e "\t$(basename ${i})"
+    for i in ${SNAP}/microk8s-*.wrapper; do
+        echo -e "\t$(basename ${i} | sed 's/microk8s-//g' | sed 's/.wrapper//g')"
     done
     echo -e "\tinspect"
 }


### PR DESCRIPTION
I have a different output of `ls` in my system so i get a weird output. This change avoids using `ls` and uses bash path glob expansion instead. This should be more platform-independent.
