### PR TITLE
Runc now requires Go 1.16 minimum in order to go get

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -186,8 +186,8 @@ parts:
       snap refresh go --channel=1.15/stable || true
       go version
       export GOPATH=${SNAPCRAFT_STAGE}
-      export CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/usr/include/" 
-      export CGO_LDFLAGS="-L${SNAPCRAFT_STAGE}/lib" 
+      export CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/usr/include/"
+      export CGO_LDFLAGS="-L${SNAPCRAFT_STAGE}/lib"
       export CGO_LDFLAGS_ALLOW="-Wl,-z,now"
       go get -tags libsqlite3 github.com/canonical/go-dqlite/cmd/dqlite
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
@@ -459,9 +459,10 @@ parts:
     override-build: |
       set -eux
       . $SNAPCRAFT_PART_SRC/set-env-variables.sh
-      snap refresh go --channel=1.15/stable || true
+      snap refresh go --channel=1.16/stable || true
       go version
       export GOPATH=$(realpath ../go)
+      export GO111MODULE=off
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
 
       # Build runc


### PR DESCRIPTION
Runc dropped support for Go 1.15 (https://github.com/opencontainers/runc/commit/12e99a0f8df0e6ac59e82ec6941c70dbe12d7142), which has stopped MicroK8s from being buildable anywhere.

Go 1.16 does not pull in the same way as 1.15, so a simple bump is not enough.  Due to the way we have to `go get` and then checkout a commit of `runc` (et. al.), the initial get of 1.15 fails and you cannot then checkout the correct revision.  On top of this, `go get ` places the package in `./mod` instead of `./src` and 1.18 will drop support for `go get` all together (https://maelvls.dev/go111module-everywhere/, https://stackoverflow.com/questions/66284870/go-get-not-downloading-to-src-folder). 

In order to hot fix this issue, I have bumped to Go 1.16 and set `GO111MODULE=off` in order to get the old behavior of `go get`.

Make no mistake, this is a band-aid and we really need to spend some time, asap, to clean this up properly by moving to Go 1.17 or 1.18 for all parts.