### PR TITLE
Prepare for v1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MicroK8s
 
-![](https://img.shields.io/badge/Kubernetes-1.22-326de6.svg)
+![](https://img.shields.io/badge/Kubernetes-1.23-326de6.svg)
 
 <img src="/docs/images/certified_kubernetes_color-222x300.png" align="right" width="200px">
 


### PR DESCRIPTION
Minor update for preparing for 1.23. This time the pre-release and release patches were the same so we did not need to update those.