### PR TITLE
Add initial implementation for conform. GH action

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,44 @@
+name: run-conformance-suite
+
+on:
+  pull_request
+  # when complete
+  # workflow_dispatch:
+  #   inputs:
+  #     channel:
+  #       description: 'Channel to use for MicroK8s'
+  #       required: true
+  #       default: '1.30/stable'
+
+
+jobs:
+  run-conformance-suite:
+    name: Run Conformance Suite
+    runs-on: ubuntu-latest
+
+    env:
+      CHANNEL: 1.30/stable
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo snap install go --classic
+          go install github.com/vmware-tanzu/sonobuoy@v0.57.1
+          sudo snap install microk8s --classic --channel $CHANNEL
+          sudo microk8s status --wait-ready
+          sudo snap install multipass
+          sudo multipass start
+
+      - name: Generate Join Token
+        id: get_token
+        run: echo "WORKER_TOKEN=$(microk8s add-node | grep '^microk8s join .* --worker\$' | awk '{print $3}')" >> "$GITHUB_OUTPUT"
+
+      - name: Launch VM and Join Cluster
+        env:
+          TOKEN: ${{ steps.get_token.outputs.WORKER_TOKEN }}
+        run: |
+          sudo multipass launch --name microk8s-worker-vm
+          sudo multipass exec microk8s-worker-vm -- bash -c "sudo snap install microk8s --classic --channel $CHANNEL; sudo microk8s join $TOKEN"

--- a/build-scripts/conformance.sh
+++ b/build-scripts/conformance.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+KUBECONFIG="/var/snap/microk8s/current/credentials/client.config"
+SONOBUOY_BIN=/home/user/go/bin/sonobuoy
+E2E_EXTRA_ARGS="--non-blocking-taints=node-role.kubernetes.io/controller --ginkgo.v"
+K8S_VERSION="v1.30.0"
+CHANNEL="1.30/stable"
+EXTRACT_DIR="results"
+RESULTS_FILE="${EXTRACT_DIR}/plugins/e2e/results/global/e2e.log"
+
+# This assumes the correct version of microk8s, sonobuoy and multipass are installed.
+# For example if CHANNEL=1.30/stable the system should have microk8s 1.30.
+
+function latest_tar_path() {
+    ls -Art *.tar.gz | tail -n 1
+}
+
+function run_e2e() {
+    "${SONOBUOY_BIN}" run \
+    --plugin-env=e2e.E2E_EXTRA_ARGS="${E2E_EXTRA_ARGS}" \
+    --mode=certified-conformance \
+    --kubernetes-version="${K8S_VERSION}" \
+    --kubeconfig "${KUBECONFIG}"
+}
+
+function extract_results() {
+    ${SONOBUOY_BIN} retrieve --kubeconfig ${KUBECONFIG}
+    mkdir -p "${EXTRACT_DIR}"
+    tar xvf "$(latest_tar_path)" -C "${EXTRACT_DIR}"
+}


### PR DESCRIPTION

<!--
  Thank you for making MicroK8s better. Please fill the template below
  with more details.
-->

#### Summary
Currently, the k8s e2e conformance suite has to be run manually, which is a tedious and time-consuming process.

The goal of this PR is to enable engineers to run conformance tests at the click of a button and get the output .tar.gz.

<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->

#### Changes
Adds a new configurable GH workflow.
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

#### Testing
Manually testing and verifying that runs produce the expected report.
<!-- Please explain how you tested your changes. -->

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
