### PR TITLE
Do not start traefik and k8s-dqlite until interfaces are connected

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -242,6 +242,7 @@ apps:
       - kubernetes-support
   daemon-traefik:
     command: run-traefik-with-args
+    install-mode: disable
     daemon: simple
     plugs:
       - kernel-module-control
@@ -316,6 +317,7 @@ apps:
       - system-observe
   daemon-k8s-dqlite:
     command: run-k8s-dqlite-with-args
+    install-mode: disable
     daemon: simple
     plugs:
       - network-bind


### PR DESCRIPTION
These are two new services that did not have the disable flag.