### PR TITLE
Improve handling for missing k8s-dqlite arguments file

### DIFF
--- a/microk8s-resources/wrappers/run-k8s-dqlite-with-args
+++ b/microk8s-resources/wrappers/run-k8s-dqlite-with-args
@@ -15,6 +15,14 @@ exit_if_service_not_expected_to_start k8s-dqlite
 
 app=k8s-dqlite
 
+if ! [ -e "$SNAP_DATA/args/${app}" ]
+then
+  exit 0
+fi
+
+# We add some delay so that systemd really retries the restarts
+sleep 6
+
 set -a
 if [ -e "${SNAP_DATA}/args/${app}-env" ]
 then


### PR DESCRIPTION
### Summary

When the `k8s-dqlite` arguments file is missing, then simply `exit 0` from the `snap.microk8s.daemon.k8s-dqlite` service.

This is to avoid a race condition where during a refresh, the k8s-dqlite daemon restarts too many times before the configure hook is able to properly cp the required configuration files.

### Notes

- This is similar to what we do for traefik on the worker nodes.