### PR TITLE
Bump traefik version to 2.5 (#2809)

### DIFF
--- a/microk8s-resources/actions/traefik.yaml
+++ b/microk8s-resources/actions/traefik.yaml
@@ -31,7 +31,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
-        - image: traefik:2.3
+        - image: traefik:2.5
           name: traefik-ingress-lb
           ports:
             - name: http

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -195,7 +195,7 @@ microk8s-addons:
 
     - name: "traefik"
       description: "traefik Ingress controller for external access"
-      version: "2.3.0"
+      version: "2.5.0"
       check_status: "pod/traefik-ingress-controller"
       supported_architectures:
         - arm64


### PR DESCRIPTION
Backporting https://github.com/ubuntu/microk8s/pull/2809 to 1.22