### PR TITLE
Update the ingress RBAC for allowing leader election

### DIFF
--- a/microk8s-resources/actions/ingress.yaml
+++ b/microk8s-resources/actions/ingress.yaml
@@ -95,7 +95,7 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - ingress-controller-leader-public
+  - ingress-controller-leader
   verbs:
   - create
   - update


### PR DESCRIPTION
Back porting the #2813 to 1.21 .

This is needed due to the 1.0.5 update.
