### PR TITLE
Replace depreated call from net-tools to iproute2

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -347,7 +347,7 @@ wait_for_service_shutdown() {
 
 get_default_ip() {
     # Get the IP of the default interface
-    local DEFAULT_INTERFACE="$($SNAP/bin/netstat -rn | $SNAP/bin/grep '^0.0.0.0' | $SNAP/usr/bin/gawk '{print $NF}' | head -1)"
+    local DEFAULT_INTERFACE="$($SNAP/sbin/ip route show default | $SNAP/usr/bin/gawk '{for(i=1; i<NF; i++) if($i=="dev") print$(i+1)}')"
     local IP_ADDR="$($SNAP/sbin/ip -o -4 addr list "$DEFAULT_INTERFACE" | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
     if [[ -z "$IP_ADDR" ]]
     then
@@ -364,7 +364,7 @@ get_ips() {
     then
         echo "none"
     else
-        if $SNAP/sbin/ifconfig "$CNI_INTERFACE" &> /dev/null
+        if $SNAP/sbin/ip link show "$CNI_INTERFACE" &> /dev/null
         then
           CNI_IP="$($SNAP/sbin/ip -o -4 addr list "$CNI_INTERFACE" | $SNAP/bin/grep -v 'inet 169.254' | $SNAP/usr/bin/gawk '{print $4}' | $SNAP/usr/bin/cut -d/ -f1 | head -1)"
           local ips="";

--- a/microk8s-resources/actions/disable.host-access.sh
+++ b/microk8s-resources/actions/disable.host-access.sh
@@ -7,7 +7,7 @@ if [ -f "${SNAP_DATA}/var/lock/host-access-enabled" ]
 then
   IP_ADDRESS=$(<"${SNAP_DATA}/var/lock/host-access-enabled")
   echo "Disabling  host-access [${IP_ADDRESS}]"
-  run_with_sudo "$SNAP/sbin/ifconfig" lo:microk8s $IP_ADDRESS down
+  run_with_sudo "$SNAP/sbin/ip" addr del "$IP_ADDRESS"/32 dev lo label lo:microk8s
   run_with_sudo "$SNAP/bin/rm" -f "$SNAP_DATA/var/lock/host-access-enabled"
   echo "Host-access is disabled"
 else

--- a/microk8s-resources/actions/enable.host-access.sh
+++ b/microk8s-resources/actions/enable.host-access.sh
@@ -30,7 +30,7 @@ fi
 echo "$IP_ADDRESS" > "${SNAP_DATA}/var/lock/host-access-enabled"
 echo "Setting ${IP_ADDRESS} as host-access"
 
-run_with_sudo "$SNAP/sbin/ifconfig" lo:microk8s "$IP_ADDRESS" up
+run_with_sudo "$SNAP/sbin/ip" addr add "$IP_ADDRESS"/32 dev lo label lo:microk8s
 
 echo "Host-access is enabled"
 

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -166,7 +166,7 @@ if [ -f "${SNAP_DATA}/var/lock/host-access-enabled" ] &&
    ! ip link show lo:microk8s &> /dev/null
 then
   IP_ADDRESS=$(<"${SNAP_DATA}/var/lock/host-access-enabled")
-  if ! "$SNAP/sbin/ifconfig" lo:microk8s "$IP_ADDRESS" up
+  if ! "$SNAP/sbin/ip" addr add "$ip_ADDRESS" dev lo label lo:microk8s
   then
     echo "Failed to enable host-access"
   else

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -52,8 +52,8 @@ function store_network {
   # Collect network setup.
   printf -- '  Copy network configuration to the final report tarball\n'
   mkdir -p $INSPECT_DUMP/network
-  netstat -pln &> $INSPECT_DUMP/network/netstat
-  ifconfig &> $INSPECT_DUMP/network/ifconfig
+  ss -pln &> $INSPECT_DUMP/network/ss
+  ip addr &> $INSPECT_DUMP/network/ip-addr
   iptables -t nat -L -n -v &> $INSPECT_DUMP/network/iptables
   iptables -S &> $INSPECT_DUMP/network/iptables-S
   iptables -L &> $INSPECT_DUMP/network/iptables-L


### PR DESCRIPTION
It consist basically of the replacement of the long deprecated ifconfig/netstat to ip addr/route/ss tools from iproute2.

The first commit fixes the issue #2657 .
While at it, it also takes care, in a second commit, of other calls of ifconfig and netstat in other scripts such as :  
* enable/disable host-access
* common/utils functions
* inside the wrapper "run-kubelite-with-args" which simply enable the host-access feature

With this, theoretically, it should be possible to remove net-tools from the snap build.