### PR TITLE
Fix "Error: unknown flag" in enable.openfaas.sh (#2457)

### DIFF
--- a/microk8s-resources/actions/enable.openfaas.sh
+++ b/microk8s-resources/actions/enable.openfaas.sh
@@ -72,7 +72,7 @@ else
         --set operator.create=$OPERATOR \
         --set basic_auth=$AUTH \
         --set generateBasicAuth=$AUTH \
-        --f "$VALUES"
+        -f "$VALUES"
 fi
 
 # print a final help message


### PR DESCRIPTION
When running `microk8s enable openfaas --values=values.yaml` (or `microk8s enable openfaas -f=values.yaml`) the error "Error: unknown flag: --f" is raised:
```
# microk8s enable openfaas --values=values.yaml
Addon dns is already enabled.
Addon helm3 is already enabled.

Enabling OpenFaaS
Operator: false
Basic Auth enabled: true
Overrides file: values.yaml
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /var/snap/microk8s/2262/credentials/client.config
"openfaas" already exists with the same configuration, skipping
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /var/snap/microk8s/2262/credentials/client.config
Error: unknown flag: --f
```

The (helm documentation)[https://helm.sh/docs/chart_template_guide/values_files/] details that the option passed should be `-f`, not `--f`.

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [ ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
