### PR TITLE
 Removed localnode.yaml as in the later versions of dqlite it got rep…

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -181,7 +181,6 @@ function store_dqlite_info {
   printf -- '  Inspect dqlite\n'
   mkdir -p $INSPECT_DUMP/dqlite
   run_with_sudo preserve_env cp ${SNAP_DATA}/var/kubernetes/backend/cluster.yaml $INSPECT_DUMP/dqlite/
-  run_with_sudo preserve_env cp ${SNAP_DATA}/var/kubernetes/backend/localnode.yaml $INSPECT_DUMP/dqlite/
   run_with_sudo preserve_env cp ${SNAP_DATA}/var/kubernetes/backend/info.yaml $INSPECT_DUMP/dqlite/
   run_with_sudo preserve_env ls -lh ${SNAP_DATA}/var/kubernetes/backend/ 2>&1 >  $INSPECT_DUMP/dqlite/list.out
 }


### PR DESCRIPTION
#### Summary

Removed the localnode.yaml copy step from scripts/inspect.sh for dqlite, because recent dqlite versions no longer create localnode.yaml and instead use cluster.yaml and info.

#### References:
Fixes: https://github.com/canonical/microk8s/issues/5359

#### Changes

    Removed the cp ${SNAP_DATA}/var/kubernetes/backend/localnode.yaml line from the dqlite inspection section in scripts/inspect.sh.

The inspection now only collects cluster.yaml and info.yaml from the dqlite backend directory, which are the files produced by current dqlite.

#### Testing

    Ran microk8s inspect on a node using the current MicroK8s/dqlite backend and verified:

        No cp: cannot stat '.../localnode.yaml' error is emitted.

The inspection report tarball still contains the dqlite directory with cluster.yaml, info.yaml, and the backend directory listing.

#### Possible Regressions

    Older MicroK8s installations or dqlite layouts that still create and rely on localnode.yaml will no longer have that file included in inspection reports.

    However, current supported MicroK8s versions use cluster.yaml and info.yaml as the authoritative dqlite state, so impact is expected to be minimal.

#### Checklist
<!-- Please verify that you have done the following -->

[* ] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
[ *] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
[ *] The introduced changes are covered by unit and/or integration tests.
