### PR TITLE
Add format option for microk8s add-node (#2395)

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -704,3 +704,42 @@ mark_boot_time() {
   now=$(date +%s)
   echo "$now" > "$1"/last-start-date
 }
+
+cluster_agent_port() {
+  port="25000"
+  if grep -e port "${SNAP_DATA}"/args/cluster-agent &> /dev/null
+  then
+    port=$(cat "${SNAP_DATA}"/args/cluster-agent | "$SNAP"/usr/bin/gawk '{print $2}')
+  fi
+
+  echo "$port"
+}
+
+server_cert_check() {
+  openssl x509 -in "$SNAP_DATA"/certs/server.crt -outform der | sha256sum | cut -d' ' -f1 | cut -c1-12
+}
+
+# check if this file is run with arguments
+if [[ "$0" == "${BASH_SOURCE}" ]] && 
+   [[ ! -z "$1" ]] 
+then
+  # call help
+  if echo "$*" | grep -q -- 'help'; then
+    echo "usage: $0 [function]"
+    echo ""
+    echo "Run a utility function and return the output."
+    echo ""
+    echo "available functions:"
+    declare -F | gawk '{print "- "$3}'
+    exit 0
+  fi
+
+  if declare -F "$1" > /dev/null
+  then
+    $1 ${@:2}
+    exit $?
+  else
+    echo "Function does not exist: $1" >&2
+    exit 1
+  fi
+fi

--- a/microk8s-resources/wrappers/microk8s-add-node.wrapper
+++ b/microk8s-resources/wrappers/microk8s-add-node.wrapper
@@ -50,25 +50,4 @@ then
 fi
 
 # Use python's built-in (3.6+) secrets generator to produce the token.
-token="$(LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/cluster/add_token.py $@)"
-
-port="25000"
-if grep -e port "${SNAP_DATA}"/args/cluster-agent &> /dev/null
-then
-  port=$(cat "${SNAP_DATA}"/args/cluster-agent | "$SNAP"/usr/bin/gawk '{print $2}')
-fi
-
-default_ip="$(get_default_ip)"
-all_ips="$(get_ips)"
-
-check=$(openssl x509 -in "$SNAP_DATA"/certs/server.crt -outform der | sha256sum | cut -d' ' -f1 | cut -c1-12)
-
-echo "From the node you wish to join to this cluster, run the following:"
-echo "microk8s join ${default_ip}:$port/${token}/${check}"
-echo ""
-echo "If the node you are adding is not reachable through the default interface you can use one of the following:"
-for addr in $(echo "${all_ips}"); do
-  if ! [[ $addr == *":"* ]]; then
-    echo " microk8s join ${addr}:$port/${token}/${check}"
-  fi
-done
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/cluster/add_token.py $@

--- a/scripts/cluster/add_token.py
+++ b/scripts/cluster/add_token.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import argparse
 import subprocess
@@ -56,8 +57,9 @@ def run_util(*args, debug=False):
 
     try:
         result.check_returncode()
-    except subprocess.CalledProcessError as err:
-        raise
+    except subprocess.CalledProcessError:
+        print("Failed to call utility function.")
+        sys.exit(1)
 
     return result.stdout.decode("utf-8").strip()
 

--- a/scripts/cluster/add_token.py
+++ b/scripts/cluster/add_token.py
@@ -1,6 +1,7 @@
 import os
 import time
 import argparse
+import subprocess
 
 try:
     from secrets import token_hex
@@ -12,6 +13,7 @@ except ImportError:
 
 
 cluster_tokens_file = os.path.expandvars("${SNAP_DATA}/credentials/cluster-tokens.txt")
+utils_sh_file = os.path.expandvars("${SNAP}/actions/common/utils.sh")
 token_with_expiry = "{}|{}\n"
 token_without_expiry = "{}\n"
 
@@ -36,6 +38,63 @@ def add_token_with_expiry(token, file, ttl):
             fp.write(token_without_expiry.format(token))
 
 
+def run_util(*args, debug=False):
+    env = os.environ.copy()
+    prog = ["bash", utils_sh_file]
+    prog.extend(args)
+
+    if debug:
+        print("\033[;1;32m+ %s\033[;0;0m" % " ".join(prog))
+
+    result = subprocess.run(
+        prog,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+
+    try:
+        result.check_returncode()
+    except subprocess.CalledProcessError as err:
+        raise
+
+    return result.stdout.decode("utf-8").strip()
+
+
+def get_network_info():
+    """
+    Obtain machine IP address(es) and cluster agent port.
+    :return: tuple of default IP, all IPs, and cluster agent port
+    """
+    default_ip = run_util("get_default_ip")
+    all_ips = run_util("get_ips").split(" ")
+    port = run_util("cluster_agent_port")
+
+    return (default_ip, all_ips, port)
+
+
+def print_pretty(token, check):
+    default_ip, all_ips, port = get_network_info()
+
+    print("From the node you wish to join to this cluster, run the following:")
+    print(f"microk8s join {default_ip}:{port}/{token}/{check}\n")
+
+    print(
+        "If the node you are adding is not reachable through the default interface you can use one of the following:"
+    )
+    for ip in all_ips:
+        print(f"microk8s join {ip}:{port}/{token}/{check}")
+
+
+def print_short(token, check):
+    default_ip, all_ips, port = get_network_info()
+
+    print(f"microk8s join {default_ip}:{port}/{token}/{check}")
+    for ip in all_ips:
+        print(f"microk8s join {ip}:{port}/{token}/{check}")
+
+
 if __name__ == "__main__":
 
     # initiate the parser with a description
@@ -58,6 +117,12 @@ if __name__ == "__main__":
         help="Specify the bootstrap token to add, must be 32 characters long. "
         "Auto generates when empty.",
     )
+    parser.add_argument(
+        "--format",
+        help="Format the output of the token in pretty, short, token, or token-check",
+        default="pretty",
+        choices={"pretty", "short", "token", "token-check"},
+    )
 
     # read arguments from the command line
     args = parser.parse_args()
@@ -74,4 +139,13 @@ if __name__ == "__main__":
         exit(1)
 
     add_token_with_expiry(token, cluster_tokens_file, ttl)
-    print(token)
+    check = run_util("server_cert_check")
+
+    if args.format == "pretty":
+        print_pretty(token, check)
+    elif args.format == "short":
+        print_short(token, check)
+    elif args.format == "token-check":
+        print(f"{token}/{check}")
+    else:
+        print(token)


### PR DESCRIPTION
This PR adds the `--format` option  to the `microk8s add-node` command to fix #2395.

## Implementation
Many of the shell calls from `microk8s-add-node.wrapper` were converted into functions placed in `utils.sh`. The utilities file gained shell interactivity (available when not sourced) to call into utility functions from the shell. This is used by the `add_token.py` file to obtain machine IP addresses, the check value, and the agent port for the dynamic formatting.

The add-node command gains the `--format` argument for configuring machine/human readable outputs.

## Values for `--format`
### pretty (default)
This output should look identical to the current way `add-node` works in microk8s:

`microk8s add-node` _or_ `microk8s add-node --format pretty`
```
From the node you wish to join to this cluster, run the following:
microk8s join 192.168.100.23:25000/13b6e309b4c70c583701112e604e0a85/1411cf3983e5

If the node you are adding is not reachable through the default interface you can use one of the following:
microk8s join 192.168.100.23:25000/13b6e309b4c70c583701112e604e0a85/1411cf3983e5
microk8s join 192.168.122.1:25000/13b6e309b4c70c583701112e604e0a85/1411cf3983e5
microk8s join 172.17.0.1:25000/13b6e309b4c70c583701112e604e0a85/1411cf3983e5
microk8s join 10.83.230.1:25000/13b6e309b4c70c583701112e604e0a85/1411cf3983e5
microk8s join fd42:7fb0:6d8c:912c::1:25000/13b6e309b4c70c583701112e604e0a85/1411cf3983e5

```

### short
The output is an easily machine-parsed list of potential connection commands starting with the default machine IP address:

`microk8s add-node --format short`
```
microk8s join 192.168.100.23:25000/0514876f04e396178576987e7bd3444d/1411cf3983e5
microk8s join 192.168.100.23:25000/0514876f04e396178576987e7bd3444d/1411cf3983e5
microk8s join 192.168.122.1:25000/0514876f04e396178576987e7bd3444d/1411cf3983e5
microk8s join 172.17.0.1:25000/0514876f04e396178576987e7bd3444d/1411cf3983e5
microk8s join 10.83.230.1:25000/0514876f04e396178576987e7bd3444d/1411cf3983e5
microk8s join fd42:7fb0:6d8c:912c::1:25000/0514876f04e396178576987e7bd3444d/1411cf3983e5
```

### token-check
The output is simply the token+check values:

`microk8s add-node --format token-check`
```
842bce4337d6e49090b17c946bf65b99/1411cf3983e5
```

### token
The output is identical to the original functionality of the Python program which has been expanded:

`microk8s add-node --format token`
```
842bce4337d6e49090b17c946bf65b99
```

## Checklist
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
