### PR TITLE
[Backport 1.30] feat: bump containerd to v1.7.29

### DIFF
--- a/build-scripts/components/containerd/version.sh
+++ b/build-scripts/components/containerd/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.6.28"
+echo "v1.7.29"


### PR DESCRIPTION
Backport of #5406 to `1.30`.

**Original PR:** https://github.com/canonical/microk8s/pull/5406

Bump containerd to v1.7.29 to address CVE-2024-25621 (affected versions < 1.7.29).

Patched version: 1.7.29.