### PR TITLE
Add low-memory guard

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -761,3 +761,19 @@ then
     exit 1
   fi
 fi
+
+exit_if_low_memory_guard() {
+  if [ -e ${SNAP_DATA}/var/lock/low-memory-guard.lock ]
+  then
+    echo ''
+    echo 'This node does not have enough RAM to host the Kubernetes control plane services'
+    echo 'and join the database quorum. You may consider joining this node as a worker'
+    echo 'node to a cluster.'
+    echo ''
+    echo 'If you would still like to start the control plane services, start MicroK8s with:'
+    echo ''
+    echo '    microk8s start --disable-low-memory-guard'
+    echo ''
+    exit 1
+  fi
+}

--- a/microk8s-resources/wrappers/apiservice-kicker
+++ b/microk8s-resources/wrappers/apiservice-kicker
@@ -15,6 +15,12 @@ then
   exit 0
 fi
 
+if [ -e "${SNAP_DATA}/var/lock/low-memory-guard.lock" ]
+then
+	echo "not starting api service kicker because of low memory guard lock"
+	exit 0
+fi
+
 restart_attempt=0
 installed_registry_help=0
 nic_name="vxlan.calico"
@@ -154,7 +160,7 @@ do
         then
           use_manifest registry-help apply
         fi
-      
+
         installed_registry_help=1
       fi
     fi

--- a/microk8s-resources/wrappers/microk8s-start.wrapper
+++ b/microk8s-resources/wrappers/microk8s-start.wrapper
@@ -14,17 +14,22 @@ fi
 
 exit_if_no_permissions
 
-PARSED=$(getopt --options=lho: --longoptions=help,output: --name "$@" -- "$@")
+PARSED=$(getopt --options=lho: --longoptions=help,output:,disable-low-memory-guard --name "$@" -- "$@")
 eval set -- "$PARSED"
 while true; do
     case "$1" in
+        --disable-low-memory-guard)
+            rm "${SNAP_DATA}/var/lock/low-memory-guard.lock" || true
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo
             echo "Start Kubernetes services"
             echo
             echo "Options:"
-            echo " -h, --help          Show this help"
+            echo " -h, --help                   Show this help"
+            echo " --disable-low-memory-guard   Start MicroK8s in machines with RAM < 512MB"
             exit 0
             ;;
         --)
@@ -37,6 +42,7 @@ while true; do
     esac
 done
 
+exit_if_low_memory_guard
 
 if ! run_with_sudo snap start ${SNAP_NAME} --enable
 then

--- a/microk8s-resources/wrappers/microk8s-status.wrapper
+++ b/microk8s-resources/wrappers/microk8s-status.wrapper
@@ -11,6 +11,13 @@ source $SNAP/actions/common/utils.sh
 
 exit_if_no_permissions
 
+if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
+then
+    echo "This MicroK8s deployment is acting as a node in a cluster."
+    echo "Please use the control plane node."
+    exit 0
+fi
+
 exit_if_low_memory_guard
 
 LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/status.py $@

--- a/microk8s-resources/wrappers/microk8s-status.wrapper
+++ b/microk8s-resources/wrappers/microk8s-status.wrapper
@@ -11,4 +11,6 @@ source $SNAP/actions/common/utils.sh
 
 exit_if_no_permissions
 
+exit_if_low_memory_guard
+
 LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/status.py $@

--- a/microk8s-resources/wrappers/run-k8s-dqlite-with-args
+++ b/microk8s-resources/wrappers/run-k8s-dqlite-with-args
@@ -13,6 +13,12 @@ source $SNAP/actions/common/utils.sh
 
 exit_if_service_not_expected_to_start k8s-dqlite
 
+if [ -e "${SNAP_DATA}/var/lock/low-memory-guard.lock" ]
+then
+	echo "not starting dqlite because of low memory guard lock"
+	exit 0
+fi
+
 app=k8s-dqlite
 
 if ! [ -e "$SNAP_DATA/args/${app}" ]

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -22,6 +22,10 @@ fi
 if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
 then
   refresh_opt_in_local_config "start-control-plane" "false" kubelite
+elif [ -e ${SNAP_DATA}/var/lock/low-memory-guard.lock ]
+then
+  echo "${app} will not run, memory guard is enabled"
+  exit 0
 else
   refresh_opt_in_local_config "start-control-plane" "true" kubelite
 fi

--- a/scripts/cluster/common/utils.py
+++ b/scripts/cluster/common/utils.py
@@ -130,6 +130,16 @@ def is_node_dqlite_worker():
     )
 
 
+def is_low_memory_guard_enabled():
+    """
+    Check if the low memory guard is enabled on this Node
+
+    :returns: True if enabled, otherwise False
+    """
+    lock = os.path.expandvars("${SNAP_DATA}/var/lock/low-memory-guard.lock")
+    return os.path.isfile(lock)
+
+
 def get_dqlite_port():
     """
     What is the port dqlite listens on

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -19,6 +19,7 @@ import yaml
 import json
 
 from common.utils import (
+    is_low_memory_guard_enabled,
     try_set_file_permissions,
     is_node_running_dqlite,
     get_cluster_agent_port,
@@ -903,7 +904,14 @@ def join_etcd(connection_parts, verify=True):
     default=False,
     help="Skip the certificate verification of the node we are joining to. (default: false)",
 )
-def join(connection, worker, skip_verify):
+@click.option(
+    "--disable-low-memory-guard",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="Disable the low memory guard. (default: false)"
+)
+def join(connection, worker, skip_verify, disable_low_memory_guard):
     """
     Join the node to a cluster
 
@@ -911,6 +919,25 @@ def join(connection, worker, skip_verify):
     """
     connection_parts = connection.split("/")
     verify = not skip_verify
+
+    if is_low_memory_guard_enabled() and disable_low_memory_guard:
+        os.remove(os.path.expandvars("$SNAP_DATA/var/lock/low-memory-guard.lock"))
+
+    if is_low_memory_guard_enabled() and not worker:
+        print("""
+This node does not have enough RAM to host the Kubernetes control plane services
+and join the database quorum. You may consider joining this node as a worker instead:
+
+    microk8s join %(connection)s --worker
+
+If you would still like to join the cluster as a control plane node, use:
+
+    microk8s join %(connection)s --disable-low-memory-guard
+
+""".format(connection=connection)
+        )
+        sys.exit(1)
+
     if is_node_running_dqlite():
         join_dqlite(connection_parts, verify, worker)
     else:

--- a/scripts/cluster/join.py
+++ b/scripts/cluster/join.py
@@ -909,7 +909,7 @@ def join_etcd(connection_parts, verify=True):
     is_flag=True,
     required=False,
     default=False,
-    help="Disable the low memory guard. (default: false)"
+    help="Disable the low memory guard. (default: false)",
 )
 def join(connection, worker, skip_verify, disable_low_memory_guard):
     """
@@ -924,17 +924,20 @@ def join(connection, worker, skip_verify, disable_low_memory_guard):
         os.remove(os.path.expandvars("$SNAP_DATA/var/lock/low-memory-guard.lock"))
 
     if is_low_memory_guard_enabled() and not worker:
-        print("""
+        print(
+            """
 This node does not have enough RAM to host the Kubernetes control plane services
 and join the database quorum. You may consider joining this node as a worker instead:
 
-    microk8s join %(connection)s --worker
+    microk8s join {connection} --worker
 
 If you would still like to join the cluster as a control plane node, use:
 
-    microk8s join %(connection)s --disable-low-memory-guard
+    microk8s join {connection} --disable-low-memory-guard
 
-""".format(connection=connection)
+""".format(
+                connection=connection
+            )
         )
         sys.exit(1)
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -124,3 +124,10 @@ else
 fi
 mkdir -p "$SNAP_DATA/opt/cni/bin/"
 cp -R "$SNAP"/opt/cni/bin/* "$SNAP_DATA"/opt/cni/bin/
+
+# Low memory guard. Enable by default when system RAM is less than 512MB.
+MEMORY=`cat /proc/meminfo | grep MemTotal | awk '{ print $2 }'`
+if [ $MEMORY -le 524288 ]
+then
+  touch ${SNAP_DATA}/var/lock/low-memory-guard.lock
+fi


### PR DESCRIPTION
### Summary

Prevent MicroK8s from starting control plane components when installed on a machine with low RAM (< 512MB).

Some things below need to be ironed out, but this PR is mostly ready for testing. The changes appear simple, but it is important that we get the UX right.

### Changes

The low-memory-guard is implemented using a lock file.

- During the `install` hook, we check the available RAM and create the lock file if needed.
- `microk8s start/stop/status` will refuse to run when the lock file exists, printing a relevant error message.
- `microk8s inspect` checks for the existence of the lock file, as well as the amount of available RAM.

When the guard is enabled, the node can be joined as a worker node in a cluster. The low memroy guard can be disabled with:

```bash
microk8s start --disable-low-memory-guard
```

### Pending

- [x] Reject joining a cluster as a control-plane node when the low memory guard is enabled.