### PR TITLE
Inspect report to include basic dqlite info

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -113,6 +113,17 @@ function store_juju_info {
 }
 
 
+function store_dqlite_info {
+  # Collect some dqlite details
+  printf -- '  Inspect dqlite\n'
+  mkdir -p $INSPECT_DUMP/dqlite
+  sudo -E cp ${SNAP_DATA}/var/kubernetes/backend/cluster.yaml $INSPECT_DUMP/dqlite/
+  sudo -E cp ${SNAP_DATA}/var/kubernetes/backend/localnode.yaml $INSPECT_DUMP/dqlite/
+  sudo -E cp ${SNAP_DATA}/var/kubernetes/backend/info.yaml $INSPECT_DUMP/dqlite/
+  sudo -E ls -lh ${SNAP_DATA}/var/kubernetes/backend/ 2>&1 >  $INSPECT_DUMP/dqlite/list.out
+}
+
+
 function store_kubeflow_info {
   # Collect some kubeflow details
   printf -- '  Inspect Kubeflow\n'
@@ -357,6 +368,9 @@ store_juju_info
 
 printf -- 'Inspecting kubeflow\n'
 store_kubeflow_info
+
+printf -- 'Inspecting dqlite\n'
+store_dqlite_info
 
 suggest_fixes
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,7 @@ apps:
   ctr:
     command: microk8s-ctr.wrapper
   inspect:
-    command: microk8s.wrapper
+    command: sudo SNAP_DATA=${SNAP_DATA} ${SNAP}/inspect.sh
   enable:
     command: microk8s-enable.wrapper
   disable:


### PR DESCRIPTION
Include a dqlite directory in the inspection report.

Fix the `microk8s.inspect` command, notice the `.`.