### PR TITLE
Fix error retrieving resource lock

### DIFF
--- a/microk8s-resources/actions/storage.yaml
+++ b/microk8s-resources/actions/storage.yaml
@@ -75,8 +75,6 @@ rules:
       - create
       - delete
   - apiGroups: [""]
-    resourceNames:
-      - microk8s.io-hostpath
     resources:
       - endpoints
     verbs:


### PR DESCRIPTION
Followup for #2881, turns out that limiting `resourceNames` gives the following error:

```
E0126 21:02:56.968579       1 leaderelection.go:330] error retrieving resource lock kube-system/microk8s.io-hostpath: endpoints "microk8s.io-hostpath" is forbidden: User "system:serviceaccount:kube-system:microk8s-hostpath" cannot get resource "endpoints" in API group "" in the namespace "kube-system"
```