### PR TITLE
Update GPU operator and fix its test

### DIFF
--- a/microk8s-resources/actions/enable.gpu.sh
+++ b/microk8s-resources/actions/enable.gpu.sh
@@ -41,7 +41,7 @@ echo "Installing NVIDIA Operator"
 "$SNAP/microk8s-helm3.wrapper" repo add nvidia https://nvidia.github.io/gpu-operator
 "$SNAP/microk8s-helm3.wrapper" repo update
 "$SNAP/microk8s-helm3.wrapper" install gpu-operator nvidia/gpu-operator \
-  --version=v1.7.0 \
+  --version=v1.8.2 \
   --set toolkit.version=1.5.0-ubuntu18.04 \
   --set operator.defaultRuntime=containerd \
   --set driver.enabled=$ENABLE_INTERNAL_DRIVER \

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -156,7 +156,7 @@ def validate_gpu():
         print("GPU tests are only relevant in x86 architectures")
         return
 
-    wait_for_pod_state("", "kube-system", "running", label="name=nvidia-device-plugin-ds")
+    wait_for_pod_state("", "gpu-operator-resources", "running", label="app=nvidia-device-plugin-daemonset")
     here = os.path.dirname(os.path.abspath(__file__))
     manifest = os.path.join(here, "templates", "cuda-add.yaml")
 

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -156,7 +156,9 @@ def validate_gpu():
         print("GPU tests are only relevant in x86 architectures")
         return
 
-    wait_for_pod_state("", "gpu-operator-resources", "running", label="app=nvidia-device-plugin-daemonset")
+    wait_for_pod_state(
+        "", "gpu-operator-resources", "running", label="app=nvidia-device-plugin-daemonset"
+    )
     here = os.path.dirname(os.path.abspath(__file__))
     manifest = os.path.join(here, "templates", "cuda-add.yaml")
 


### PR DESCRIPTION
Updated GPU operator as the v1.8.2 allows for "support for user-defined MIG partition configuration via a ConfigMap" [1].

[1] https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/release-notes.html

