### PR TITLE
upgrade metrics server to v0.5.2

### DIFF
--- a/microk8s-resources/actions/metrics-server.yaml
+++ b/microk8s-resources/actions/metrics-server.yaml
@@ -130,12 +130,12 @@ spec:
       containers:
         - args:
             - --cert-dir=/tmp
-            - --secure-port=443
+            - --secure-port=4443
             - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
             - --kubelet-use-node-status-port
             - --metric-resolution=15s
             - --kubelet-insecure-tls # ignore kubelet cert
-          image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+          image: k8s.gcr.io/metrics-server/metrics-server:v0.5.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -146,7 +146,7 @@ spec:
             periodSeconds: 10
           name: metrics-server
           ports:
-            - containerPort: 443
+            - containerPort: 4443
               name: https
               protocol: TCP
           readinessProbe:


### PR DESCRIPTION
Upgrading metrics server to `v0.5.2`

*Also verify you have:*
* [X] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
