### PR TITLE
feat(scripts): Include IngressClass for determining addon status

### DIFF
--- a/scripts/wrappers/common/utils.py
+++ b/scripts/wrappers/common/utils.py
@@ -563,7 +563,7 @@ def get_status(available_addons, isReady):
     disabled = []
     if isReady:
         # 'all' does not include ingress
-        kube_output = kubectl_get("all,ingress")
+        kube_output = kubectl_get("all,ingress,ingressclass")
         cluster_output = kubectl_get_clusterroles()
         kube_output = kube_output + cluster_output
         for addon in available_addons:


### PR DESCRIPTION
### Overview

This pull request makes a minor update to the `get_status` function in `scripts/wrappers/common/utils.py` to improve the completeness of Kubernetes resource status checks.

- Kubernetes resource status check: The `kubectl_get` call now includes `ingressclass` resources in addition to `all` and `ingress`, ensuring that ingress class resources are also considered when determining status.