### PR TITLE
Deprecate storage addon

### DIFF
--- a/microk8s-resources/actions/disable.hostpath-storage.sh
+++ b/microk8s-resources/actions/disable.hostpath-storage.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Disabling default storage"
+read -ra ARGUMENTS <<< "$1"
+
+declare -A map
+map[\$SNAP_COMMON]="$SNAP_COMMON"
+use_manifest storage delete "$(declare -p map)"
+sleep 5
+echo "Storage removed"
+if [ ! -z "${ARGUMENTS[@]}" ] && [ "${ARGUMENTS[@]}" = "destroy-storage" ]
+then
+  run_with_sudo rm -rf "$SNAP_COMMON/default-storage"
+  echo "Storage space reclaimed"
+else
+  read -p "Remove PVC storage at $SNAP_COMMON/default-storage ? (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
+  run_with_sudo rm -rf "$SNAP_COMMON/default-storage"
+  echo "Storage space reclaimed"
+fi

--- a/microk8s-resources/actions/disable.hostpath-storage.sh
+++ b/microk8s-resources/actions/disable.hostpath-storage.sh
@@ -4,20 +4,20 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-echo "Disabling default storage"
+echo "Disabling hostpath storage."
 read -ra ARGUMENTS <<< "$1"
 
 declare -A map
 map[\$SNAP_COMMON]="$SNAP_COMMON"
 use_manifest storage delete "$(declare -p map)"
 sleep 5
-echo "Storage removed"
+echo "Storage removed."
 if [ ! -z "${ARGUMENTS[@]}" ] && [ "${ARGUMENTS[@]}" = "destroy-storage" ]
 then
   run_with_sudo rm -rf "$SNAP_COMMON/default-storage"
-  echo "Storage space reclaimed"
+  echo "Storage space reclaimed."
 else
   read -p "Remove PVC storage at $SNAP_COMMON/default-storage ? (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
   run_with_sudo rm -rf "$SNAP_COMMON/default-storage"
-  echo "Storage space reclaimed"
+  echo "Storage space reclaimed."
 fi

--- a/microk8s-resources/actions/disable.registry.sh
+++ b/microk8s-resources/actions/disable.registry.sh
@@ -7,4 +7,4 @@ source $SNAP/actions/common/utils.sh
 echo "Disabling the private registry"
 use_manifest registry delete
 use_manifest registry-help apply
-echo "The registry is disabled. Use 'microk8s disable storage:destroy-storage' to free the storage space."
+echo "The registry is disabled. Use 'microk8s disable hostpath-storage:destroy-storage' to free the storage space."

--- a/microk8s-resources/actions/disable.storage.sh
+++ b/microk8s-resources/actions/disable.storage.sh
@@ -4,4 +4,7 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
+echo "DEPRECIATION WARNING: 'storage' is deprecated and will soon be removed. Please use 'hostpath-storage' instead."
+echo ""
+
 "$SNAP/microk8s-disable.wrapper" hostpath-storage

--- a/microk8s-resources/actions/disable.storage.sh
+++ b/microk8s-resources/actions/disable.storage.sh
@@ -7,4 +7,4 @@ source $SNAP/actions/common/utils.sh
 echo "DEPRECIATION WARNING: 'storage' is deprecated and will soon be removed. Please use 'hostpath-storage' instead."
 echo ""
 
-"$SNAP/microk8s-disable.wrapper" hostpath-storage
+"$SNAP/microk8s-disable.wrapper" hostpath-storage $1

--- a/microk8s-resources/actions/disable.storage.sh
+++ b/microk8s-resources/actions/disable.storage.sh
@@ -4,20 +4,4 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-echo "Disabling default storage"
-read -ra ARGUMENTS <<< "$1"
-
-declare -A map
-map[\$SNAP_COMMON]="$SNAP_COMMON"
-use_manifest storage delete "$(declare -p map)"
-sleep 5
-echo "Storage removed"
-if [ ! -z "${ARGUMENTS[@]}" ] && [ "${ARGUMENTS[@]}" = "destroy-storage" ]
-then
-  run_with_sudo rm -rf "$SNAP_COMMON/default-storage"
-  echo "Storage space reclaimed"
-else
-  read -p "Remove PVC storage at $SNAP_COMMON/default-storage ? (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
-  run_with_sudo rm -rf "$SNAP_COMMON/default-storage"
-  echo "Storage space reclaimed"
-fi
+"$SNAP/microk8s-disable.wrapper" hostpath-storage

--- a/microk8s-resources/actions/enable.hostpath-storage.sh
+++ b/microk8s-resources/actions/enable.hostpath-storage.sh
@@ -4,7 +4,15 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-echo "Enabling default storage class"
+if [ -d "$SNAP_COMMON/default-storage" ]
+then
+  echo "Hostpath storage is already enabled."
+  exit 0
+fi
+
+echo "Enabling default storage class."
+echo "WARNING: Hostpath storage is not sutable for production environments."
+echo ""
 run_with_sudo mkdir -p ${SNAP_COMMON}/default-storage
 
 declare -A map
@@ -15,6 +23,6 @@ echo "Storage will be available soon"
 if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
 then
   echo ""
-  echo "WARNING: The storage class enabled does not persist volumes across nodes"
+  echo "WARNING: The storage class enabled does not persist volumes across nodes."
   echo ""
 fi

--- a/microk8s-resources/actions/enable.hostpath-storage.sh
+++ b/microk8s-resources/actions/enable.hostpath-storage.sh
@@ -11,7 +11,7 @@ then
 fi
 
 echo "Enabling default storage class."
-echo "WARNING: Hostpath storage is not sutable for production environments."
+echo "WARNING: Hostpath storage is not suitable for production environments."
 echo ""
 run_with_sudo mkdir -p ${SNAP_COMMON}/default-storage
 

--- a/microk8s-resources/actions/enable.hostpath-storage.sh
+++ b/microk8s-resources/actions/enable.hostpath-storage.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $SNAP/actions/common/utils.sh
+
+echo "Enabling default storage class"
+run_with_sudo mkdir -p ${SNAP_COMMON}/default-storage
+
+declare -A map
+map[\$SNAP_COMMON]="$SNAP_COMMON"
+use_manifest storage apply "$(declare -p map)"
+echo "Storage will be available soon"
+
+if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
+then
+  echo ""
+  echo "WARNING: The storage class enabled does not persist volumes across nodes"
+  echo ""
+fi

--- a/microk8s-resources/actions/enable.hostpath-storage.sh
+++ b/microk8s-resources/actions/enable.hostpath-storage.sh
@@ -18,7 +18,7 @@ run_with_sudo mkdir -p ${SNAP_COMMON}/default-storage
 declare -A map
 map[\$SNAP_COMMON]="$SNAP_COMMON"
 use_manifest storage apply "$(declare -p map)"
-echo "Storage will be available soon"
+echo "Storage will be available soon."
 
 if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
 then

--- a/microk8s-resources/actions/enable.portainer.sh
+++ b/microk8s-resources/actions/enable.portainer.sh
@@ -10,8 +10,8 @@ MANIFEST_PTR="https://raw.githubusercontent.com/portainer/k8s/master/deploy/mani
 
 KUBECTL="$SNAP/kubectl --kubeconfig=${SNAP_DATA}/credentials/client.config"
 
-microk8s enable storage
-microk8s enable dns
+"$SNAP/microk8s-enable.wrapper" hostpath-storage
+"$SNAP/microk8s-enable.wrapper" dns
 
 echo "Enabling portainer"
 

--- a/microk8s-resources/actions/enable.registry.sh
+++ b/microk8s-resources/actions/enable.registry.sh
@@ -12,7 +12,7 @@ if [ -z "${ARGUMENTS[@]}" ]; then
   echo "You can use the \"size\" argument while enabling the registry, eg microk8s.enable registry:size=30Gi"
   declare -A map
   map[\$DISKSIZE]="20Gi"
-  "$SNAP/microk8s-enable.wrapper" storage
+  "$SNAP/microk8s-enable.wrapper" hostpath-storage
   echo "Applying registry manifest"
   use_manifest registry apply "$(declare -p map)"
   echo "The registry is enabled"
@@ -29,7 +29,7 @@ elif [[ ${ARGUMENTS[@]} =~ $regex_args ]]; then
       echo "The size of the registry should be higher or equal to 20Gi and match the regex: (^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)"
       exit 1
 		elif [ "$key" = "size" ] && [[ $value =~ $REGEX_DISK_SIZE ]]; then
-      "$SNAP/microk8s-enable.wrapper" storage
+      "$SNAP/microk8s-enable.wrapper" hostpath-storage
       declare -A map
       map[\$DISKSIZE]=$value
     fi

--- a/microk8s-resources/actions/enable.storage.sh
+++ b/microk8s-resources/actions/enable.storage.sh
@@ -4,17 +4,8 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-echo "Enabling default storage class"
-run_with_sudo mkdir -p ${SNAP_COMMON}/default-storage
-
-declare -A map
-map[\$SNAP_COMMON]="$SNAP_COMMON"
-use_manifest storage apply "$(declare -p map)"
-echo "Storage will be available soon"
-
-if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
-then
   echo ""
-  echo "WARNING: The storage class enabled does not persist volumes across nodes"
+  echo "DEPRECIATION WARNING: 'storage' is deprecated and will soon be removed. Please use 'hostpath-storage' instead."
   echo ""
-fi
+
+"$SNAP/microk8s-enable.wrapper" hostpath-storage

--- a/microk8s-resources/actions/enable.storage.sh
+++ b/microk8s-resources/actions/enable.storage.sh
@@ -4,8 +4,7 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-  echo ""
-  echo "DEPRECIATION WARNING: 'storage' is deprecated and will soon be removed. Please use 'hostpath-storage' instead."
-  echo ""
+echo "DEPRECIATION WARNING: 'storage' is deprecated and will soon be removed. Please use 'hostpath-storage' instead."
+echo ""
 
 "$SNAP/microk8s-enable.wrapper" hostpath-storage

--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -44,7 +44,7 @@ microk8s-addons:
         - arm64
         - amd64
 
-    - name: "storage"
+    - name: "hostpath-storage"
       description: "Storage class; allocates storage from host directory"
       version: "1.0.0"
       check_status: "pod/hostpath-provisioner"

--- a/microk8s-resources/wrappers/microk8s-join.wrapper
+++ b/microk8s-resources/wrappers/microk8s-join.wrapper
@@ -9,9 +9,15 @@ export PYTHONNOUSERSITE=false
 
 source $SNAP/actions/common/utils.sh
 
-if [ -e  "$SNAP_DATA/args/cni-network/cni.yaml.disabled" ] && [ -e "$SNAP_DATA/args/cni-network/05-cilium-cni.conf" ] ; then 
-  echo "Cilium is enabled and is not suitable for multi node clusters."
+if [ -e  "$SNAP_DATA/args/cni-network/cni.yaml.disabled" ] && [ -e "$SNAP_DATA/args/cni-network/05-cilium-cni.conf" ] ; then
+  echo "WARNING: Cilium is enabled and is not suitable for multi node clusters."
   exit 1
+fi
+
+if [ -d "$SNAP_COMMON/default-storage" ]
+then
+  echo "WARNING: Hostpath storage is enabled and is not suitable for multi node clusters."
+  echo ""
 fi
 
 exit_if_no_permissions

--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -27,7 +27,7 @@ disable_addons() {
     fi
     echo "Disabling addon : $action"
     addon_arguments=""
-    if [ "$action" = "storage" ] && [ ${destroy_storage_enabled} ]
+    if [ "$action" = "hostpath-storage" ] && [ ${destroy_storage_enabled} ]
     then
        microk8s disable $action:destroy-storage > /dev/null 2>&1 || true
     else

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -134,9 +134,9 @@ class TestAddons(object):
         validate_dashboard_ingress()
         print("Disabling dashboard-ingress")
         microk8s_disable("dashboard-ingress")
-        print("Enabling storage")
-        microk8s_enable("storage")
-        print("Validating storage")
+        print("Enabling hostpath-storage")
+        microk8s_enable("hostpath-storage")
+        print("Validating hostpath-storage")
         validate_storage()
         microk8s_enable("registry")
         print("Validating registry")
@@ -151,8 +151,8 @@ class TestAddons(object):
         microk8s_disable("registry")
         print("Disabling dashboard")
         microk8s_disable("dashboard")
-        print("Disabling storage")
-        microk8s_disable("storage:destroy-storage")
+        print("Disabling hostpath-storage")
+        microk8s_disable("hostpath-storage:destroy-storage")
         """
         We would disable DNS here but this freezes any terminating pods.
         We let microk8s reset to do the cleanup.


### PR DESCRIPTION
Here we're starting the process of deprecating the `storage` addon and replace it with the `hostpath-storage` addon.

We're also acknowledging the limitations of hostpath storage.