### PR TITLE
add: force option in usage

### DIFF
--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -162,6 +162,10 @@ def usage():
         "--skip-verify  skip the certificate verification of the node we are"
         " joining to (default: false)."
     )
+    print(
+        "--force  force the node removal operation"
+        " (default: false)."
+    )
 
 
 def set_arg(key, value, file):

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -165,7 +165,6 @@ def usage():
     print("--force  force the node removal operation" " (default: false).")
 
 
-
 def set_arg(key, value, file):
     """
     Set an argument to a file

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -162,10 +162,8 @@ def usage():
         "--skip-verify  skip the certificate verification of the node we are"
         " joining to (default: false)."
     )
-    print(
-        "--force  force the node removal operation"
-        " (default: false)."
-    )
+    print("--force  force the node removal operation" " (default: false).")
+
 
 
 def set_arg(key, value, file):


### PR DESCRIPTION
Signed-off-by: Karthikeyan Govindaraj <github.gkarthiks@gmail.com>

### Thank you for making MicroK8s better

Please reference the issue this PR is fixing, or provide a description of the problem addressed.
This PR is to print the `--force` option in the usage/help command for the `microk8s help` command.

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
