### PR TITLE
build-scripts: update NNP patches

### DIFF
--- a/build-scripts/patches/runc/0001-apparmor-change-profile-immediately-not-on-exec.patch
+++ b/build-scripts/patches/runc/0001-apparmor-change-profile-immediately-not-on-exec.patch
@@ -1,31 +1,30 @@
-From ef52797c30f6c2a50e0ba996b41dc8d592a70222 Mon Sep 17 00:00:00 2001
+From 08607d16c6f9ef393e18e0f62fcd967e91c5f7c9 Mon Sep 17 00:00:00 2001
 From: Alberto Mardegan <mardy@users.sourceforge.net>
 Date: Wed, 16 Jun 2021 15:04:16 +0300
 Subject: [PATCH 1/3] apparmor: change profile immediately, not on exec
 
 ---
- libcontainer/apparmor/apparmor.go | 9 ++++-----
- 1 file changed, 4 insertions(+), 5 deletions(-)
+ libcontainer/apparmor/apparmor_linux.go | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/libcontainer/apparmor/apparmor.go b/libcontainer/apparmor/apparmor.go
-index debfc1e4..2929d134 100644
---- a/libcontainer/apparmor/apparmor.go
-+++ b/libcontainer/apparmor/apparmor.go
-@@ -40,10 +40,9 @@ func setProcAttr(attr, value string) error {
+diff --git a/libcontainer/apparmor/apparmor_linux.go b/libcontainer/apparmor/apparmor_linux.go
+index 5da14fb3..93ede183 100644
+--- a/libcontainer/apparmor/apparmor_linux.go
++++ b/libcontainer/apparmor/apparmor_linux.go
+@@ -49,9 +49,9 @@ func setProcAttr(attr, value string) error {
  	return err
  }
  
 -// changeOnExec reimplements aa_change_onexec from libapparmor in Go
 -func changeOnExec(name string) error {
--	value := "exec " + name
--	if err := setProcAttr("exec", value); err != nil {
+-	if err := setProcAttr("exec", "exec "+name); err != nil {
 +// changeProfile reimplements aa_change_profile from libapparmor in Go
 +func changeProfile(name string) error {
 +	if err := setProcAttr("current", "changeprofile "+name); err != nil {
  		return fmt.Errorf("apparmor failed to apply profile: %s", err)
  	}
  	return nil
-@@ -56,5 +55,5 @@ func ApplyProfile(name string) error {
+@@ -64,5 +64,5 @@ func ApplyProfile(name string) error {
  		return nil
  	}
  

--- a/build-scripts/patches/runc/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
+++ b/build-scripts/patches/runc/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
@@ -1,4 +1,4 @@
-From c40952070bcc265a8d7358930120d87515dab1c9 Mon Sep 17 00:00:00 2001
+From 66fd3c5129599834de8262ee90a1ab2bf6b68ff0 Mon Sep 17 00:00:00 2001
 From: Alberto Mardegan <mardy@users.sourceforge.net>
 Date: Wed, 16 Jun 2021 15:04:40 +0300
 Subject: [PATCH 2/3] setns_init_linux: set the NNP flag after changing the
@@ -12,10 +12,10 @@ set. So, we invert the order of the two operations.
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/libcontainer/setns_init_linux.go b/libcontainer/setns_init_linux.go
-index 0b9cd885..bfd18ce3 100644
+index 97987f1d..eec427a0 100644
 --- a/libcontainer/setns_init_linux.go
 +++ b/libcontainer/setns_init_linux.go
-@@ -56,11 +56,6 @@ func (l *linuxSetnsInit) Init() error {
+@@ -57,11 +57,6 @@ func (l *linuxSetnsInit) Init() error {
  			return err
  		}
  	}
@@ -27,7 +27,7 @@ index 0b9cd885..bfd18ce3 100644
  	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
  		return err
  	}
-@@ -79,6 +74,11 @@ func (l *linuxSetnsInit) Init() error {
+@@ -80,6 +75,11 @@ func (l *linuxSetnsInit) Init() error {
  	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
  		return err
  	}

--- a/build-scripts/patches/runc/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
+++ b/build-scripts/patches/runc/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
@@ -1,4 +1,4 @@
-From 27a59ff6ea5fb68d524ddeba6be8f2983cee8ff3 Mon Sep 17 00:00:00 2001
+From 728d989c7643a87ca9d57e3135e35c7af833bae0 Mon Sep 17 00:00:00 2001
 From: Alberto Mardegan <mardy@users.sourceforge.net>
 Date: Thu, 17 Jun 2021 14:31:35 +0300
 Subject: [PATCH 3/3] standard_init_linux: change AppArmor profile as late as
@@ -9,10 +9,10 @@ Subject: [PATCH 3/3] standard_init_linux: change AppArmor profile as late as
  1 file changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
-index b20ce148..0732400c 100644
+index d77022ad..6f43da5f 100644
 --- a/libcontainer/standard_init_linux.go
 +++ b/libcontainer/standard_init_linux.go
-@@ -112,10 +112,6 @@ func (l *linuxStandardInit) Init() error {
+@@ -114,10 +114,6 @@ func (l *linuxStandardInit) Init() error {
  			return errors.Wrap(err, "sethostname")
  		}
  	}
@@ -23,7 +23,7 @@ index b20ce148..0732400c 100644
  	for key, value := range l.config.Config.Sysctl {
  		if err := writeSystemProperty(key, value); err != nil {
  			return errors.Wrapf(err, "write sysctl key %s", key)
-@@ -135,17 +131,21 @@ func (l *linuxStandardInit) Init() error {
+@@ -137,17 +133,21 @@ func (l *linuxStandardInit) Init() error {
  	if err != nil {
  		return errors.Wrap(err, "get pdeath signal")
  	}


### PR DESCRIPTION
The base commit for the runc component was bumped while these patches
were waiting to be merged, and now they don't apply anymore. Here's an
updated version.
