### PR TITLE
fix: use 1.3.5 k8s-dqlite

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.3.3"
+echo "v1.3.5"


### PR DESCRIPTION
Backports dqlite upgrade to 1.33 to patch CVE