### PR TITLE
1.21 Backport: Bump Kubeflow addon to latest revisions

### DIFF
--- a/.github/workflows/test-kubeflow.yaml
+++ b/.github/workflows/test-kubeflow.yaml
@@ -70,7 +70,7 @@ jobs:
           sudo apt install -y libssl-dev python3-pip firefox-geckodriver
           git clone https://github.com/juju-solutions/bundle-kubeflow.git
           cd bundle-kubeflow
-          git reset --hard f5c744b9
+          git reset --hard c89276f
           sudo pip3 install -r requirements.txt -r test-requirements.txt
           sudo microk8s status --wait-ready
           sudo microk8s kubectl -n kube-system rollout status ds/calico-node
@@ -188,7 +188,7 @@ jobs:
             sudo apt install -y libssl-dev python3-pip firefox-geckodriver
             git clone https://github.com/juju-solutions/bundle-kubeflow.git
             cd bundle-kubeflow
-            git reset --hard f5c744b9
+            git reset --hard c89276f
             sudo pip3 install -r requirements.txt -r test-requirements.txt
             sudo microk8s status --wait-ready
             sudo microk8s kubectl -n kube-system rollout status ds/calico-node

--- a/microk8s-resources/actions/enable.kubeflow.sh
+++ b/microk8s-resources/actions/enable.kubeflow.sh
@@ -431,7 +431,7 @@ def print_info(hostname, password):
 @click.command()
 @click.option(
     "--bundle",
-    default="cs:kubeflow-267",
+    default="cs:kubeflow-270",
     help="The Kubeflow bundle to deploy. Can be one of full, lite, edge, or a charm store URL.",
 )
 @click.option(
@@ -475,11 +475,11 @@ def kubeflow(bundle, channel, debug, hostname, ignore_min_mem, no_proxy, passwor
     # user to specify a full charm store URL if they'd like, such as
     # `cs:kubeflow-lite-123`.
     if bundle == "full":
-        bundle = "cs:kubeflow-267"
+        bundle = "cs:kubeflow-270"
     elif bundle == "lite":
-        bundle = "cs:kubeflow-lite-51"
+        bundle = "cs:kubeflow-lite-54"
     elif bundle == "edge":
-        bundle = "cs:kubeflow-edge-44"
+        bundle = "cs:kubeflow-edge-46"
     else:
         bundle = bundle
 


### PR DESCRIPTION
### Summary

This PR backports #2480 to the 1.21 branch.

References https://github.com/canonical/bundle-kubeflow/issues/381

Please reference the issue this PR is fixing, or provide a description of the problem addressed.

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
