### PR TITLE
upgrade keda to the latest version

### DIFF
--- a/microk8s-resources/actions/enable.keda.sh
+++ b/microk8s-resources/actions/enable.keda.sh
@@ -16,7 +16,7 @@ do_prerequisites() {
 
 
 get_keda () {
-  KEDA_VERSION="v2.1.0"
+  KEDA_VERSION="v2.4.0"
   KEDA_ERSION=$(echo $KEDA_VERSION | sed 's/v//g')
   echo "Fetching keda version $KEDA_ERSION."
   run_with_sudo "${SNAP}/usr/bin/curl" --cacert $CA_CERT -L https://github.com/kedacore/keda/releases/download/${KEDA_VERSION}/keda-${KEDA_ERSION}.yaml -o "$SNAP_DATA/keda/keda.yaml"


### PR DESCRIPTION
This PR upgrades KEDA to the latest version `v2.4.0`.
Tested on kubernetes `1.23.0-beta.0`

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
