### PR TITLE
snap: Remove kernel-module-control interface

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -61,7 +61,7 @@ jobs:
           for i in docker-privileged docker-support kubernetes-support k8s-journald k8s-kubelet \
                    k8s-kubeproxy dot-kube network network-bind network-control network-observe \
                    firewall-control process-control kernel-module-observe mount-observe \
-                   hardware-observe system-observe home opengl home-read-all kernel-module-control \
+                   hardware-observe system-observe home opengl home-read-all \
                    login-session-observe log-observe dot-config-helm
           do
             sudo snap connect microk8s:$i
@@ -95,7 +95,7 @@ jobs:
           for i in docker-privileged docker-support kubernetes-support k8s-journald k8s-kubelet \
                    k8s-kubeproxy dot-kube network network-bind network-control network-observe \
                    firewall-control process-control kernel-module-observe mount-observe \
-                   hardware-observe system-observe home opengl home-read-all kernel-module-control \
+                   hardware-observe system-observe home opengl home-read-all \
                    login-session-observe log-observe dot-config-helm
           do
             sudo snap connect microk8s:$i

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -231,7 +231,6 @@ apps:
     daemon: simple
     install-mode: disable
     plugs:
-      - kernel-module-control
       - network-bind
       - network-observe
       - network-control

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,12 +68,10 @@ hooks:
   connect-plug-network-control:
     plugs:
       - dot-kube
-      - kernel-module-control
       - network-control
   disconnect-plug-network-control:
     plugs:
       - dot-kube
-      - kernel-module-control
       - network-control
   connect-plug-docker-privileged:
     plugs:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,7 +31,6 @@ snap_interfaces = [
     "home",
     "opengl",
     "home-read-all",
-    "kernel-module-control",
     "login-session-observe",
     "log-observe",
 ]


### PR DESCRIPTION
I added this interface just to suppress some AppArmor denials, which were anyway harmless. We are about to land a change in snapd which will suppress these denials anyway (https://github.com/snapcore/snapd/pull/10933) and will not require further changes in microk8s.

It's up to you whether you want to merge this right now or wait for a newer snapd. As I said, these denials are cosmetic, so I'd vote for merging this now and concede that we'll see a couple of denials until a newer snapd fixes them.