### PR TITLE
Remove deprecated configuration from containerd-template.toml

### DIFF
--- a/microk8s-resources/default-args/certs.d/docker.io/hosts.toml
+++ b/microk8s-resources/default-args/certs.d/docker.io/hosts.toml
@@ -1,0 +1,5 @@
+server = "https://docker.io"
+
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
+

--- a/microk8s-resources/default-args/certs.d/localhost:32000/hosts.toml
+++ b/microk8s-resources/default-args/certs.d/localhost:32000/hosts.toml
@@ -1,0 +1,5 @@
+server = "http://localhost:32000"
+
+[host."http://localhost:32000"]
+  capabilities = ["pull", "resolve"]
+

--- a/microk8s-resources/default-args/containerd-template.toml
+++ b/microk8s-resources/default-args/containerd-template.toml
@@ -74,10 +74,4 @@ oom_score = 0
 
   # 'plugins."io.containerd.grpc.v1.cri".registry' contains config related to the registry
   [plugins."io.containerd.grpc.v1.cri".registry]
-
-    # 'plugins."io.containerd.grpc.v1.cri".registry.mirrors' are namespace to mirror mapping for all namespaces.
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-        endpoint = ["https://registry-1.docker.io", ]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:32000"]
-        endpoint = ["http://localhost:32000"]
+    config_path = "${SNAP_DATA}/args/certs.d"


### PR DESCRIPTION
As described in #2647, containerd has changed the way registries are configured. This patch adapts microk8s to this change. See more at [containerd](https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration).

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.

PS: I haven't signed the CLA as it requires me to provide the name of a "Canonical Project Manager or contact". Please advise.