### PR TITLE
Upgrade hostpath-provisioner

### DIFF
--- a/microk8s-resources/actions/storage.yaml
+++ b/microk8s-resources/actions/storage.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: microk8s-hostpath
       containers:
         - name: hostpath-provisioner
-          image: cdkbot/hostpath-provisioner-$ARCH:1.0.0
+          image: cdkbot/hostpath-provisioner:1.1.0
           env:
             - name: NODE_NAME
               valueFrom:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -614,7 +614,6 @@ parts:
         rm actions/*.cilium.sh
         rm actions/*.traefik.sh
         rm actions/*.registry.sh
-        rm actions/*.storage.sh
         rm actions/*.portainer.sh
         rm actions/*.linkerd.sh
         rm -rf "actions/kata"


### PR DESCRIPTION
### Summary

Update hostpath-provisioner version to 1.1.0.

### Changes

- Update hostpath-provisioner image to `cdkbot/hostpath-provisioner:1.1.0`
- New multi-arch image supports s390x, so enable storage addon for s390x architectures as well.
- After this PR is merged, we can begin with removing the `RemoveSelfLink=false` feature flag, which is removed on Kubernetes 1.24