### PR TITLE
Do not run cilium test on lxc

### DIFF
--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -251,17 +251,14 @@ class TestAddons(object):
     @pytest.mark.skipif(
         platform.machine() != "x86_64", reason="Cilium tests are only relevant in x86 architectures"
     )
+    @pytest.mark.skipif(
+        is_container(),
+        reason="Cilium tests are skipped in containers",
+    )
     def test_cilium(self):
         """
         Sets up and validates Cilium.
         """
-        try:
-            check_call("sudo grep -E lxc /proc/1/environ".split())
-            print("Cilium test skipped on lxc containers")
-            return True
-        except CalledProcessError:
-            print("Testing cilium on this platform")
-
         print("Enabling Cilium")
         run(
             "/snap/bin/microk8s.enable cilium".split(),

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -153,6 +153,31 @@ class TestAddons(object):
         """
 
     @pytest.mark.skipif(
+        platform.machine() != "x86_64", reason="Cilium tests are only relevant in x86 architectures"
+    )
+    @pytest.mark.skipif(
+        os.environ.get("UNDER_TIME_PRESSURE") == "True",
+        reason="Skipping cilium tests as we are under time pressure",
+    )
+    def test_cilium(self):
+        """
+        Sets up and validates Cilium.
+        """
+        print("Enabling Cilium")
+        run(
+            "/snap/bin/microk8s.enable cilium".split(),
+            stdout=PIPE,
+            input=b"N\n",
+            stderr=STDOUT,
+            check=True,
+        )
+        print("Validating Cilium")
+        validate_cilium()
+        print("Disabling Cilium")
+        microk8s_disable("cilium")
+        microk8s_reset()
+
+    @pytest.mark.skipif(
         os.environ.get("UNDER_TIME_PRESSURE") == "True",
         reason="Skipping GPU tests as we are under time pressure",
     )
@@ -246,31 +271,6 @@ class TestAddons(object):
         validate_prometheus()
         print("Disabling prometheus")
         microk8s_disable("prometheus")
-        microk8s_reset()
-
-    @pytest.mark.skipif(
-        platform.machine() != "x86_64", reason="Cilium tests are only relevant in x86 architectures"
-    )
-    @pytest.mark.skipif(
-        os.environ.get("UNDER_TIME_PRESSURE") == "True",
-        reason="Skipping cilium tests as we are under time pressure",
-    )
-    def test_cilium(self):
-        """
-        Sets up and validates Cilium.
-        """
-        print("Enabling Cilium")
-        run(
-            "/snap/bin/microk8s.enable cilium".split(),
-            stdout=PIPE,
-            input=b"N\n",
-            stderr=STDOUT,
-            check=True,
-        )
-        print("Validating Cilium")
-        validate_cilium()
-        print("Disabling Cilium")
-        microk8s_disable("cilium")
         microk8s_reset()
 
     @pytest.mark.skip("disabling the test while we work on a 1.20 release")


### PR DESCRIPTION
Cilium is complaining when enabled on lxc:
```
kube-system   pod/cilium-bzzqp                               0/1     Init:CreateContainerError
```
and 
```
(combined from similar events): Error: failed to generate container "95c9998218f6b6bc29c56b4d08a4b64de4b705f786d86e7bf8ebd599ca155328" spec: failed to generate spec: path "/run/cilium/cgroupv2" is mounted on "/run/cilium/cgroupv2" but it is not a shared or slave mount
```

This PR runs the cilium test on GH actions and not on lxc containers.