### PR TITLE
Update ingress for v1.22

### DIFF
--- a/microk8s-resources/actions/disable.ingress.sh
+++ b/microk8s-resources/actions/disable.ingress.sh
@@ -7,7 +7,7 @@ source $SNAP/actions/common/utils.sh
 echo "Disabling Ingress"
 
 ARCH=$(arch)
-TAG="v0.35.0"
+TAG="v1.0.0-alpha.2"
 DEFAULT_CERT="- ' '" # This default value is always fine when deleting resources.
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 

--- a/microk8s-resources/actions/enable.ingress.sh
+++ b/microk8s-resources/actions/enable.ingress.sh
@@ -22,7 +22,7 @@ fi
 echo "Enabling Ingress"
 
 ARCH=$(arch)
-TAG="v0.44.0"
+TAG="v1.0.0-alpha.2"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 DEFAULT_CERT="- ' '"
 

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -30,7 +30,7 @@ microk8s-addons:
 
     - name: "ingress"
       description: "Ingress controller for external access"
-      version: "0.25.1"
+      version: "1.0.0-alpha.2"
       check_status: "pod/nginx-ingress-microk8s-controller"
       supported_architectures:
         - arm64


### PR DESCRIPTION
Due to removal of v1beta1 APIs on K8s [2] we have to go with an alpha Ingress controller release [1].

[1] https://github.com/kubernetes/ingress-nginx/releases 
[2] https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/
