### PR TITLE
Bundle nano with strict in order to be able to use `kubectl edit`

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -89,7 +89,7 @@ sudo snap install microk8s_latest_amd64.snap --dangerous
 #### Connecting the required interfaces
 
 ```
-for i in docker-privileged docker-support kubernetes-support k8s-journald k8s-kubelet k8s-kubeproxy dot-kube network network-bind network-control network-observe firewall-control process-control kernel-module-observe mount-observe hardware-observe system-observe home opengl; do sudo snap connect microk8s:$i; done
+for i in docker-privileged docker-support kubernetes-support k8s-journald k8s-kubelet k8s-kubeproxy dot-kube network network-bind network-control network-observe firewall-control process-control kernel-module-observe mount-observe hardware-observe system-observe home opengl dot-config-helm home-read-all log-observe login-session-observe; do sudo snap connect microk8s:$i; done
 ```
 
 After copying it, you can install it with:

--- a/microk8s-resources/wrappers/microk8s-kubectl.wrapper
+++ b/microk8s-resources/wrappers/microk8s-kubectl.wrapper
@@ -25,7 +25,7 @@ fi
 declare -a args="($(cat $SNAP_DATA/args/kubectl))"
 if [ -n "${args[@]-}" ]
 then
-  "${SNAP}/kubectl" "${args[@]}" "$@"
+  EDITOR="${SNAP}/bin/nano" "${SNAP}/kubectl" "${args[@]}" "$@"
 else
-  "${SNAP}/kubectl" "$@"
+  EDITOR="${SNAP}/bin/nano" "${SNAP}/kubectl" "$@"
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -494,6 +494,8 @@ passthrough:
       bind: $SNAP_DATA/kube-proxy
     /etc/service/enabled:
       bind: $SNAP_COMMON/etc/service/enabled
+    /etc/nanorc:
+      bind-file: $SNAP_COMMON/etc/nanorc
 
 parts:
   raft:
@@ -987,3 +989,12 @@ parts:
       juju: bin/juju
     prime:
       - bin/juju
+
+  nano:
+    plugin: nil
+    stage-packages:
+      - nano
+    stage:
+      - bin/nano
+    prime:
+      - bin/nano

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -832,9 +832,8 @@ parts:
       - -sbin/iptables*
       - -lib/xtables
 
-  bash-utils:
-    source: snap
-    plugin: dump
+  auxiliary:
+    plugin: nil
     stage-packages:
       - aufs-tools
       - coreutils
@@ -854,6 +853,7 @@ parts:
       - net-tools
       - sed
       - socat
+      - nano
       - util-linux
       - zfsutils-linux
     stage:
@@ -989,12 +989,3 @@ parts:
       juju: bin/juju
     prime:
       - bin/juju
-
-  nano:
-    plugin: nil
-    stage-packages:
-      - nano
-    stage:
-      - bin/nano
-    prime:
-      - bin/nano


### PR DESCRIPTION
Bundling `nano` (this seems to be defacto in Ubuntu) in order to be able to edit manifests on-the-fly with `kubectl`.