### PR TITLE
Use SafeLoader instead of FullLoader

### DIFF
--- a/scripts/cluster/agent.py
+++ b/scripts/cluster/agent.py
@@ -466,7 +466,7 @@ def get_dqlite_nodes():
     while waits > 0:
         try:
             with open("{}/info.yaml".format(cluster_dir)) as f:
-                data = yaml.load(f, Loader=yaml.FullLoader)
+                data = yaml.safe_load(f)
                 out = subprocess.check_output(
                     "{snappath}/bin/dqlite -s file://{dbdir}/cluster.yaml -c {dbdir}/cluster.crt "
                     "-k {dbdir}/cluster.key -f json k8s .cluster".format(

--- a/scripts/cluster/common/utils.py
+++ b/scripts/cluster/common/utils.py
@@ -126,7 +126,7 @@ def get_dqlite_port():
     port = 19001
     if os.path.exists(dqlite_info):
         with open(dqlite_info) as f:
-            data = yaml.load(f, Loader=yaml.FullLoader)
+            data = yaml.safe_load(f)
         if "Address" in data:
             port = data["Address"].split(":")[1]
 

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -894,7 +894,7 @@ def update_dqlite(cluster_cert, cluster_key, voters, host):
     # We get the dqlite port from the already existing deployment
     port = 19001
     with open("{}/info.yaml".format(cluster_backup_dir)) as f:
-        data = yaml.load(f, Loader=yaml.FullLoader)
+        data = yaml.safe_load(f)
     if "Address" in data:
         port = data["Address"].split(":")[1]
 

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -80,7 +80,7 @@ def get_dqlite_info():
     while waits > 0:
         try:
             with open("{}/info.yaml".format(cluster_dir), mode="r") as f:
-                data = yaml.load(f, Loader=yaml.FullLoader)
+                data = yaml.safe_load(f)
                 out = subprocess.check_output(
                     "{snappath}/bin/dqlite -s file://{dbdir}/cluster.yaml -c {dbdir}/cluster.crt "
                     "-k {dbdir}/cluster.key -f json k8s .cluster".format(
@@ -183,7 +183,7 @@ def get_available_addons(arch):
     with open(addon_dataset, "r") as file:
         # The FullLoader parameter handles the conversion from YAML
         # scalar values to Python the dictionary format
-        addons = yaml.load(file, Loader=yaml.FullLoader)
+        addons = yaml.safe_load(file)
         for addon in addons["microk8s-addons"]["addons"]:
             if arch in addon["supported_architectures"]:
                 available.append(addon)


### PR DESCRIPTION
## Summary

This minor PR is to make use of `yaml.safe_load` when loading YAML files in Python. This is to prevent issues (security or otherwise) that may arise from using the `yaml.FullLoader`
