### PR TITLE
Fix removal of callback tokens

### DIFF
--- a/scripts/cluster/reset.py
+++ b/scripts/cluster/reset.py
@@ -183,7 +183,7 @@ def remove_callback_token(node):
         with open(callback_tokens_file, "r+") as callback_fp:
             # Entries are of the format: 'node_hostname:agent_port token'
             # We need to get the node_hostname part
-            for _, line in enumerate(callback_fp):
+            for line in callback_fp:
                 parts = line.split(":")
                 if parts[0] == node:
                     continue

--- a/scripts/cluster/reset.py
+++ b/scripts/cluster/reset.py
@@ -181,8 +181,10 @@ def remove_callback_token(node):
     with open(tmp_file, "w") as backup_fp:
         os.chmod(tmp_file, 0o600)
         with open(callback_tokens_file, "r+") as callback_fp:
+            # Entries are of the format: 'node_hostname:agent_port token'
+            # We need to get the node_hostname part
             for _, line in enumerate(callback_fp):
-                parts = line.split()
+                parts = line.split(':')
                 if parts[0] == node:
                     continue
                 else:

--- a/scripts/cluster/reset.py
+++ b/scripts/cluster/reset.py
@@ -184,7 +184,7 @@ def remove_callback_token(node):
             # Entries are of the format: 'node_hostname:agent_port token'
             # We need to get the node_hostname part
             for _, line in enumerate(callback_fp):
-                parts = line.split(':')
+                parts = line.split(":")
                 if parts[0] == node:
                     continue
                 else:


### PR DESCRIPTION
Parsing the callback tokens file was not correct and we were not removing callback tokens of nodes that had departed the cluster. This was casing the distributed ops to iterate over nodes that had already been removed from the cluster as described in  https://github.com/ubuntu/microk8s/issues/2750