### PR TITLE
ignore unroutable DHCP failure addresses when considering IP addresses for get_ips()

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -358,7 +358,7 @@ get_default_ip() {
 }
 
 get_ips() {
-    local IP_ADDR="$($SNAP/bin/hostname -I)"
+    local IP_ADDR="$($SNAP/bin/hostname -I | sed 's/169\.254\.[0-9]\{1,3\}\.[0-9]\{1,3\}//g')"
     local CNI_INTERFACE="vxlan.calico"
     if [[ -z "$IP_ADDR" ]]
     then
@@ -366,7 +366,7 @@ get_ips() {
     else
         if $SNAP/sbin/ifconfig "$CNI_INTERFACE" &> /dev/null
         then
-          CNI_IP="$($SNAP/sbin/ip -o -4 addr list "$CNI_INTERFACE" | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
+          CNI_IP="$($SNAP/sbin/ip -o -4 addr list "$CNI_INTERFACE" | $SNAP/bin/grep -v 'inet 169.254' | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
           local ips="";
           for ip in $IP_ADDR
           do


### PR DESCRIPTION
A fix for https://github.com/ubuntu/microk8s/issues/1822 - and probably many other "my API server restarts / crashes / isn't stable" issues which have not diagnosed this far down.

A recap:
- api kicker service considers a list of IP addresses on the system, looks for changes, restarts API server on changes
- some OSes / users install tools like `dhcpcd`, which by default attempts to DHCP _every interface_.
- when DHCP fails for `vxlan.calico`, a `169.254...` address is assigned to the interface
- That address is removed moments later when dhcp decides to re-try
- this causes `get_ips()` to trigger a re-generation of the api-server CSR
- this causes api-kicker to restart the API, more or less in a loop, causing availability and stability issues

Fix is ignoring `169.254` addresses entirely. They're never relevant for our purposes?

Also note that the `grep` is probably not required, as we usually grab the first address which will have already been assigned as a proper `10.x` address (for example). Still adds a bit of sanity to filter it, as I'm not 100% how that list is sorted.

Thanks!

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
