### PR TITLE
chore: branch out 1.35

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -2,8 +2,7 @@ name: Build and test MicroK8s snap
 
 on:
   pull_request:
-    branches:
-      - master
+    branches: [1.35]
 
 jobs:
   build:
@@ -54,7 +53,7 @@ jobs:
         uses: ./.github/actions/test-prep
       - name: Running upgrade path test
         run: |
-          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade-path.py
+          sudo -E UPGRADE_MICROK8S_FROM=1.35/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade-path.py
 
   test-addons-core:
     name: Test core addons
@@ -120,7 +119,7 @@ jobs:
         run: |
           set -x
           export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
-          sudo -E bash -c "UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"
+          sudo -E bash -c "UPGRADE_MICROK8S_FROM=1.35/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"
 
   test-cluster-agent:
     name: Cluster agent health check

--- a/build-scripts/addons/repositories.sh
+++ b/build-scripts/addons/repositories.sh
@@ -3,8 +3,8 @@
 # List of addon repositories to bundle in the snap
 # (name),(repository),(reference)
 ADDONS_REPOS="
-core,https://github.com/canonical/microk8s-core-addons,main
-community,https://github.com/canonical/microk8s-community-addons,main
+core,https://github.com/canonical/microk8s-core-addons,1.35
+community,https://github.com/canonical/microk8s-community-addons,1.35
 "
 
 # List of addon repositories to automatically enable

--- a/build-scripts/components/cluster-agent/version.sh
+++ b/build-scripts/components/cluster-agent/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "main"
+echo "1.35"

--- a/build-scripts/components/kubernetes/version.sh
+++ b/build-scripts/components/kubernetes/version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KUBE_TRACK="${KUBE_TRACK:-}"            # example: "1.24"
+KUBE_TRACK="${KUBE_TRACK:-1.35}"            # example: "1.24"
 KUBE_VERSION="${KUBE_VERSION:-}"        # example: "v1.24.2"
 
 if [ -z "${KUBE_VERSION}" ]; then


### PR DESCRIPTION
#### chore: branch out 1.35

This PR branches out the 1.35 release.

Changes:
- CI workflow targets `1.35` branch instead of `master`
- Upgrade tests use `1.35/edge` channel
- Addon repositories point to `1.35` branches
- Cluster agent version set to `1.35`
- Default `KUBE_TRACK` set to `1.35`

#### Checklist

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [x] The introduced changes are covered by unit and/or integration tests.