### PR TITLE
snap/hooks/configure: increase timeout to 5 minutes

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -548,9 +548,9 @@ if [ -e "${SNAP_DATA}/args/cni-network/cni.yaml" ] &&
 then
   echo "Setting up the CNI"
   start_timer="$(date +%s)"
-  # Wait up to two minutes for the apiserver to come up.
+  # Wait up to five minutes for the apiserver to come up.
   # TODO: this polling is not good enough. We should find a new way to ensure the apiserver is up.
-  timeout="120"
+  timeout="300"
   KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
   while ! (is_apiserver_ready)
   do


### PR DESCRIPTION
Two minutes is apparently too little for the machines running the snapd
spread tests (https://github.com/snapcore/snapd/pull/10892).

Increase it to five minutes; this should be fine, as the default timeout
in snapd for hooks is ten minutes.
