### PR TITLE
[1.22-eksd] Fix configure hook failing when EC2 endpoint is not reachable

### DIFF
--- a/microk8s-resources/default-hooks/reconcile.d/10-provider-id-update
+++ b/microk8s-resources/default-hooks/reconcile.d/10-provider-id-update
@@ -7,8 +7,8 @@ KUBECTL="${SNAP}/microk8s-kubectl.wrapper"
 if [ -e "${SNAP_DATA}/var/lock/providerid-needs-update" ]
 then
   echo "Updating providerID"
-  INSTANCE_ID=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/instance-id)
-  A_ZONE=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/placement/availability-zone)
+  INSTANCE_ID=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/instance-id || true)
+  A_ZONE=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/placement/availability-zone || true)
   if [[ ! -z "$INSTANCE_ID" ]] && [[ ! -z "$A_ZONE" ]]
   then
     hostname=$(hostname)

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -225,8 +225,8 @@ fi
 
 if is_ec2_instance
 then
-  INSTANCE_ID=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/instance-id)
-  A_ZONE=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/placement/availability-zone)
+  INSTANCE_ID=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/instance-id || true)
+  A_ZONE=$(curl -sS -m 5 http://169.254.169.254/latest/meta-data/placement/availability-zone || true)
   if [[ ! -z "$INSTANCE_ID" ]] && [[ ! -z "$A_ZONE" ]]
   then
     sed -i -n -e '/^--provider-id /!p' -e "\$a--provider-id aws:///$A_ZONE/$INSTANCE_ID" ${SNAP_DATA}/args/kubelet


### PR DESCRIPTION
<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
Fix configure hook failing when EC2 endpoint is not reachable

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
Update configure hook so curl does not fail the entire hook if EC2 endpoint is unreachable.

#### Testing
<!-- Please explain how you tested your changes. -->
Manually tested by installing the snap inside LXD containers on EC2 host.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
