### PR TITLE
Upgrade tests for strict branch

### DIFF
--- a/tests/patch-kube-proxy.sh
+++ b/tests/patch-kube-proxy.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-echo "--conntrack-max-per-core=0" >> /var/snap/microk8s/current/args/kube-proxy
-snapctl restart microk8s.daemon-proxy

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -94,13 +94,11 @@ class VM:
     def _transfer_install_local_snap_lxc(self, channel_or_snap):
         print("Installing snap from {}".format(channel_or_snap))
         cmd_prefix = "/snap/bin/lxc exec {}  -- script -e -c".format(self.vm_name).split()
-        cmd = ["rm -rf /var/tmp/microk8s.snap"]
+        cmd = ["rm -rf /root/microk8s.snap"]
         subprocess.check_output(cmd_prefix + cmd)
-        cmd = "lxc file push {} {}/var/tmp/microk8s.snap".format(
-            channel_or_snap, self.vm_name
-        ).split()
+        cmd = "lxc file push {} {}/root/microk8s.snap".format(channel_or_snap, self.vm_name).split()
         subprocess.check_output(cmd)
-        cmd = ["snap install /var/tmp/microk8s.snap --dangerous"]
+        cmd = ["snap install /root/microk8s.snap --dangerous"]
         subprocess.check_output(cmd_prefix + cmd)
         time.sleep(20)
         for i in snap_interfaces:
@@ -136,13 +134,13 @@ class VM:
     def _transfer_install_local_snap_multipass(self, channel_or_snap):
         print("Installing snap from {}".format(channel_or_snap))
         subprocess.check_call(
-            "/snap/bin/multipass transfer {} {}:/var/tmp/microk8s.snap".format(
+            "/snap/bin/multipass transfer {} {}:/root/microk8s.snap".format(
                 channel_or_snap, self.vm_name
             ).split()
         )
         subprocess.check_call(
             "/snap/bin/multipass exec {}  -- sudo "
-            "snap install /var/tmp/microk8s.snap --dangerous".format(self.vm_name).split()
+            "snap install /root/microk8s.snap --dangerous".format(self.vm_name).split()
         )
         for i in snap_interfaces:
             subprocess.check_call(

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -25,10 +25,10 @@ function create_machine() {
 
   # Allow for the machine to boot and get an IP
   sleep 20
-  tar cf - ./tests | lxc exec $NAME -- tar xvf - -C /var/tmp
+  tar cf - ./tests | lxc exec $NAME -- tar xvf - -C /root
   DISTRO_DEPS_TMP="${DISTRO//:/_}"
   DISTRO_DEPS="${DISTRO_DEPS_TMP////-}"
-  lxc exec $NAME -- /bin/bash "/var/tmp/tests/lxc/install-deps/$DISTRO_DEPS"
+  lxc exec $NAME -- /bin/bash "/root/tests/lxc/install-deps/$DISTRO_DEPS"
   lxc exec $NAME -- reboot
   sleep 20
 
@@ -58,14 +58,14 @@ fi
 # TODO Handle local in the upgrade
 create_machine $NAME $PROXY
 # use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
-lxc exec $NAME -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /var/tmp/tests/test-upgrade.py"
+lxc exec $NAME -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /root/tests/test-upgrade.py"
 lxc delete $NAME --force
 
 # Test upgrade-path
 NAME=machine-$RANDOM
 create_machine $NAME $PROXY
 # use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
-lxc exec $NAME -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /var/tmp/tests/test-upgrade-path.py"
+lxc exec $NAME -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /root/tests/test-upgrade-path.py"
 lxc delete $NAME --force
 
 # Test addons
@@ -78,9 +78,8 @@ then
 else
   lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL} --classic
 fi
-lxc exec $NAME -- /var/tmp/tests/patch-kube-proxy.sh
-lxc exec $NAME -- /var/tmp/tests/smoke-test.sh
+lxc exec $NAME -- /root/tests/smoke-test.sh
 # use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
-lxc exec $NAME -- script -e -c "pytest -s /var/tmp/tests/test-addons.py"
+lxc exec $NAME -- script -e -c "pytest -s /root/tests/test-addons.py"
 lxc exec $NAME -- microk8s reset
 lxc delete $NAME --force

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -75,9 +75,9 @@ create_machine $NAME $PROXY
 if [ ${TO_CHANNEL} == "local" ]
 then
   lxc file push ./microk8s_latest_amd64.snap $VM2_NAME/tmp/
-  lxc exec $VM1_NAME -- snap install /tmp/microk8s_latest_amd64.snap --dangerous --classic
+  lxc exec $VM1_NAME -- snap install /tmp/microk8s_latest_amd64.snap --dangerous
 else
-  lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL} --classic
+  lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL}
 fi
 lxc exec $NAME -- /root/tests/smoke-test.sh
 # use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -22,6 +22,7 @@ function create_machine() {
   cat tests/lxc/microk8s.profile | lxc profile edit microk8s
 
   lxc launch -p default -p microk8s $DISTRO $NAME
+  lxc config device override $NAME root size=50GB
 
   # Allow for the machine to boot and get an IP
   sleep 20

--- a/tests/test-distro.sh
+++ b/tests/test-distro.sh
@@ -72,10 +72,11 @@ lxc delete $NAME --force
 # Test addons
 NAME=machine-$RANDOM
 create_machine $NAME $PROXY
-if [ ${TO_CHANNEL} == "local" ]
+if [ $(echo "${TO_CHANNEL}" | grep ".snap") ]
 then
-  lxc file push ./microk8s_latest_amd64.snap $VM2_NAME/tmp/
-  lxc exec $VM1_NAME -- snap install /tmp/microk8s_latest_amd64.snap --dangerous
+  lxc file push ./${TO_CHANNEL} $NAME/tmp/
+  lxc exec $NAME -- snap install /tmp/${TO_CHANNEL} --dangerous
+  lxc exec $NAME -- bash -c 'for i in docker-privileged docker-support kubernetes-support k8s-journald k8s-kubelet k8s-kubeproxy dot-kube network network-bind network-control network-observe firewall-control process-control kernel-module-observe mount-observe hardware-observe system-observe dot-config-helm home-read-all log-observe login-session-observe home opengl; do snap connect microk8s:$i; done'
 else
   lxc exec $NAME -- snap install microk8s --channel=${TO_CHANNEL}
 fi

--- a/tests/test-upgrade-path.py
+++ b/tests/test-upgrade-path.py
@@ -59,7 +59,7 @@ class TestUpgradePath(object):
 
         channel = "1.{}/stable".format(start_channel)
         print("Installing {}".format(channel))
-        cmd = "sudo snap install microk8s --classic --channel={}".format(channel)
+        cmd = "sudo snap install microk8s --channel={}".format(channel)
         run_until_success(cmd)
         wait_for_installation()
         channel_minor = start_channel
@@ -67,7 +67,7 @@ class TestUpgradePath(object):
         while channel_minor <= last_stable_minor:
             channel = "1.{}/stable".format(channel_minor)
             print("Refreshing to {}".format(channel))
-            cmd = "sudo snap refresh microk8s --classic --channel={}".format(channel)
+            cmd = "sudo snap refresh microk8s --channel={}".format(channel)
             run_until_success(cmd)
             wait_for_installation()
             time.sleep(30)
@@ -75,7 +75,7 @@ class TestUpgradePath(object):
 
         print("Installing {}".format(upgrade_to))
         if upgrade_to.endswith(".snap"):
-            cmd = "sudo snap install {} --classic --dangerous".format(upgrade_to)
+            cmd = "sudo snap install {} --dangerous".format(upgrade_to)
         else:
             cmd = "sudo snap refresh microk8s --channel={}".format(upgrade_to)
         run_until_success(cmd, timeout_insec=600)

--- a/tests/test-upgrade-path.py
+++ b/tests/test-upgrade-path.py
@@ -26,52 +26,54 @@ class TestUpgradePath(object):
         Deploy an old snap and try to refresh until the current one.
 
         """
-        start_channel = 16
-        last_stable_minor = None
-        if upgrade_from.startswith("latest") or "/" not in upgrade_from:
-            attempt = 0
-            release_url = "https://dl.k8s.io/release/stable.txt"
-            while attempt < 10 and not last_stable_minor:
-                r = requests.get(release_url)
-                if r.status_code == 200:
-                    last_stable_str = r.content.decode().strip()
-                    # We have "v1.18.4" and we need the "18"
-                    last_stable_parts = last_stable_str.split(".")
-                    last_stable_minor = int(last_stable_parts[1])
-                else:
-                    time.sleep(3)
-                    attempt += 1
-        else:
-            channel_parts = upgrade_from.split(".")
-            channel_parts = channel_parts[1].split("/")
-            print(channel_parts)
-            last_stable_minor = int(channel_parts[0])
+        # start_channel = 21
+        # last_stable_minor = None
+        # if upgrade_from.startswith("latest") or "/" not in upgrade_from:
+        #     attempt = 0
+        #     release_url = "https://dl.k8s.io/release/stable.txt"
+        #     while attempt < 10 and not last_stable_minor:
+        #         r = requests.get(release_url)
+        #         if r.status_code == 200:
+        #             last_stable_str = r.content.decode().strip()
+        #             # We have "v1.18.4" and we need the "18"
+        #             last_stable_parts = last_stable_str.split(".")
+        #             last_stable_minor = int(last_stable_parts[1])
+        #         else:
+        #             time.sleep(3)
+        #             attempt += 1
+        # else:
+        #     channel_parts = upgrade_from.split(".")
+        #     channel_parts = channel_parts[1].split("/")
+        #     print(channel_parts)
+        #     last_stable_minor = int(channel_parts[0])
 
-        last_stable_minor -= 1
+        # last_stable_minor -= 1
 
-        print("")
-        print(
-            "Testing refresh path from 1.{} to 1.{} and finally refresh to {}".format(
-                start_channel, last_stable_minor, upgrade_to
-            )
-        )
-        assert last_stable_minor is not None
+        # print("")
+        # print(
+        #     "Testing refresh path from 1.{} to 1.{} and finally refresh to {}".format(
+        #         start_channel, last_stable_minor, upgrade_to
+        #     )
+        # )
+        # assert last_stable_minor is not None
 
-        channel = "1.{}/stable".format(start_channel)
+        # channel = "1.{}/stable".format(start_channel)
+
+        channel = "latest/edge/strict"
         print("Installing {}".format(channel))
         cmd = "sudo snap install microk8s --channel={}".format(channel)
         run_until_success(cmd)
         wait_for_installation()
-        channel_minor = start_channel
-        channel_minor += 1
-        while channel_minor <= last_stable_minor:
-            channel = "1.{}/stable".format(channel_minor)
-            print("Refreshing to {}".format(channel))
-            cmd = "sudo snap refresh microk8s --channel={}".format(channel)
-            run_until_success(cmd)
-            wait_for_installation()
-            time.sleep(30)
-            channel_minor += 1
+        # channel_minor = start_channel
+        # channel_minor += 1
+        # while channel_minor <= last_stable_minor:
+        #     channel = "1.{}/stable".format(channel_minor)
+        #     print("Refreshing to {}".format(channel))
+        #     cmd = "sudo snap refresh microk8s --channel={}".format(channel)
+        #     run_until_success(cmd)
+        #     wait_for_installation()
+        #     time.sleep(30)
+        #     channel_minor += 1
 
         print("Installing {}".format(upgrade_to))
         if upgrade_to.endswith(".snap"):

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -40,7 +40,7 @@ class TestUpgrade(object):
         """
         print("Testing upgrade from {} to {}".format(upgrade_from, upgrade_to))
 
-        cmd = "sudo snap install microk8s --classic --channel={}".format(upgrade_from)
+        cmd = "sudo snap install microk8s --channel={}".format(upgrade_from)
         run_until_success(cmd)
         wait_for_installation()
         if is_container():

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -43,13 +43,6 @@ class TestUpgrade(object):
         cmd = "sudo snap install microk8s --channel={}".format(upgrade_from)
         run_until_success(cmd)
         wait_for_installation()
-        if is_container():
-            # In some setups (eg LXC on GCE) the hashsize nf_conntrack file under
-            # sys is marked as rw but any update on it is failing causing kube-proxy
-            # to fail.
-            here = os.path.dirname(os.path.abspath(__file__))
-            apply_patch = os.path.join(here, "patch-kube-proxy.sh")
-            check_call("sudo {}".format(apply_patch).split())
 
         # Run through the validators and
         # select those that were valid for the original snap

--- a/tests/test_distros.py
+++ b/tests/test_distros.py
@@ -81,7 +81,7 @@ class InstallTests:
 
     def test_snap_install(self):
         """Test installing a snap"""
-        self.node.snap.install("microk8s", channel=self.install_version, classic=True)
+        self.node.snap.install("microk8s", channel=self.install_version, classic=False)
         # Required for registry
         self.node.snap.install("docker", channel="stable", classic=True)
         self.node.docker.set_storage_driver("vfs")
@@ -140,9 +140,9 @@ class UpgradeTests(InstallTests):
         print(f"Install Version: {self.install_version}")
         print(f"Upgrade Version: {self.upgrade_version}")
         if self.upgrade_version.endswith(".snap"):
-            self.node.snap.install(self.upgrade_version, classic=True, dangerous=True)
+            self.node.snap.install(self.upgrade_version, classic=False, dangerous=True)
         else:
-            self.node.snap.refresh("microk8s", channel=self.upgrade_version, classic=True)
+            self.node.snap.refresh("microk8s", channel=self.upgrade_version, classic=False)
 
     def test_restart_microk8s(self):
         """Test restarting microk8s"""


### PR DESCRIPTION
Placeholder until I can figure out how to run this correctly.  I'm running:

```
 ./tests/test-distro.sh ubuntu:18.04 latest/edge/strict microk8s.snap
```
But it fails with:

```
Tests are running in b'lxc\n'
+ echo --conntrack-max-per-core=0
+ snapctl restart microk8s.daemon-proxy
error: error running snapctl: cannot restart without a context
F

======================================================================================== FAILURES =========================================================================================
________________________________________________________________________________ TestUpgrade.test_upgrade _________________________________________________________________________________

self = <test-upgrade.TestUpgrade object at 0x7f9470cbd320>

    def test_upgrade(self):
        """
        Deploy, probe, upgrade, validate nothing broke.

        """
        print("Testing upgrade from {} to {}".format(upgrade_from, upgrade_to))

        cmd = "sudo snap install microk8s --channel={}".format(upgrade_from)
        run_until_success(cmd)
        wait_for_installation()
        if is_container():
            # In some setups (eg LXC on GCE) the hashsize nf_conntrack file under
            # sys is marked as rw but any update on it is failing causing kube-proxy
            # to fail.
            here = os.path.dirname(os.path.abspath(__file__))
            apply_patch = os.path.join(here, "patch-kube-proxy.sh")
>           check_call("sudo {}".format(apply_patch).split())

/var/tmp/tests/test-upgrade.py:52:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

popenargs = (['sudo', '/var/tmp/tests/patch-kube-proxy.sh'],), kwargs = {}, retcode = 1, cmd = ['sudo', '/var/tmp/tests/patch-kube-proxy.sh']

    def check_call(*popenargs, **kwargs):
        """Run command with arguments.  Wait for command to complete.  If
        the exit code was zero then return, otherwise raise
        CalledProcessError.  The CalledProcessError object will have the
        return code in the returncode attribute.

        The arguments are the same as for the call function.  Example:

        check_call(["ls", "-l"])
        """
        retcode = call(*popenargs, **kwargs)
        if retcode:
            cmd = kwargs.get("args")
            if cmd is None:
                cmd = popenargs[0]
>           raise CalledProcessError(retcode, cmd)
E           subprocess.CalledProcessError: Command '['sudo', '/var/tmp/tests/patch-kube-proxy.sh']' returned non-zero exit status 1.

/usr/lib/python3.6/subprocess.py:311: CalledProcessError
==================================================================================== warnings summary =====================================================================================
test-upgrade.py::TestUpgrade::test_upgrade
  /var/tmp/tests/utils.py:110: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    return yaml.load(output)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================= short test summary info =================================================================================
FAILED ../var/tmp/tests/test-upgrade.py::TestUpgrade::test_upgrade - subprocess.CalledProcessError: Command '['sudo', '/var/tmp/tests/patch-kube-proxy.sh']' returned non-zero exit stat...
======================================================================== 1 failed, 1 warning in 244.40s (0:04:04) =========================================================================
Script done, file is typescript
+ lxc delete machine-3411 --force
```