### PR TITLE
Support multiple addon repositories

### DIFF
--- a/microk8s-resources/wrappers/microk8s-addons.wrapper
+++ b/microk8s-resources/wrappers/microk8s-addons.wrapper
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+ARCH="$($SNAP/bin/uname -m)"
+export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
+export PYTHONNOUSERSITE=false
+
+LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/addons.py $@

--- a/microk8s-resources/wrappers/microk8s-addons.wrapper
+++ b/microk8s-resources/wrappers/microk8s-addons.wrapper
@@ -2,9 +2,19 @@
 
 set -eu
 
+source $SNAP/actions/common/utils.sh
+
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 ARCH="$($SNAP/bin/uname -m)"
 export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export PYTHONNOUSERSITE=false
+
+if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
+then
+  echo "This MicroK8s deployment is acting as a node in a cluster. Please use the microk8s addons on the master."
+  exit 1
+fi
+
+exit_if_no_permissions
 
 LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/addons.py $@

--- a/microk8s-resources/wrappers/microk8s-addons.wrapper
+++ b/microk8s-resources/wrappers/microk8s-addons.wrapper
@@ -9,12 +9,6 @@ ARCH="$($SNAP/bin/uname -m)"
 export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export PYTHONNOUSERSITE=false
 
-if [ -e ${SNAP_DATA}/var/lock/clustered.lock ]
-then
-  echo "This MicroK8s deployment is acting as a node in a cluster. Please use the microk8s addons on the master."
-  exit 1
-fi
-
 exit_if_no_permissions
 
 LD_LIBRARY_PATH=$IN_SNAP_LD_LIBRARY_PATH ${SNAP}/usr/bin/python3 ${SNAP}/scripts/wrappers/addons.py $@

--- a/microk8s-resources/wrappers/microk8s-addons.wrapper
+++ b/microk8s-resources/wrappers/microk8s-addons.wrapper
@@ -5,6 +5,9 @@ set -eu
 source $SNAP/actions/common/utils.sh
 
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export GIT_EXEC_PATH="$SNAP/usr/lib/git-core"
+export GIT_TEMPLATE_DIR="$SNAP/usr/share/git-core/templates"
+
 ARCH="$($SNAP/bin/uname -m)"
 export IN_SNAP_LD_LIBRARY_PATH="$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$ARCH-linux-gnu:$SNAP/usr/lib/$ARCH-linux-gnu"
 export PYTHONNOUSERSITE=false

--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python3
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import click
+import yaml
+
+from common.utils import get_current_arch, snap_common
+
+addons = click.Group()
+
+repository = click.Group("repo")
+addons.add_command(repository)
+
+
+@repository.command("add", help="Add a MicroK8s addons repository")
+@click.argument("name")
+@click.argument("repository")
+@click.option("--reference")
+@click.option("--force", is_flag=True, default=False)
+def add(name: str, repository: str, reference: str, force: bool):
+    destination_path = snap_common() / "addons" / name
+    if destination_path.exists():
+        if not force:
+            click.echo("Error: repository '{}' already exists!".format(name))
+            click.echo("Use the --force flag to overwrite it".format(name))
+            sys.exit(1)
+
+        print("Removing", destination_path)
+        shutil.rmtree(destination_path)
+
+    cmd = ["git", "clone", repository, destination_path]
+    if reference is not None:
+        cmd += ["-b", reference]
+
+    subprocess.check_call(cmd)
+
+
+@repository.command("remove", help="Remove a MicroK8s addons repository")
+@click.argument("name")
+def remove(name: str):
+    destination_path = snap_common() / "addons" / name
+    if not destination_path.exists():
+        click.echo("Error: repository '{}' does not exist".format(name))
+        sys.exit(1)
+
+    print("Removing repository {} from {}", name, destination_path)
+    shutil.rmtree(destination_path)
+
+
+@repository.command("list", help="List configured MicroK8s addons repositories")
+@click.option("--format", default="table", type=click.Choice(["json", "yaml", "table"]))
+def list(format: str):
+    arch = get_current_arch()
+    repositories = []
+    for dir in os.listdir(snap_common() / "addons"):
+        try:
+            repo_dir = snap_common() / "addons" / dir
+            count = 0
+            addons_yaml = repo_dir / "addons.yaml"
+            with open(addons_yaml, "r") as fin:
+                addons = yaml.safe_load(fin)
+
+            for addon in addons["microk8s-addons"]["addons"]:
+                if arch in addon["supported_architectures"]:
+                    count += 1
+
+            source = "(builtin)"
+            try:
+                remote_url = subprocess.check_output(
+                    ["git", "remote", "get-url", "origin"], cwd=repo_dir, stderr=subprocess.DEVNULL
+                ).decode()
+                revision = subprocess.check_output(
+                    ["git", "rev-parse", "HEAD"], cwd=repo_dir, stderr=subprocess.DEVNULL
+                ).decode()[:6]
+                source = "{}@{}".format(remote_url.strip(), revision.strip())
+            except (subprocess.CalledProcessError, TypeError, ValueError):
+                pass
+
+            repositories.append(
+                {
+                    "name": dir,
+                    "addons": count,
+                    "source": source,
+                    "description": addons["microk8s-addons"]["description"],
+                }
+            )
+
+        except Exception as e:
+            click.echo("could not load addons from {}: {}".format(addons_yaml, e), err=True)
+
+    if format == "json":
+        click.echo(json.dumps(repositories))
+    elif format == "yaml":
+        click.echo(yaml.safe_dump(repositories))
+    elif format == "table":
+        click.echo(("{:10} {:>6} {}").format("REPO", "ADDONS", "SOURCE"))
+        for repo in repositories:
+            click.echo("{:10} {:>6} {}".format(repo["name"], repo["addons"], repo["source"]))
+
+
+if __name__ == "__main__":
+    addons(prog_name="microk8s addons")

--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -73,7 +73,7 @@ def remove(name: str):
         sys.exit(1)
 
     click.echo("Updating repository {}".format(name))
-    subprocess.check_call(["git", "pull", "-v"], cwd=repo_dir)
+    subprocess.check_call(["git", "pull"], cwd=repo_dir)
 
     if not (repo_dir / "addons.yaml").exists():
         click.echo(

--- a/scripts/wrappers/addons.py
+++ b/scripts/wrappers/addons.py
@@ -62,7 +62,7 @@ def remove(name: str):
 
 @repository.command("update", help="Update a MicroK8s addons repository")
 @click.argument("name")
-def remove(name: str):
+def update(name: str):
     repo_dir = snap_common() / "addons" / name
     if not repo_dir.exists():
         click.echo("Error: repository '{}' does not exist".format(name), err=True)

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -6,9 +6,12 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+import logging
 
 import click
 import yaml
+
+LOG = logging.getLogger(__name__)
 
 kubeconfig = "--kubeconfig=" + os.path.expandvars("${SNAP_DATA}/credentials/client.config")
 
@@ -256,64 +259,154 @@ def check_help_flag(addons: list) -> bool:
     return False
 
 
-def xable(action: str, addons: list, xabled_addons: list):
+def parse_xable_addon_args(addon_args: list, available_addons: list):
+    """
+    Parse the list of addons passed into the microk8s enable or disable commands.
+    Further, it will infer the repository name for addons when possible.
+    If any errors are encountered, we print them to stderr and exit.
+
+    :param addon_args: The parameters passed to the microk8s enable command
+    :param available_addons: List of available addons as (repository_name, addon_name) tuples
+
+    Handles the following cases:
+    - microk8s enable foo bar:--baz      # enable many addons, inline arguments
+    - microk8s enable bar --baz          # enable one addon, unix style command line arguments
+
+    :return: a list of (repository_name, addon_name, args) tuples
+    """
+
+    # Backwards compatibility with enabling multiple addons at once, e.g.
+    # `microk8s.enable foo bar:"baz"`
+    available_addon_names = [addon_name for (_, addon_name) in available_addons]
+    addon_names = [arg.split(":")[0] for arg in addon_args]
+    if set(addon_names) < set(available_addon_names):
+        return [parse_xable_single_arg(addon_arg, available_addons) for addon_arg in addon_args]
+
+    # The new way of xabling addons, that allows for unix-style argument passing,
+    # such as `microk8s.enable foo --bar`.
+    repository_name, addon_name, args = parse_xable_single_arg(addon_args[0], available_addons)
+    if args and addon_args[1:]:
+        click.echo(
+            "Can't pass string arguments and flag arguments simultaneously!\n"
+            "Enable or disable addons with only one argument style at a time:\n"
+            "\n"
+            "    microk8s enable foo:'bar'\n"
+            "or\n"
+            "    microk8s enable foo --bar\n"
+        )
+        sys.exit(1)
+
+    return [(repository_name, addon_name, args)]
+
+
+def parse_xable_single_arg(addon_arg: str, available_addons: list):
+    """
+    Parse an addon arg of the following form: `(repository_name/)addon_name(:args)`
+    It will automatically infer the repository name if not specified. If multiple repositories
+    are found for the addon, we print an error and exit.
+
+    :param addon_arg: A parameter passed to the microk8s enable command
+    :param available_addons: List of available addons as (repository_name, addon_name) tuples
+
+    :return: a (repository_name, addon_name, args) tuple
+    """
+    addon_name, *args = addon_arg.split(":")
+    parts = addon_name.split("/")
+    if len(parts) == 2:
+        return (parts[0], parts[1], args)
+    elif len(parts) == 1:
+        matching_addons = list(filter((lambda x: x[1] == addon_name), available_addons))
+        matching_repositories = [x[0] for x in matching_addons]
+        if len(matching_repositories) == 0:
+            click.echo("Addon {} was not found in any repository".format(addon_name), err=True)
+            sys.exit(1)
+        elif len(matching_repositories) == 1:
+            click.echo(
+                "Infer repository {} for addon {}".format(matching_repositories[0], addon_name),
+                err=True,
+            )
+            return (matching_repositories[0], addon_name, args)
+        else:
+            click.echo(
+                "Addon {} exists in more than repository. Please explicitly specify\n"
+                "the repository using any of:\n".format(addon_name),
+                err=True,
+            )
+            for repository in matching_repositories:
+                click.echo("    {}/{}".format(repository, addon_name), err=True)
+            click.echo("", err=True)
+            sys.exit(1)
+
+    else:
+        click.echo("Invalid addon name {}".format(addon_name))
+        sys.exit(1)
+
+
+def xable(action: str, addon_args: list):
     """Enables or disables the given addons.
 
     Collated into a single function since the logic is identical other than
     the script names.
+
+    :param action: "enable" or "disable"
+    :param addons: List of addons to enable. Each addon may be prefixed with `repository/`
+                   to specify which addon repository it will be sourced from.
     """
-    arch = get_current_arch()
-    addons_list = get_available_addons(arch)
-    addon_names = [addon["name"] for addon in addons_list]
-
-    addons_root = snap_common() / "addons/core/addons"
-
-    # Backwards compatibility with enabling multiple addons at once, e.g.
-    # `microk8s.enable foo bar:"baz"`
-    if all(a.split(":")[0] in addon_names for a in addons) and len(addons) > 1:
-        for addon in addons:
-            if addon in xabled_addons:
-                click.echo("Addon %s is already %sd." % (addon, action))
-            else:
-                addon, *args = addon.split(":")
-                wait_for_ready(timeout=30)
-                p = subprocess.run(["{}/{}/{}".format(addons_root, addon, action), *args])
-                if p.returncode:
-                    sys.exit(p.returncode)
-                wait_for_ready(timeout=30)
-
-    # The new way of xabling addons, that allows for unix-style argument passing,
-    # such as `microk8s.enable foo --bar`.
+    available_addons_info = get_available_addons(get_current_arch())
+    enabled_addons_info, disabled_addons_info = get_status(available_addons_info, True)
+    if action == "enable":
+        xabled_addons_info = enabled_addons_info
+    elif action == "disable":
+        xabled_addons_info = disabled_addons_info
     else:
-        addon, *args = addons[0].split(":")
+        click.echo("Invalid action {}. Only enable and disable are supported".format(action))
+        sys.exit(1)
 
-        if addon in xabled_addons:
-            click.echo("Addon %s is already %sd." % (addon, action))
-            sys.exit(0)
+    # available_addons is a list of (repository_name, addon_name) tuples for all available addons
+    available_addons = [(addon["repository"], addon["name"]) for addon in available_addons_info]
+    # xabled_addons is a list (repository_name, addon_name) tuples of already xabled addons
+    xabled_addons = [(addon["repository"], addon["name"]) for addon in xabled_addons_info]
 
-        if addon not in addon_names:
-            click.echo("Nothing to do for `%s`." % addon, err=True)
-            sys.exit(1)
+    addons = parse_xable_addon_args(addon_args, available_addons)
 
-        if args and addons[1:]:
-            click.echo(
-                "Can't pass string arguments and flag arguments simultaneously!\n"
-                "{0} an addon with only one argument style at a time:\n"
-                "\n"
-                "    microk8s {1} foo:'bar'\n"
-                "or\n"
-                "    microk8s {1} foo --bar\n".format(action.title(), action)
-            )
-            sys.exit(1)
+    for repository_name, addon_name, args in addons:
+        if (repository_name, addon_name) in xabled_addons:
+            click.echo("Addon {}/{} is already {}d".format(repository_name, addon_name, action))
+            continue
 
         wait_for_ready(timeout=30)
-        script = "{}/{}/{}".format(addons_root, addon, action)
-        if args:
-            p = subprocess.run([script, *args])
-        else:
-            p = subprocess.run([script, *list(addons[1:])])
-
+        p = subprocess.run(
+            [snap_common() / "addons" / repository_name / "addons" / addon_name / action, *args]
+        )
         if p.returncode:
             sys.exit(p.returncode)
-
         wait_for_ready(timeout=30)
+
+
+def is_enabled(addon, item):
+    if addon in item:
+        return True
+    else:
+        filepath = os.path.expandvars(addon)
+        return os.path.isfile(filepath)
+
+
+def get_status(available_addons, isReady):
+    enabled = []
+    disabled = []
+    if isReady:
+        # 'all' does not include ingress
+        kube_output = kubectl_get("all,ingress")
+        cluster_output = kubectl_get_clusterroles()
+        kube_output = kube_output + cluster_output
+        for addon in available_addons:
+            found = False
+            for row in kube_output.split("\n"):
+                if is_enabled(addon["check_status"], row):
+                    enabled.append(addon)
+                    found = True
+                    break
+            if not found:
+                disabled.append(addon)
+
+    return enabled, disabled

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -296,7 +296,7 @@ def parse_xable_addon_args(addon_args: list, available_addons: list):
         )
         sys.exit(1)
 
-    return [(repository_name, addon_name, args)]
+    return [(repository_name, addon_name, addon_args[1:])]
 
 
 def parse_xable_single_arg(addon_arg: str, available_addons: list):

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -318,25 +318,23 @@ def parse_xable_single_arg(addon_arg: str, available_addons: list):
     if len(parts) == 2:
         return (parts[0], parts[1], args)
     elif len(parts) == 1:
-        matching_addons = list(filter((lambda x: x[1] == addon_name), available_addons))
-        matching_repositories = [x[0] for x in matching_addons]
-        if len(matching_repositories) == 0:
+        matching_repos = [repo for (repo, addon) in available_addons if addon == addon_name]
+        if len(matching_repos) == 0:
             click.echo("Addon {} was not found in any repository".format(addon_name), err=True)
             sys.exit(1)
-        elif len(matching_repositories) == 1:
+        elif len(matching_repos) == 1:
             click.echo(
-                "Infer repository {} for addon {}".format(matching_repositories[0], addon_name),
-                err=True,
+                "Infer repository {} for addon {}".format(matching_repos[0], addon_name), err=True
             )
-            return (matching_repositories[0], addon_name, args)
+            return (matching_repos[0], addon_name, args)
         else:
             click.echo(
                 "Addon {} exists in more than repository. Please explicitly specify\n"
                 "the repository using any of:\n".format(addon_name),
                 err=True,
             )
-            for repository in matching_repositories:
-                click.echo("    {}/{}".format(repository, addon_name), err=True)
+            for repo in matching_repos:
+                click.echo("    {}/{}".format(repo, addon_name), err=True)
             click.echo("", err=True)
             sys.exit(1)
 

--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -213,9 +213,20 @@ def get_available_addons(arch):
 
 def get_addon_by_name(addons, name):
     filtered_addon = []
+
+    parts = name.split("/")
+    if len(parts) == 1:
+        repo_name, addon_name = None, parts[0]
+    elif len(parts) == 2:
+        repo_name, addon_name = parts[0], parts[1]
+    else:
+        # just fallback to the addon name
+        repo_name, addon_name = None, name
+
     for addon in addons:
-        if name == addon["name"]:
+        if addon_name == addon["name"] and (repo_name == addon["repository"] or not repo_name):
             filtered_addon.append(addon)
+
     return filtered_addon
 
 

--- a/scripts/wrappers/disable.py
+++ b/scripts/wrappers/disable.py
@@ -33,10 +33,7 @@ def disable(addons):
     ensure_started()
     wait_for_ready(timeout=30)
 
-    _, disabled_addons = get_status(get_available_addons(get_current_arch()), True)
-    disabled_addons = {a["name"] for a in disabled_addons}
-
-    xable("disable", addons, disabled_addons)
+    xable("enable", addons)
 
 
 if __name__ == "__main__":

--- a/scripts/wrappers/disable.py
+++ b/scripts/wrappers/disable.py
@@ -33,7 +33,7 @@ def disable(addons):
     ensure_started()
     wait_for_ready(timeout=30)
 
-    xable("enable", addons)
+    xable("disable", addons)
 
 
 if __name__ == "__main__":

--- a/scripts/wrappers/enable.py
+++ b/scripts/wrappers/enable.py
@@ -33,10 +33,7 @@ def enable(addons):
     ensure_started()
     wait_for_ready(timeout=30)
 
-    enabled_addons, _ = get_status(get_available_addons(get_current_arch()), True)
-    enabled_addons = {a["name"] for a in enabled_addons}
-
-    xable("enable", addons, enabled_addons)
+    xable("enable", addons)
 
 
 if __name__ == "__main__":

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -327,7 +327,7 @@ then
 fi
 
 # Securing important directories
-for dir in ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock
+for dir in ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock
 do
   chmod -R ug+rwX ${dir}
   chmod -R o-rwX ${dir}
@@ -341,7 +341,7 @@ fi
 
 if getent group microk8s >/dev/null 2>&1
 then
-  chgrp microk8s -R ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ || true
+  chgrp microk8s -R ${SNAP_COMMON}/addons ${SNAP_DATA}/credentials/ ${SNAP_DATA}/certs/ ${SNAP_DATA}/args/ ${SNAP_DATA}/var/lock/ ${SNAP_DATA}/var/kubernetes/backend/ || true
 fi
 
 try_copy_users_to_snap_microk8s

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -11,9 +11,11 @@ need_controller_restart=false
 need_scheduler_restart=false
 
 # If the addons directory is missing from SNAP_COMMON, then we are upgrading from an older MicroK8s version.
-if [ ! -d "${SNAP_COMMON}/addons/core" ]
+if [ ! -d "${SNAP_COMMON}/addons" ]
 then
-  cp -rv ${SNAP}/addons ${SNAP_COMMON}/addons
+  mkdir -p ${SNAP_COMMON}/addons
+  snap_current=`echo "${SNAP}" | sed -e "s,${SNAP_REVISION},current,"`
+  git clone "${snap_current}/addons/core" "${SNAP_COMMON}/addons/core"
 fi
 
 # This is a one-off patch. It will allow us to refresh the beta snap without breaking the user's deployment.

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -23,7 +23,8 @@ else
 fi
 
 # Install the core addons
-cp -rv ${SNAP}/addons ${SNAP_COMMON}/addons
+snap_current=`echo "${SNAP}" | sed -e "s,${SNAP_REVISION},current,"`
+git clone "${snap_current}/addons/core" "${SNAP_COMMON}/addons/core"
 
 # Create the certificates
 mkdir ${SNAP_DATA}/certs

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,6 +69,8 @@ apps:
     completer: kubectl.bash
   add-node:
     command: microk8s-add-node.wrapper
+  addons:
+    command: microk8s-addons.wrapper
   refresh-certs:
     command: microk8s-refresh-certs.wrapper
   join:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -529,18 +529,18 @@ parts:
       - python3
       - python3-yaml
       - python3-click
+      - git
     source: .
     override-build: |
       set -eux
 
       . build-scripts/set-env-variables.sh
-      python3 build-scripts/fetch-addons.py --addons-only --target-directory core
 
       if [ -d "addons" ]; then
         rm -rf addons
       fi
-      mkdir addons
-      mv core addons/
+      mkdir -p addons
+      git clone $ADDONS_REPO -b $ADDONS_REPO_BRANCH addons/core
       snapcraftctl build
 
   microk8s:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -491,6 +491,7 @@ parts:
       - diffutils
       - ethtool
       - gawk
+      - git
       - grep
       - hostname
       - iproute2

--- a/tests/unit/test_addons.py
+++ b/tests/unit/test_addons.py
@@ -1,0 +1,34 @@
+from common.utils import parse_xable_addon_args
+
+import pytest
+
+ADDONS = [
+    ("core", "addon1"),
+    ("core", "addon2"),
+    ("community", "addon3"),
+    ("core", "conflict"),
+    ("community", "conflict"),
+]
+
+
+@pytest.mark.parametrize(
+    "args, result",
+    [
+        (["addon1"], [("core", "addon1", [])]),
+        (["core/conflict"], [("core", "conflict", [])]),
+        (["community/conflict"], [("community", "conflict", [])]),
+        (["community/conflict", "--with-arg"], [("community", "conflict", ["--with-arg"])]),
+        (["addon1", "--with-arg"], [("core", "addon1", ["--with-arg"])]),
+        (
+            ["addon1:arg1", "addon2:arg2", "addon3"],
+            [
+                ("core", "addon1", ["arg1"]),
+                ("core", "addon2", ["arg2"]),
+                ("community", "addon3", []),
+            ],
+        ),
+    ],
+)
+def test_parse_addons_args(args, result):
+    addons = parse_xable_addon_args(args, ADDONS)
+    assert addons == result

--- a/tests/unit/test_addons.py
+++ b/tests/unit/test_addons.py
@@ -27,6 +27,22 @@ ADDONS = [
                 ("community", "addon3", []),
             ],
         ),
+        (
+            ["addon1:arg1", "addon2:arg2", "community/conflict"],
+            [
+                ("core", "addon1", ["arg1"]),
+                ("core", "addon2", ["arg2"]),
+                ("community", "conflict", []),
+            ],
+        ),
+        (
+            ["core/addon1:arg1", "addon2:arg2", "community/conflict:arg3"],
+            [
+                ("core", "addon1", ["arg1"]),
+                ("core", "addon2", ["arg2"]),
+                ("community", "conflict", ["arg3"]),
+            ],
+        ),
     ],
 )
 def test_parse_addons_args(args, result):

--- a/tests/unit/test_addons.py
+++ b/tests/unit/test_addons.py
@@ -1,4 +1,4 @@
-from common.utils import parse_xable_addon_args
+from wrappers.common.utils import parse_xable_addon_args
 
 import pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,3 +37,8 @@ exclude =
     .tox_env,
 max-complexity = 10
 import-order-style = google
+
+[testenv:unit]
+commands = pytest -s tests/unit/ {posargs}
+setenv =
+    PYTHONPATH={toxinidir}/scripts/wrappers

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:unit]
 setenv = PYTHONPATH={toxinidir}/scripts
-commands = pytest -s tests/unit/test-upgrade-calico-cni.py
+commands = pytest -s tests/unit/ {posargs}
 
 [testenv:clustering]
 commands = pytest -s tests/test-cluster.py
@@ -37,8 +37,3 @@ exclude =
     .tox_env,
 max-complexity = 10
 import-order-style = google
-
-[testenv:unit]
-commands = pytest -s tests/unit/ {posargs}
-setenv =
-    PYTHONPATH={toxinidir}/scripts/wrappers


### PR DESCRIPTION
### Summary

Extend the microk8s `status`, `enable` and `disable` commands to support addons from multiple repositories.

Also, introduce the following commands:

```bash
microk8s addons repo list
microk8s addons repo add
microk8s addons repo remove
microk8s addons repo update
```

### Testing

Simple commands to test with a custom addons repository:

```bash
sudo snap install microk8s --classic --channel latest/edge/addon-repos
microk8s addons repo list
microk8s addons repo add neo https://github.com/neoaggelos/microk8s-addons-extras
microk8s addons repo list

microk8s enable neo/nginx
microk8s status
```