### PR TITLE
Enable hostpath-storage for s390x architectures

### DIFF
--- a/microk8s-resources/wrappers/addon-lists.yaml
+++ b/microk8s-resources/wrappers/addon-lists.yaml
@@ -51,6 +51,7 @@ microk8s-addons:
       supported_architectures:
         - arm64
         - amd64
+        - s390x
 
     - name: "registry"
       description: "Private image registry exposed on localhost:32000"


### PR DESCRIPTION
### Summary

Add `s390x` to the list of supported architectures for the hostpath-storage addon.