### PR TITLE
feat: bump build component versions for 1.36 release

### DIFF
--- a/build-scripts/components/cni/version.sh
+++ b/build-scripts/components/cni/version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Match https://github.com/kubernetes/kubernetes/blob/master/build/dependencies.yaml#L20
-echo "v1.8.0"
+echo "v1.9.1"

--- a/build-scripts/components/containerd/version.sh
+++ b/build-scripts/components/containerd/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v2.1.6"
+echo "v2.2.3"

--- a/build-scripts/components/etcd/version.sh
+++ b/build-scripts/components/etcd/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v3.6.6"
+echo "v3.6.10"

--- a/build-scripts/components/flannel-cni-plugin/version.sh
+++ b/build-scripts/components/flannel-cni-plugin/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.8.0-flannel2"
+echo "v1.9.1-flannel1"

--- a/build-scripts/components/flanneld/version.sh
+++ b/build-scripts/components/flanneld/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v0.27.4"
+echo "v0.28.4"

--- a/build-scripts/components/helm/version.sh
+++ b/build-scripts/components/helm/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v3.19.2"
+echo "v3.20.2"

--- a/build-scripts/components/runc/version.sh
+++ b/build-scripts/components/runc/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "v1.3.3"
+echo "v1.4.2"


### PR DESCRIPTION
Bump build component versions in `build-scripts/components/` to align with upstream for the 1.36 MicroK8s release.

## Changes

| Component | Previous | New | Source |
|---|---|---|---|
| cni | v1.8.0 | **v1.9.1** | k8s 1.36 `dependencies.yaml` |
| containerd | v2.1.6 | **v2.2.3** | latest 2.2.x stable |
| etcd | v3.6.6 | **v3.6.10** | latest stable |
| flannel-cni-plugin | v1.8.0-flannel2 | **v1.9.1-flannel1** | latest stable |
| flanneld | v0.27.4 | **v0.28.4** | latest stable |
| helm | v3.19.2 | **v3.20.2** | latest 3.x stable |
| runc | v1.3.3 | **v1.4.2** | latest 1.4.x stable |

**Unchanged:** k8s-dqlite (v1.8.1 — already current), kubernetes (dynamically fetched).

## Notes

- containerd 2.1→2.2 and runc 1.3→1.4 are minor version bumps — watch CI closely
- All versions verified against upstream releases on 2026-04-28