### PR TITLE
Update the strict runc patches for 1.3.0

### DIFF
--- a/build-scripts/components/runc/strict-patches/v1.3.0/0001-apparmor-change-profile-immediately-not-on-exec.patch
+++ b/build-scripts/components/runc/strict-patches/v1.3.0/0001-apparmor-change-profile-immediately-not-on-exec.patch
@@ -1,0 +1,36 @@
+From 5cdb43bdc26e81be36d93fd8b81b7de6ad152c22 Mon Sep 17 00:00:00 2001
+From: Alberto Mardegan <mardy@users.sourceforge.net>
+Date: Wed, 16 Jun 2021 15:04:16 +0300
+Subject: [PATCH 1/3] apparmor: change profile immediately, not on exec
+
+---
+ libcontainer/apparmor/apparmor_linux.go | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libcontainer/apparmor/apparmor_linux.go b/libcontainer/apparmor/apparmor_linux.go
+index 17d36ed1..fb159f3c 100644
+--- a/libcontainer/apparmor/apparmor_linux.go
++++ b/libcontainer/apparmor/apparmor_linux.go
+@@ -53,9 +53,9 @@ func setProcAttr(attr, value string) error {
+ 	return err
+ }
+ 
+-// changeOnExec reimplements aa_change_onexec from libapparmor in Go
+-func changeOnExec(name string) error {
+-	if err := setProcAttr("exec", "exec "+name); err != nil {
++// changeProfile reimplements aa_change_profile from libapparmor in Go
++func changeProfile(name string) error {
++	if err := setProcAttr("current", "changeprofile "+name); err != nil {
+ 		return fmt.Errorf("apparmor failed to apply profile: %w", err)
+ 	}
+ 	return nil
+@@ -69,5 +69,5 @@ func applyProfile(name string) error {
+ 		return nil
+ 	}
+ 
+-	return changeOnExec(name)
++	return changeProfile(name)
+ }
+-- 
+2.49.0
+

--- a/build-scripts/components/runc/strict-patches/v1.3.0/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
+++ b/build-scripts/components/runc/strict-patches/v1.3.0/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
@@ -1,0 +1,48 @@
+From 259ebdf71e84433f55c1b28efb206ccc3a1b2736 Mon Sep 17 00:00:00 2001
+From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
+Date: Thu, 1 Feb 2024 11:23:08 +0200
+Subject: [PATCH 2/3] setns_init_linux: set the NNP flag after changing the
+ apparmor profile
+
+With the current version of the AppArmor kernel module, it's not
+possible to switch the AppArmor profile if the NoNewPrivileges flag is
+set. So, we invert the order of the two operations.
+
+Adjusts the previous patch for runc version v1.1.12
+
+Co-Authored-By: Alberto Mardegan <mardy@users.sourceforge.net>
+---
+ libcontainer/setns_init_linux.go | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/libcontainer/setns_init_linux.go b/libcontainer/setns_init_linux.go
+index 92c6ef77..e9a55e31 100644
+--- a/libcontainer/setns_init_linux.go
++++ b/libcontainer/setns_init_linux.go
+@@ -62,11 +62,6 @@ func (l *linuxSetnsInit) Init() error {
+ 			return fmt.Errorf("failed to setup pidfd: %w", err)
+ 		}
+ 	}
+-	if l.config.NoNewPrivileges {
+-		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+-			return err
+-		}
+-	}
+ 	if l.config.Config.Umask != nil {
+ 		unix.Umask(int(*l.config.Config.Umask))
+ 	}
+@@ -106,6 +101,11 @@ func (l *linuxSetnsInit) Init() error {
+ 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+ 		return err
+ 	}
++	if l.config.NoNewPrivileges {
++		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++			return err
++		}
++	}
+ 	if l.config.Config.Personality != nil {
+ 		if err := setupPersonality(l.config.Config); err != nil {
+ 			return err
+-- 
+2.49.0
+

--- a/build-scripts/components/runc/strict-patches/v1.3.0/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
+++ b/build-scripts/components/runc/strict-patches/v1.3.0/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
@@ -1,0 +1,55 @@
+From 7f91e445a8731856e2d22b2295d8438e07cf2bf7 Mon Sep 17 00:00:00 2001
+From: Alberto Mardegan <mardy@users.sourceforge.net>
+Date: Thu, 17 Jun 2021 14:31:35 +0300
+Subject: [PATCH] standard_init_linux: change AppArmor profile as late as
+ possible
+
+---
+ libcontainer/standard_init_linux.go | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
+index 384750bf..ccd9297a 100644
+--- a/libcontainer/standard_init_linux.go
++++ b/libcontainer/standard_init_linux.go
+@@ -126,9 +126,6 @@ func (l *linuxStandardInit) Init() error {
+ 			return &os.SyscallError{Syscall: "setdomainname", Err: err}
+ 		}
+ 	}
+-	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+-		return fmt.Errorf("unable to apply apparmor profile: %w", err)
+-	}
+ 
+ 	for key, value := range l.config.Config.Sysctl {
+ 		if err := writeSystemProperty(key, value); err != nil {
+@@ -149,11 +146,6 @@ func (l *linuxStandardInit) Init() error {
+ 	if err != nil {
+ 		return fmt.Errorf("can't get pdeath signal: %w", err)
+ 	}
+-	if l.config.NoNewPrivileges {
+-		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+-			return &os.SyscallError{Syscall: "prctl(SET_NO_NEW_PRIVS)", Err: err}
+-		}
+-	}
+ 
+ 	if err := setupScheduler(l.config); err != nil {
+ 		return err
+@@ -169,6 +161,15 @@ func (l *linuxStandardInit) Init() error {
+ 	if err := syncParentReady(l.pipe); err != nil {
+ 		return fmt.Errorf("sync ready: %w", err)
+ 	}
++	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
++		return fmt.Errorf("apply apparmor profile: %w", err)
++	}
++	if l.config.NoNewPrivileges {
++		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++			return fmt.Errorf("set nonewprivileges: %w", err)
++		}
++	}
++
+ 	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
+ 		return fmt.Errorf("can't set process label: %w", err)
+ 	}
+-- 
+2.43.0
+


### PR DESCRIPTION
#### Summary
We updated runc to 1.3.0 and the strict patches do not apply cleanly anymore.

#### Changes
Create a directory for 1.3.0 and put there the updated runc patches. Minor update in the 0003 one.

#### Testing
Manual

#### Possible Regressions
Yes

#### Checklist

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

