### PR TITLE
feat: use built-in venv, prevent silent failures, avoid pip compatibility issues, and ensure cleanup even if deactivate fails

### DIFF
--- a/installer/build-linux.sh
+++ b/installer/build-linux.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
+set -euo pipefail
 
-virtualenv -p python3 .venv
+python3 -m venv .venv
+
 source ./.venv/bin/activate
+pip install --upgrade pip
 pip install -r requirements.txt
+
 pyinstaller ./microk8s.spec
-deactivate
+
+deactivate 2>/dev/null || true
 rm -rf .venv
+

--- a/installer/build-linux.sh
+++ b/installer/build-linux.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 python3 -m venv .venv
 
 source ./.venv/bin/activate
-pip install --upgrade pip
+pip install --upgrade "pip==23.3.1"
 pip install -r requirements.txt
 
 pyinstaller ./microk8s.spec


### PR DESCRIPTION
#### Summary
Improvements in script installer/build-linux.sh

#### Changes
Changes in installer/build-linux.sh:
- ensure exit on errors, undefined variables, and pipe failures
- use the built-in venv module, removing an external dependency (virtualenv)
- ensure you're using a recent pip version, avoiding potential compatibility issues
- suppresses errors if deactivate fails (which can happen in non-interactive shells)

#### Testing
I carefully tested this new version of installer/build-linux.sh a few times

#### Checklist
<!-- Please verify that you have done the following -->

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.

@ktsakalozos fyi