### PR TITLE
minor fixes to update-images workflow

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -27,7 +27,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           commit-message: update list of images used by ${{ matrix.channel }}
-          title: "[${{ matrix.branch }}] Update MicroK8s images"
+          title: "[${{ matrix.channel }}] Update MicroK8s images"
           body: update list of images used by ${{ matrix.channel }}
           reviewers: neoaggelos,ktsakalozos
           branch: auto-update-images/${{ matrix.branch }}

--- a/build-scripts/update-images.sh
+++ b/build-scripts/update-images.sh
@@ -49,4 +49,9 @@ while ! sudo microk8s kubectl wait --for=condition=ready pod/nginx; do
   sleep 3
 done
 
+while ! sudo microk8s kubectl wait -n kube-system --for=jsonpath='{.status.readyReplicas}=1' deploy/coredns; do
+  echo 'waiting for dns'
+  sleep 3
+done
+
 sudo microk8s ctr image ls -q | grep -v sha256 | grep -v nginx:latest | sort > $2


### PR DESCRIPTION
### Summary

Ensure coredns pod starts before listing images. Also, mention channel instead of branch name in the PR title.