### PR TITLE
CI: bump k8s-dqlite v1.6.0 (new watcher, write batching)

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.4.1"
+echo "v1.6.0"


### PR DESCRIPTION
## Description

Bump the k8s-dqlite version to v1.6.0.
For the details of the fix read the release notes at: https://github.com/canonical/k8s-dqlite/releases/tag/v1.6.0

... waiting on Dqlite release.