### PR TITLE
Backport 1.22: Allow kube-proxy to change nf_conntrack_max on lxc

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -174,6 +174,14 @@ then
   fi
 fi
 
+# on lxc containers do not try to change the conntrack configuration
+# see https://github.com/ubuntu/microk8s/issues/1438
+if grep -E lxc /proc/1/environ &&
+  ! grep -E "conntrack-max-per-core" $SNAP_DATA/args/kube-proxy
+then
+  refresh_opt_in_local_config "conntrack-max-per-core" "0" kube-proxy
+fi
+
 if ! [ -f /proc/sys/net/bridge/bridge-nf-call-iptables ]
 then
   if ! modprobe br_netfilter

--- a/tests/lxc/microk8s-zfs.profile
+++ b/tests/lxc/microk8s-zfs.profile
@@ -31,4 +31,7 @@ devices:
     path: /sys/fs/bpf
     source: /sys/fs/bpf
     type: disk
-
+  aadisable5:
+    path: /proc/sys/net/netfilter/nf_conntrack_max
+    source: /proc/sys/net/netfilter/nf_conntrack_max
+    type: disk

--- a/tests/lxc/microk8s.profile
+++ b/tests/lxc/microk8s.profile
@@ -27,3 +27,7 @@ devices:
     path: /sys/fs/bpf
     source: /sys/fs/bpf
     type: disk
+  aadisable4:
+    path: /proc/sys/net/netfilter/nf_conntrack_max
+    source: /proc/sys/net/netfilter/nf_conntrack_max
+    type: disk


### PR DESCRIPTION
Backport #2777 to 1.22 branch