### PR TITLE
fix: [1.33] Relax cri-containerd AppArmor restrictions to permit network and signal syscalls

### DIFF
--- a/microk8s-resources/containerd-profile
+++ b/microk8s-resources/containerd-profile
@@ -43,4 +43,5 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
 
   signal (receive) peer=snap.microk8s.daemon-kubelite,
   signal (receive) peer=snap.microk8s.daemon-containerd,
+  signal (send,receive) peer=cri-containerd.apparmor.d//&unconfined,
 }


### PR DESCRIPTION
backport https://github.com/canonical/microk8s/pull/5239 to 1.33