### PR TITLE
deprecated --address flag removed in version 1.24

### DIFF
--- a/microk8s-resources/default-args/kube-controller-manager
+++ b/microk8s-resources/default-args/kube-controller-manager
@@ -3,7 +3,6 @@
 --root-ca-file=${SNAP_DATA}/certs/ca.crt
 --cluster-signing-cert-file=${SNAP_DATA}/certs/ca.crt
 --cluster-signing-key-file=${SNAP_DATA}/certs/ca.key
---address=127.0.0.1
 --use-service-account-credentials
 --leader-elect-lease-duration=60s
 --leader-elect-renew-deadline=30s

--- a/microk8s-resources/default-args/kube-scheduler
+++ b/microk8s-resources/default-args/kube-scheduler
@@ -1,5 +1,4 @@
 --kubeconfig=${SNAP_DATA}/credentials/scheduler.config
---address=127.0.0.1
 --leader-elect-lease-duration=60s
 --leader-elect-renew-deadline=30s
 --profiling=false

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -431,6 +431,19 @@ then
   need_api_restart=true
 fi
 
+# scheduler --address flag is removed after 1.24
+if grep -e "--address=" ${SNAP_DATA}/args/kube-scheduler
+then
+  "${SNAP}/bin/sed" -i '/--address=/d' "$SNAP_DATA/args/kube-scheduler"
+fi
+
+# controller-manager --address flag is removed after 1.24
+if grep -e "--address=" ${SNAP_DATA}/args/kube-controller-manager
+then
+  "${SNAP}/bin/sed" -i '/--address=/d' "$SNAP_DATA/args/kube-controller-manager"
+  need_api_restart=true
+fi
+
 if ! grep '\-\-enable\-v2' ${SNAP_DATA}/args/etcd
 then
   refresh_opt_in_config enable-v2 true etcd


### PR DESCRIPTION
### Summary

`kube-scheduler` and `kube-controller-manager` have deprecated the `--address` flag and it is being removed in 1.24

Related logs:
```
Feb 07 11:37:32 ip-172-31-33-169 microk8s.daemon-kubelite[2706]: I0207 11:37:32.038243    2706 daemon.go:22] Starting Controller Manager
Feb 07 11:37:32 ip-172-31-33-169 microk8s.daemon-kubelite[2706]: Flag --address has been deprecated, This flag has no effect now and will be removed in v1.24.
Feb 07 11:37:32 ip-172-31-33-169 microk8s.daemon-kubelite[2706]: I0207 11:37:32.060648    2706 daemon.go:33] Starting Scheduler
Feb 07 11:37:32 ip-172-31-33-169 microk8s.daemon-kubelite[2706]: Flag --address has been deprecated, This flag has no effect now and will be removed in v1.24. You can use --bind-address instead.
```