### PR TITLE
Update inaccel add-on

### DIFF
--- a/microk8s-resources/actions/disable.inaccel.sh
+++ b/microk8s-resources/actions/disable.inaccel.sh
@@ -6,6 +6,8 @@ source $SNAP/actions/common/utils.sh
 
 echo "Disabling InAccel FPGA Operator"
 
-"$SNAP/microk8s-helm3.wrapper" uninstall inaccel
+"$SNAP/microk8s-helm3.wrapper" uninstall inaccel \
+  --namespace kube-system \
+  $@
 
 echo "InAccel is disabled"

--- a/microk8s-resources/actions/enable.inaccel.sh
+++ b/microk8s-resources/actions/enable.inaccel.sh
@@ -9,6 +9,7 @@ source $SNAP/actions/common/utils.sh
 echo "Enabling InAccel FPGA Operator"
 
 "$SNAP/microk8s-helm3.wrapper" install inaccel fpga-operator \
+  --namespace kube-system \
   --repo https://setup.inaccel.com/helm \
   --set kubelet=$SNAP_COMMON/var/lib/kubelet \
   $@

--- a/tests/templates/inaccel.yaml
+++ b/tests/templates/inaccel.yaml
@@ -1,6 +1,11 @@
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    inaccel/cli: |
+      bitstream install https://store.inaccel.com/artifactory/bitstreams/xilinx/aws-vu9p-f1/shell-v04261818_201920.2/aws/vector/1/1addition
+  labels:
+    inaccel/fpga: enabled
   name: inaccel-vadd
 spec:
   containers:
@@ -9,23 +14,6 @@ spec:
       resources:
         limits:
           xilinx/aws-vu9p-f1: 1
-      volumeMounts:
-        - mountPath: /var/lib/inaccel
-          name: inaccel
-  initContainers:
-    - args:
-        - bitstream
-        - install
-        - https://store.inaccel.com/artifactory/bitstreams/xilinx/aws-vu9p-f1/shell-v04261818_201920.2/aws/vector/1/1addition
-      image: inaccel/cli
-      name: init
-      volumeMounts:
-        - mountPath: /var/lib/inaccel
-          name: inaccel
   nodeSelector:
     xilinx/aws-vu9p-f1: shell-v04261818_201920.2
   restartPolicy: OnFailure
-  volumes:
-    - csi:
-        driver: inaccel
-      name: inaccel

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -174,7 +174,7 @@ def validate_gpu():
 
 def validate_inaccel():
     """
-    Validate inaccel
+    Validate inaccel by trying a vadd.
     """
     if platform.machine() != "x86_64":
         print("FPGA tests are only relevant in x86 architectures")


### PR DESCRIPTION
* Set `kube-system` as the default namespace
    * As of `fpga-operator-2.5.3` release, the templates respect the Helm release namespace
    * Users will be able to modify this using the cli: `microk8s enable/disable inaccel -n <my-namepace>`

* Test mutating webhook features
    * InAccel FPGA Operator v2.5.0 introduced a Mutating Webhook Configuraton
        * Simplifies FPGA-enabled Pods (less YAML lines)
         * Enables easier integration with CRDs