### PR TITLE
Drop RemoveSelfLink=false feature flag

### DIFF
--- a/microk8s-resources/default-args/kube-apiserver
+++ b/microk8s-resources/default-args/kube-apiserver
@@ -13,7 +13,6 @@
 --allow-privileged=true
 --service-account-issuer='https://kubernetes.default.svc'
 --service-account-signing-key-file=${SNAP_DATA}/certs/serviceaccount.key
---feature-gates=RemoveSelfLink=false
 --event-ttl=5m
 --profiling=false
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -418,10 +418,10 @@ then
   need_api_restart=true
 fi
 
-# Needed by the storage addon
-if ! grep -e "RemoveSelfLink" ${SNAP_DATA}/args/kube-apiserver
+# RemoveSelfLink feature flag is removed after 1.24
+if grep -e "feature-gates=RemoveSelfLink" ${SNAP_DATA}/args/kube-apiserver
 then
-  echo "--feature-gates=RemoveSelfLink=false" >> ${SNAP_DATA}/args/kube-apiserver
+  "${SNAP}/bin/sed" -i '/feature-gates=RemoveSelfLink/d' "$SNAP_DATA/args/kube-apiserver"
   need_api_restart=true
 fi
 


### PR DESCRIPTION
### Summary

The `RemoveSelfLink=false` feature flag is being removed in Kubernetes 1.24. We had kept that since it was required for our hostpath-provisioner to work.

This is no longer needed, so we can remove it, in time for 1.24.

The PR also adds a check for `microk8s inspect`, with steps for upgrading users that may encounter issues.