### PR TITLE
Use libsqlite-dev from the sqlite build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -170,8 +170,6 @@ parts:
     source-type: git
     plugin: go
     go-channel: 1.15/stable
-    build-packages:
-      - libsqlite3-dev
     go-importpath: github.com/canonical/go-dqlite
     override-build: |
       set -eux


### PR DESCRIPTION
We want to build the dqlite-client using the libs from the sqlite we build.