### PR TITLE
fix: Preserve individual environment variables with sudo

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -88,6 +88,10 @@ remove_vxlan_interfaces() {
   done
 }
 
+list_env_vars() {
+  env | awk -F= '{print $1}' | paste -sd,
+}
+
 run_with_sudo() {
   if [ "$1" == "preserve_env" ]; then
     shift
@@ -96,7 +100,7 @@ run_with_sudo() {
     "$@"
   else
     local SAVE_LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
-    LD_LIBRARY_PATH="" sudo -E PATH="${PATH}" LD_LIBRARY_PATH="${SAVE_LD_LIBRARY_PATH}" PYTHONPATH="${PYTHONPATH:-}" "$@"
+    LD_LIBRARY_PATH="" sudo --preserve-env="$(list_env_vars)" PATH="${PATH}" LD_LIBRARY_PATH="${SAVE_LD_LIBRARY_PATH}" PYTHONPATH="${PYTHONPATH:-}" "$@"
   fi
 }
 

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -144,12 +144,12 @@ function store_kubernetes_info {
     $SNAP/kubectl get pv > $INSPECT_DUMP/k8s/get-pv 2>&1
     $SNAP/kubectl get pvc --all-namespaces > $INSPECT_DUMP/k8s/get-pvc 2>&1
   else
-    sudo -E /snap/bin/microk8s kubectl version 2>&1 | sudo tee $INSPECT_DUMP/k8s/version > /dev/null
-    sudo -E /snap/bin/microk8s kubectl cluster-info 2>&1 | sudo tee $INSPECT_DUMP/k8s/cluster-info > /dev/null
-    sudo -E /snap/bin/microk8s kubectl cluster-info dump -A 2>&1 | sudo tee $INSPECT_DUMP/k8s/cluster-info-dump > /dev/null
-    sudo -E /snap/bin/microk8s kubectl get all --all-namespaces -o wide 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-all > /dev/null
-    sudo -E /snap/bin/microk8s kubectl get pv 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-pv > /dev/null # 2>&1 redirects stderr and stdout to /dev/null if no resources found
-    sudo -E /snap/bin/microk8s kubectl get pvc --all-namespaces 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-pvc > /dev/null # 2>&1 redirects stderr and stdout to /dev/null if no resources found
+    run_with_sudo /snap/bin/microk8s kubectl version 2>&1 | sudo tee $INSPECT_DUMP/k8s/version > /dev/null
+    run_with_sudo /snap/bin/microk8s kubectl cluster-info 2>&1 | sudo tee $INSPECT_DUMP/k8s/cluster-info > /dev/null
+    run_with_sudo /snap/bin/microk8s kubectl cluster-info dump -A 2>&1 | sudo tee $INSPECT_DUMP/k8s/cluster-info-dump > /dev/null
+    run_with_sudo /snap/bin/microk8s kubectl get all --all-namespaces -o wide 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-all > /dev/null
+    run_with_sudo /snap/bin/microk8s kubectl get pv 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-pv > /dev/null # 2>&1 redirects stderr and stdout to /dev/null if no resources found
+    run_with_sudo /snap/bin/microk8s kubectl get pvc --all-namespaces 2>&1 | sudo tee $INSPECT_DUMP/k8s/get-pvc > /dev/null # 2>&1 redirects stderr and stdout to /dev/null if no resources found
   fi
 
   # Collect bill of materials


### PR DESCRIPTION
### Overview

`sudo-rs` ignores `-E` and requires individual environment variables to be preserved.

Fixes: https://github.com/canonical/microk8s/issues/5266
Fixes: https://github.com/canonical/microk8s/issues/5280
Fixes: https://github.com/canonical/microk8s/issues/5302
Fixes: https://github.com/canonical/microk8s/issues/5282
Fixes: https://github.com/canonical/microk8s/issues/5283
