### PR TITLE
Update the PATH containerd-shims has to find runc for v1.22

### DIFF
--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -15,7 +15,6 @@ fi
 SNAP_CURRENT="/snap/microk8s/current"
 CURRENT_PATH="$SNAP_CURRENT/usr/sbin:$SNAP_CURRENT/usr/bin:$SNAP_CURRENT/sbin:$SNAP_CURRENT/bin"
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$CURRENT_PATH:$PATH"
-export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH

--- a/microk8s-resources/wrappers/run-containerd-with-args
+++ b/microk8s-resources/wrappers/run-containerd-with-args
@@ -7,6 +7,14 @@ if [ -d /sys/kernel/security/apparmor ] && [ "$(cat /proc/self/attr/current)" !=
     exec aa-exec -p unconfined -- "$0" "$@"
 fi
 
+# Why we put the /snap/microk8s/current in the path?
+# containerd-shims need to call runc. They inherit their PATH from containerd.
+# As the snap refreshes runc changes location, eg moves from
+# /snap/microk8s/123/usr/bin/runc to /snap/microk8s/124/usr/runc.
+# containerd-shims need to look for runc in  /snap/microk8s/current/usr/bin/runc
+SNAP_CURRENT="/snap/microk8s/current"
+CURRENT_PATH="$SNAP_CURRENT/usr/sbin:$SNAP_CURRENT/usr/bin:$SNAP_CURRENT/sbin:$SNAP_CURRENT/bin"
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$CURRENT_PATH:$PATH"
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -330,6 +330,15 @@ then
   chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ || true
 fi
 
+# see issue https://github.com/ubuntu/microk8s/issues/2645
+if ! [ -e /usr/sbin/runc ] && ! which runc &&
+   ln -s /snap/microk8s/current/bin/runc /usr/sbin/runc
+then
+  echo "\`/usr/sbin/runc\` linked to /snap/microk8s/current/bin/runc"
+else
+  echo "runc already exists"
+fi
+
 if ! [ -e "${SNAP_DATA}/opt/cni/bin/flanneld" ]
 then
   # cover situation where cilium was installed prior to this update

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -20,6 +20,12 @@ then
   unlink /var/lib/kubelet || true
 fi
 
+# Remove the symlink to runc 
+if test -L /usr/sbin/runc
+then
+  unlink /usr/sbin/runc || true
+fi
+
 pod_cidr="$(cat $SNAP_DATA/args/kubelet | grep "pod-cidr" | tr "=" " "| gawk '{print $2}')"
 if [ -z "$pod_cidr" ]
 then


### PR DESCRIPTION
Backporting fix to 1.22 of https://github.com/ubuntu/microk8s/issues/2645