### PR TITLE
Fixed Snap Build Warnings

### DIFF
--- a/microk8s-resources/wrappers/microk8s-add-node.wrapper
+++ b/microk8s-resources/wrappers/microk8s-add-node.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s-ctr.wrapper
+++ b/microk8s-resources/wrappers/microk8s-ctr.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s-dbctl.wrapper
+++ b/microk8s-resources/wrappers/microk8s-dbctl.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s-disable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-disable.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s-join.wrapper
+++ b/microk8s-resources/wrappers/microk8s-join.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s-leave.wrapper
+++ b/microk8s-resources/wrappers/microk8s-leave.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
+++ b/microk8s-resources/wrappers/microk8s-refresh-certs.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s-remove-node.wrapper
+++ b/microk8s-resources/wrappers/microk8s-remove-node.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s-status.wrapper
+++ b/microk8s-resources/wrappers/microk8s-status.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 

--- a/microk8s-resources/wrappers/microk8s.wrapper
+++ b/microk8s-resources/wrappers/microk8s.wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -e
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,7 +57,7 @@ apps:
     command: run-null-daemon
     daemon: simple
   daemon-k8s-dqlite:
-    command: wrappers/run-k8s-dqlite-with-args
+    command: run-k8s-dqlite-with-args
     daemon: simple
   dashboard-proxy:
     command: microk8s-dashboard-proxy.wrapper

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,7 @@ apps:
   ctr:
     command: microk8s-ctr.wrapper
   inspect:
-    command: sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh
+    command: microk8s.wrapper
   enable:
     command: microk8s-enable.wrapper
   disable:


### PR DESCRIPTION
This PR fixes #2621.

1. Updated bash interpreter in microk8s `.wrapper` files to fix warnings similar to:
```
The interpreter 'bash' for 'microk8s.wrapper' was resolved to '/bin/bash'.
The command 'microk8s.wrapper' has been changed to '/bin/bash $SNAP/microk8s.wrapper' to safely account for the interpreter.
A shell wrapper will be generated for command '/bin/bash $SNAP/microk8s.wrapper' as it does not conform with the command pattern expected by the runtime. Commands must be relative to the prime directory and can only consist of alphanumeric characters, spaces, and the following special characters: / . _ # : $ -
```
2. Updated `daemon-k8s-dqlite` command within the `snapcraft.yml` to fix:
```
The command 'wrappers/run-k8s-dqlite-with-args' for 'wrappers/run-k8s-dqlite-with-args' was resolved to 'microk8s-resources/wrappers/run-k8s-dqlite-with-args'.
The command 'wrappers/run-k8s-dqlite-with-args' has been changed to 'microk8s-resources/wrappers/run-k8s-dqlite-with-args'.
```
3. Updated `inspect` command to utilize `run-k8s-dqlite-with-args` to fix:
```
The command 'sudo' for 'sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh' was resolved to '/usr/bin/sudo'.
The command 'sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh' has been changed to '/usr/bin/sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh'.
A shell wrapper will be generated for command '/usr/bin/sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh' as it does not conform with the command pattern expected by the runtime. Commands must be relative to the prime directory and can only consist of alphanumeric characters, spaces, and the following special characters: / . _ # : $ -
```