### PR TITLE
scripts/inspect.sh: prefer journalctl over dmesg

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -32,7 +32,7 @@ function check_service {
 function check_apparmor {
   # Collect apparmor info.
   mkdir -p $INSPECT_DUMP/apparmor
-  dmesg &> $INSPECT_DUMP/apparmor/dmesg
+  journalctl -k &> $INSPECT_DUMP/apparmor/dmesg
 }
 
 


### PR DESCRIPTION
The `dmesg` command directly opens `/dev/kmsg`, whereas journalctl talks
to journald via a socket. Now, we currently have two AppArmor denials
(indentation added by me for improved readability):

    [ 3150.199682] audit: type=1400 audit(1632434096.924:2083):
      apparmor="DENIED" operation="open" profile="snap.microk8s.microk8s"
      name="/bin/journalctl" pid=171631 comm="bash" requested_mask="r"
      denied_mask="r" fsuid=0 ouid=0
    [ 3150.238547] audit: type=1400 audit(1632434096.960:2084):
      apparmor="DENIED" operation="open" profile="snap.microk8s.microk8s"
      name="/dev/kmsg" pid=171646 comm="dmesg" requested_mask="r"
      denied_mask="r" fsuid=0 ouid=0

Since we are anyway using journalctl in scripts/inspect.sh a few lines
above, it makes sense to use it also to retrieve the kernel message.
We'll deal with the denial with running journalctl in another commit.
