### PR TITLE
Do not print dqlite error messages while dqlite forms a cluster

### DIFF
--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -914,6 +914,7 @@ def update_dqlite(cluster_cert, cluster_key, voters, host):
                     snappath=snap_path, dbdir=cluster_dir
                 ).split(),
                 timeout=4,
+                stderr=subprocess.STDOUT,
             )
             if host in out.decode():
                 break


### PR DESCRIPTION
When joining a node dqlite may print to stderr:
```
$ microk8s join 192.168.1.156:25000/b12f8fe475e8dcf4a1e3178a1de2dcd8/17f9b3dd3c5b
Contacting cluster at 192.168.1.156
Waiting for this node to finish joining the cluster. Error: open servers store: stat /var/snap/microk8s/2493/var/kubernetes/backend/cluster.yaml: no such file or directory
Usage:
  dqlite -s <servers> <database> [command] [flags]

Flags:
  -c, --cert string       public TLS cert
  -f, --format string     output format (tabular, json) (default "tabular")
  -h, --help              help for dqlite
  -k, --key string        private TLS key
  -s, --servers strings   comma-separated list of db servers, or file://<store>
..  
```

We do not want this output to show up as for any error we retry querying dqlite. 
