### PR TITLE
snap: bind-mount the whole /etc/service/enabled/ directory

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -443,8 +443,8 @@ passthrough:
       bind: $SNAP_DATA/kubelet
     /var/lib/kube-proxy:
       bind: $SNAP_DATA/kube-proxy
-    /etc/service/enabled/felix/supervise/lock:
-      bind-file: $SNAP_COMMON/etc/service/enabled/felix/supervise/lock
+    /etc/service/enabled:
+      bind: $SNAP_COMMON/etc/service/enabled
 
 parts:
   raft:


### PR DESCRIPTION
There are other lock files that are used, such as

    /etc/service/enabled/monitor-addresses/supervise/lock
    /etc/service/enabled/allocate-tunnel-addrs/supervise/lock

It's probably a good idea to bind-mount the whole parent directory.
