### PR TITLE
OpenEBS changes for k8s v1.22

### DIFF
--- a/microk8s-resources/actions/disable.openebs.sh
+++ b/microk8s-resources/actions/disable.openebs.sh
@@ -9,8 +9,6 @@ OPENEBS_NS="openebs"
 
 echo "Disabling OpenEBS"
 
-read -ra ARGUMENTS <<< "$1"
-
 forceful_bdc_delete() {
     
     MESSAGE="Deleting BDC forcefully"
@@ -143,11 +141,4 @@ disable_openebs() {
 }
 
 
-if [ ! -z "${ARGUMENTS[@]}" ] && [ "${ARGUMENTS[@]}" = "force" ]
-then
-  disable_openebs
-else
-  echo "Information with regards to OpenEBS uninstallation (https://docs.openebs.io/docs/next/uninstall.html)".
-  read -p "Have you deleted all the pods and PersistentVolumeClaims using OpenEBS PVC? (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
-  disable_openebs
-fi
+disable_openebs

--- a/microk8s-resources/actions/enable.openebs.sh
+++ b/microk8s-resources/actions/enable.openebs.sh
@@ -8,13 +8,6 @@ KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 
 OPENEBS_NS="openebs"
 
-echo ""
-echo "This addon is not yet available on Kubernetes v1.22. Follow the link for more details: "
-echo "https://github.com/ubuntu/microk8s/issues/2498"
-echo ""
-exit 1
-
-
 # Check if iscsid is installed 
 if ! systemctl is-enabled iscsid | grep enabled &> /dev/null
   then
@@ -37,10 +30,17 @@ HELM="$SNAP_DATA/bin/helm3 --kubeconfig=$SNAP_DATA/credentials/client.config"
 $HELM repo add openebs https://openebs.github.io/charts
 $HELM repo update
 $HELM -n openebs install openebs openebs/openebs \
-    --set varDirectoryPath.baseDir="$SNAP_COMMON/var/openebs" \
-    --set jiva.defaultStoragePath="$SNAP_COMMON/var/openebs" \
-    --set localprovisioner.basePath="$SNAP_COMMON/var/openebs/local" \
-    --set ndm.sparse.path="$SNAP_COMMON/var/openebs/sparse"
+    --set cstor.enabled=true \
+    --set jiva.enabled=true \
+    --set localpv-provisioner.enabled=true \
+    --set openebs-ndm.enabled=true \
+    --set legacy.enabled=false \
+    --set cstor.cleanup.image.tag="latest" \
+    --set cstor.csiNode.kubeletDir="$SNAP_COMMON/var/lib/kubelet/" \
+    --set jiva.csiNode.kubeletDir="$SNAP_COMMON/var/lib/kubelet/" \
+    --set localpv-provisioner.localpv.basePath="$SNAP_COMMON/var/openebs/local" \
+    --set localpv-provisioner.hostpathClass.basePath="$SNAP_COMMON/var/openebs/local" \
+    --set openebs-ndm.ndm.sparse.path="$SNAP_COMMON/var/openebs/sparse"
 
 echo "OpenEBS is installed"
 
@@ -69,8 +69,8 @@ echo ""
 echo "" 
 echo "-----------------------"
 echo "" 
-echo "If you are planning to use OpenEBS with multi nodes, you can use the openebs-jiva-default StorageClass."
-echo "An example of creating a PersistentVolumeClaim utilizing the openebs-jiva-default StorageClass"
+echo "If you are planning to use OpenEBS with multi nodes, you can use the openebs-jiva-csi-default StorageClass."
+echo "An example of creating a PersistentVolumeClaim utilizing the openebs-jiva-csi-default StorageClass"
 echo "" 
 echo "" 
 echo "kind: PersistentVolumeClaim
@@ -78,7 +78,7 @@ apiVersion: v1
 metadata:
   name: jiva-volume-claim
 spec:
-  storageClassName: openebs-jiva-default
+  storageClassName: openebs-jiva-csi-default
   accessModes:
     - ReadWriteOnce
   resources:

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -218,7 +218,7 @@ microk8s-addons:
     - name: "openebs"
       description: "OpenEBS is the open-source storage solution for Kubernetes"
       version: "2.6.0"
-      check_status: "pod/openebs-apiserver"
+      check_status: "pod/openebs-ndm"
       supported_architectures:
         - arm64
         - amd64

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -447,7 +447,6 @@ class TestAddons(object):
         check_call("/snap/bin/microk8s.dbctl --debug backup -o backupfile".split())
         check_call("/snap/bin/microk8s.dbctl --debug restore backupfile.tar.gz".split())
 
-    @pytest.mark.skip("disabling the addon test until is fixed in v1.22")
     @pytest.mark.skipif(
         platform.machine() == "s390x",
         reason="OpenEBS is not available on s390x",

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -506,7 +506,7 @@ def validate_openebs():
         "",
         "openebs",
         "running",
-        label="openebs.io/component-name=maya-apiserver",
+        label="openebs.io/component-name=ndm",
         timeout_insec=900,
     )
     print("OpenEBS is up and running.")


### PR DESCRIPTION
Signed-off-by: Niladri Halder niladri.halder@mayadata.io

Enable changes:

 * Disables installation of legacy components which use deprecated API versions
 * Installs Jiva(CSI), cStor(CSI) and dynamic-localpv-provisioner storage engines.
 * Sample PVC for jiva now uses the default Jiva storageClass, i.e. openebs-jiva-csi-default
 * Removed the messages stating that the OpenEBS plugin is not available.

Disable changes:

 * Removed deletion of SPC-based components as these are not API-compatible
 * Included deletion for legacy components which are API-compatible
 * Included deletion for cStor(CSI). Jiva(CSI) deletion is handled by namespace delete.
 