### PR TITLE
Add our K8s learning resource based on Microk8s

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -5,6 +5,7 @@ request with updates to this page.
 
 | Event/Mention                                          | Author(s)       | Source     | Date          |
 |---------------------------------------------------------------------|--------------|----------|---------------|
+| [Kubernetes Automation Toolkit](https://github.com/BigBitBusInc/kubernetes-automation-toolkit) | Sachin Agarwal (BigBitBus) | github.com | 6-Aug-2021 |
 | [IoT/edge: Akri (MSFT) on MicroK8s](https://github.com/didier-durand/microk8s-akri) | Didier Durand | github.com | 27-Nov-2020 |
 | [Kata Containers on MicroK8s](https://github.com/didier-durand/microk8s-kata-containers) | Didier Durand | github.com | 13-Nov-2020 |
 | [MicroK8s analyzed with kube-bench](https://github.com/didier-durand/microk8s-kube-bench) | Didier Durand | github.com | 23-Oct-2020 |


### PR DESCRIPTION
We created a learning resource for Kubernetes called the Kubernetes Automation Toolkit, which uses Microk8s to setup a cluster. Good uptake on GH (37 stars already) plus

It has also been used here: https://www.canarie.ca/cloud/boosterpacks/catalogue/flight-plan-automate-cloud-orchestration-with-kubernetes/sample-solution-kubernetes-automation-toolkit-kat/

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [ x ] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [ x ] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
