### PR TITLE
[Backport 1.32-strict] feat: bump containerd to v1.7.29

### DIFF
--- a/build-scripts/components/containerd/version.sh
+++ b/build-scripts/components/containerd/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.6.36"
+echo "v1.7.29"

--- a/tests/unit/yamls/cni.yaml
+++ b/tests/unit/yamls/cni.yaml
@@ -3531,7 +3531,6 @@ status:
   storedVersions: []
 
 ---
-
 ---
 # Source: calico/templates/calico-kube-controllers-rbac.yaml
 
@@ -3618,7 +3617,6 @@ subjects:
     name: calico-kube-controllers
     namespace: kube-system
 ---
-
 ---
 # Source: calico/templates/calico-node-rbac.yaml
 # Include a clusterrole for the calico-node DaemonSet,


### PR DESCRIPTION
Backport of #5406 to `1.32-strict`.

**Original PR:** https://github.com/canonical/microk8s/pull/5406

Bump containerd to v1.7.29 to address CVE-2024-25621 (affected versions < 1.7.29).

Patched version: 1.7.29.