### PR TITLE
 Points Kubeflow's check_status value to kubeflow.enabled lock file 

### DIFF
--- a/microk8s-resources/actions/disable.kubeflow.sh
+++ b/microk8s-resources/actions/disable.kubeflow.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env python3
 
 import os
+import sys
 import subprocess
 
 import click
 
+def mark_kubeflow_disabled():
+    """Mark Kubeflow addon as disabled by removing kubeflow.enabled lock file."""
+    try:
+        snapdata_path = os.environ.get("SNAP_DATA")
+        lock_fname = "{}/var/lock/kubeflow.enabled".format(snapdata_path)
+        subprocess.call(['sudo', 'rm', lock_fname])
+    except (subprocess.CalledProcessError):
+        print("Failed to mark Kubeflow addon as disabled." )
+        sys.exit(4)
 
 @click.command()
 def kubeflow():
@@ -65,6 +75,8 @@ def kubeflow():
             )
         except subprocess.CalledProcessError:
             pass
+
+    mark_kubeflow_disabled()
 
     click.echo("Destruction complete.")
 

--- a/microk8s-resources/actions/enable.kubeflow.sh
+++ b/microk8s-resources/actions/enable.kubeflow.sh
@@ -29,6 +29,16 @@ CONNECTIVITY_CHECKS = [
 ]
 
 
+def mark_kubeflow_enabled():
+    """Mark Kubeflow addon as enabled by creating kubeflow.enabled."""
+    try:
+        snapdata_path = os.environ.get("SNAP_DATA")
+        lock_fname = "{}/var/lock/kubeflow.enabled".format(snapdata_path)
+        subprocess.call(['sudo', 'touch', lock_fname])
+    except (subprocess.CalledProcessError):
+        print("Failed to mark Kubeflow addon as enabled." )
+        sys.exit(4)
+
 def charm_exists(name: str):
     try:
         run("microk8s-juju.wrapper", "show-application", name, die=False)
@@ -519,6 +529,7 @@ def kubeflow(bundle, channel, debug, hostname, ignore_min_mem, no_proxy, passwor
 
     print_info(hostname, password)
 
+    mark_kubeflow_enabled()
 
 if __name__ == "__main__":
     kubeflow(prog_name="microk8s enable kubeflow", auto_envvar_prefix="KUBEFLOW")

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -141,7 +141,7 @@ microk8s-addons:
     - name: "kubeflow"
       description: "Kubeflow for easy ML deployments"
       version: ""
-      check_status: "pod/ambassador-operator-0"
+      check_status: "{SNAP_DATA}/var/lock/kubeflow.enabled"
       supported_architectures:
         - amd64
 


### PR DESCRIPTION
Creates lock file after all actions in enable.kubeflow.sh
and points check_status in addon-lists.yaml to that file.
This ensures Kubeflow addon is listed as enabled when
running microk8s status

Fixes #2695