### PR TITLE
Disable profiling and reduce event TTL for Kubernetes services

### DIFF
--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -15,6 +15,8 @@
 --service-account-issuer='https://kubernetes.default.svc'
 --service-account-signing-key-file=${SNAP_DATA}/certs/serviceaccount.key
 --feature-gates=RemoveSelfLink=false
+--event-ttl=5m
+--profiling=false
 
 # Enable the aggregation layer
 --requestheader-client-ca-file=${SNAP_DATA}/certs/front-proxy-ca.crt

--- a/microk8s-resources/default-args/kube-controller-manager
+++ b/microk8s-resources/default-args/kube-controller-manager
@@ -7,3 +7,4 @@
 --use-service-account-credentials
 --leader-elect-lease-duration=60s
 --leader-elect-renew-deadline=30s
+--profiling=false

--- a/microk8s-resources/default-args/kube-proxy
+++ b/microk8s-resources/default-args/kube-proxy
@@ -1,3 +1,4 @@
 --kubeconfig=${SNAP_DATA}/credentials/proxy.config
 --cluster-cidr=10.1.0.0/16
 --healthz-bind-address=127.0.0.1
+--profiling=false

--- a/microk8s-resources/default-args/kube-scheduler
+++ b/microk8s-resources/default-args/kube-scheduler
@@ -2,3 +2,4 @@
 --address=127.0.0.1
 --leader-elect-lease-duration=60s
 --leader-elect-renew-deadline=30s
+--profiling=false


### PR DESCRIPTION
## Summary

Update default API server arguments

- Disable profiling (--profiling=false)
- Reduce event TTL to 5 minutes (--event-ttl=5m)
