### PR TITLE
Do not print dqlite error messages while dqlite forms a cluster

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -22,7 +22,7 @@ jobs:
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
       - name: Install snapcraft
-        run: sudo snap install snapcraft --classic
+        run: sudo snap install snapcraft --classic --channel=4.x/stable
       - name: Build snap
         run: |
           sg lxd -c 'snapcraft --use-lxd'

--- a/.github/workflows/test-kubeflow.yaml
+++ b/.github/workflows/test-kubeflow.yaml
@@ -23,7 +23,7 @@ jobs:
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
       - name: Install snapcraft
-        run: sudo snap install snapcraft --classic
+        run: sudo snap install snapcraft --classic --channel=4.x/stable
 
       - name: Build snap
         run: sg lxd -c 'snapcraft --use-lxd'

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -836,6 +836,7 @@ def update_dqlite(cluster_cert, cluster_key, voters, host):
                     snappath=snap_path, dbdir=cluster_dir
                 ).split(),
                 timeout=4,
+                stderr=subprocess.STDOUT,
             )
             if host in out.decode():
                 break


### PR DESCRIPTION
When joining a node dqlite may print to stderr:
```
$ microk8s join 192.168.1.156:25000/b12f8fe475e8dcf4a1e3178a1de2dcd8/17f9b3dd3c5b
Contacting cluster at 192.168.1.156
Waiting for this node to finish joining the cluster. Error: open servers store: stat /var/snap/microk8s/2493/var/kubernetes/backend/cluster.yaml: no such file or directory
Usage:
  dqlite -s <servers> <database> [command] [flags]

Flags:
  -c, --cert string       public TLS cert
  -f, --format string     output format (tabular, json) (default "tabular")
  -h, --help              help for dqlite
  -k, --key string        private TLS key
  -s, --servers strings   comma-separated list of db servers, or file://<store>
..  
```

We do not want this output to show up as for any error we retry querying dqlite. 
