### PR TITLE
snap: grant sys_module capability to network hooks

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,10 +68,12 @@ hooks:
   connect-plug-network-control:
     plugs:
       - dot-kube
+      - kernel-module-control
       - network-control
   disconnect-plug-network-control:
     plugs:
       - dot-kube
+      - kernel-module-control
       - network-control
   connect-plug-docker-privileged:
     plugs:


### PR DESCRIPTION
This addresses the following two denials:

    [ 8007.018386] audit: type=1400 audit(1632740135.247:748): apparmor="DENIED" operation="capable" profile="snap.microk8s.hook.disconnect-plug-network-control" pid=399340 comm="ip" capability=16  capname="sys_module"
    [ 8528.424346] audit: type=1400 audit(1632740656.640:2737): apparmor="DENIED" operation="capable" profile="snap.microk8s.hook.connect-plug-network-control" pid=404584 comm="ip" capability=16  capname="sys_module"

