### PR TITLE
fix ingress leader election when rbac is enabled

### DIFF
--- a/microk8s-resources/actions/enable.ingress.sh
+++ b/microk8s-resources/actions/enable.ingress.sh
@@ -22,7 +22,7 @@ fi
 echo "Enabling Ingress"
 
 ARCH=$(arch)
-TAG="v1.0.5"
+TAG="v1.1.0"
 EXTRA_ARGS="- --publish-status-address=127.0.0.1"
 DEFAULT_CERT="- ' '"
 

--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -95,7 +95,6 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - ingress-controller-leader-public
   - ingress-controller-leader
   verbs:
   - create

--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -96,6 +96,7 @@ rules:
   - configmaps
   resourceNames:
   - ingress-controller-leader-public
+  - ingress-controller-leader
   verbs:
   - create
   - update


### PR DESCRIPTION
This PR addresses a breaking change in the way ingress access the configmap for its leader election.
It was previously called `<election-id>-<ingress-class>` where `election-id` is named `ingress-controller-leader` and `ingress-class` is `public`.

Now the resourceName is just the `election-id`

*Also verify you have:*
* [x] Read the [contributions](https://github.com/ubuntu/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
