### PR TITLE
Add note and workaround for nip.io in tests

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -152,3 +152,10 @@ cd tests/
 pytest -s test-addons.py
 pytest -s test-upgrade.py
 ```
+
+Note: the `ingress` and `dashboard-ingress` tests make use of nip.io for wildcard ingress domains on localhost. [DNS rebinding protection](https://en.wikipedia.org/wiki/DNS_rebinding) may prevent the resolution of the domains used in the tests. 
+
+A workaround is adding these entries to `/etc/hosts`:
+```
+127.0.0.1 kubernetes-dashboard.127.0.0.1.nip.io
+127.0.0.1 microbot.127.0.0.1.nip.io

--- a/docs/build.md
+++ b/docs/build.md
@@ -159,3 +159,4 @@ A workaround is adding these entries to `/etc/hosts`:
 ```
 127.0.0.1 kubernetes-dashboard.127.0.0.1.nip.io
 127.0.0.1 microbot.127.0.0.1.nip.io
+```


### PR DESCRIPTION
This PR adds a note to the build documentation about the use of nip.io in tests. Networks implementing [DNS rebinding protection](https://en.wikipedia.org/wiki/DNS_rebinding) may block the resolution of loopback addresses as documented on the nip.io page. 

On my own network, this condition lead to failed tests.

The note includes a `/etc/hosts` workaround.

## Checklist
*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
