### PR TITLE
snap: declare the microk8s user and group

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,10 @@ grade: stable
 confinement: strict
 base: core18
 
+system-usernames:
+  passthrough:
+    snap_microk8s: shared
+
 plugs:
   home-read-all:
     interface: home


### PR DESCRIPTION
With this declaration, snapd will automatically create a user and a
group called "snap_microk8s". We use the passthrough feature to force
snapcraft to accept this value even though it doesn't understand it.

Note: https://github.com/ubuntu/microk8s/pull/2416 would be the best solution, but it's currently blocked by https://github.com/snapcore/snapcraft/pull/3545. While we wait for that change to land, here's a more immediate solution.