### PR TITLE
Update the PATH containerd-shims has to find runc

### DIFF
--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -15,7 +15,6 @@ fi
 SNAP_CURRENT="/snap/microk8s/current"
 CURRENT_PATH="$SNAP_CURRENT/usr/sbin:$SNAP_CURRENT/usr/bin:$SNAP_CURRENT/sbin:$SNAP_CURRENT/bin"
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$CURRENT_PATH:$PATH"
-export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -7,6 +7,14 @@ if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" !=
     exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
+# Why we put the /snap/microk8s/current in the path?
+# containerd-shims need to call runc. They inherit their PATH from containerd.
+# As the snap refreshes runc changes location, eg moves from
+# /snap/microk8s/123/usr/bin/runc to /snap/microk8s/124/usr/runc.
+# containerd-shims need to look for runc in  /snap/microk8s/current/usr/bin/runc
+SNAP_CURRENT="/snap/microk8s/current"
+CURRENT_PATH="$SNAP_CURRENT/usr/sbin:$SNAP_CURRENT/usr/bin:$SNAP_CURRENT/sbin:$SNAP_CURRENT/bin"
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$CURRENT_PATH:$PATH"
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"


### PR DESCRIPTION
Addresses https://github.com/ubuntu/microk8s/issues/2645

To test this PR you can:
```
sudo snap install microk8s --revision 2746 --classic
microk8s.enable ingress
microk8s.kubectl get all -A
# wait for everything to be ready
sudo snap refresh microk8s --revision 2742
sudo snap refresh microk8s --revision 2740
#
ls -lh /snap/microk8s/
# revision 2746 should be missing
microk8s.kubectl get all -A
#delete the ingress pod
# eg microk8s.kubectl delete pod/nginx-ingress-microk8s-controller-9vlhc -n ingress
microk8s.kubectl get all -A
```
Make sure you do not have a runc already somewhere in your path so the one used is the one from the snap.
