### PR TITLE
Add sh requirement

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ pylxd
 pytest
 pytest-xdist
 pyyaml
+sh


### PR DESCRIPTION
I keep having to install this manually when running tests.
