### PR TITLE
Helm install command pinning openebs v2.x.x to microk8s v1.21

### DIFF
--- a/microk8s-resources/actions/enable.openebs.sh
+++ b/microk8s-resources/actions/enable.openebs.sh
@@ -30,6 +30,8 @@ HELM="$SNAP_DATA/bin/helm3 --kubeconfig=$SNAP_DATA/credentials/client.config"
 $HELM repo add openebs https://openebs.github.io/charts
 $HELM repo update
 $HELM -n openebs install openebs openebs/openebs \
+    --version 2.x.x \
+    --set legacy.enabled=true \
     --set varDirectoryPath.baseDir="$SNAP_COMMON/var/openebs" \
     --set jiva.defaultStoragePath="$SNAP_COMMON/var/openebs" \
     --set localprovisioner.basePath="$SNAP_COMMON/var/openebs/local" \


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

This modifies the helm install command for the OpenEBS addon, and pins v2.x.x to microk8s v1.22.
Additionally, this chart used legacy components exclusives.