### PR TITLE
fix: remove deprecated etcd-v2 flag

### DIFF
--- a/microk8s-resources/default-args/etcd
+++ b/microk8s-resources/default-args/etcd
@@ -5,4 +5,3 @@
 --trusted-ca-file=${SNAP_DATA}/certs/ca.crt
 --cert-file=${SNAP_DATA}/certs/server.crt
 --key-file=${SNAP_DATA}/certs/server.key
---enable-v2=true

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -407,9 +407,10 @@ then
   need_api_restart=true
 fi
 
-if ! grep '\-\-enable\-v2' ${SNAP_DATA}/args/etcd
+# etcd --enable-v2 flag is removed after 3.6
+if grep -e "--enable-v2=" ${SNAP_DATA}/args/etcd
 then
-  refresh_opt_in_config enable-v2 true etcd
+  "${SNAP}/bin/sed" -i '/--enable-v2=/d' "$SNAP_DATA/args/etcd"
   snapctl restart ${SNAP_NAME}.daemon-etcd
 fi
 


### PR DESCRIPTION
Removes the deprecated `--enable-v2` etcd flag from new and existing installations.

Fixes #5209 