### PR TITLE
Enable storage addon even if hostpath directory exists

### DIFF
--- a/microk8s-resources/actions/enable.hostpath-storage.sh
+++ b/microk8s-resources/actions/enable.hostpath-storage.sh
@@ -4,12 +4,6 @@ set -e
 
 source $SNAP/actions/common/utils.sh
 
-if [ -d "$SNAP_COMMON/default-storage" ]
-then
-  echo "Hostpath storage is already enabled."
-  exit 0
-fi
-
 echo "Enabling default storage class."
 echo "WARNING: Hostpath storage is not suitable for production environments."
 echo ""


### PR DESCRIPTION
### Summary

Removing misleading error message when enabling storage addon.

### Notes

- The `enable.storage.sh` is idempotent, so this check is not useful.
- The error message `"The hostpath-storage addon is already enabled"` is wrong and highly misleading. For example, if a user disables the hostpath-storage addon and chooses to preserve existing data, they get the following very confusing UX:

```
root@k8s:/snap/microk8s/current/microk8s-resources/actions# m enable hostpath-storage
Hostpath storage is already enabled.
root@k8s:/snap/microk8s/current/microk8s-resources/actions# m disable hostpath-storage
Addon hostpath-storage is already disabled.
```

### Backports

This affects all MicroK8s versions, so needs to be backported to 1.21, 1.22 and 1.23 branches after merging