### PR TITLE
Build k8s binaries with go v1.17

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -287,7 +287,7 @@ parts:
       - git
     override-build: |
       set -eux
-      snap refresh go --channel=1.16/stable || true
+      snap refresh go --channel=1.17/stable || true
       . ./set-env-variables.sh
 
       # if "${KUBE_SNAP_BINS}" exist we have to use the binaries from there


### PR DESCRIPTION
Update the k8s build process to use go 1.17. This is needed for v1.23.