### PR TITLE
Use Docker's own registry image

### DIFF
--- a/microk8s-resources/actions/registry.yaml
+++ b/microk8s-resources/actions/registry.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: registry
-          image: cdkbot/registry-$ARCH:2.6
+          image: registry:2.7.1
           env:
             - name: REGISTRY_HTTP_ADDR
               value: :5000


### PR DESCRIPTION
cdkbot's image is very out-of-date and compiled with a very old version of Go.