### PR TITLE
fix: use 1.8.1 k8s-dqlite

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.8.0"
+echo "v1.8.1"


### PR DESCRIPTION
As part of our LTS commitment, update k8s-dqlite to use version 1.8.1 which patches a CVE. 