### PR TITLE
fix: add deprecation warning to dashboard-proxy command

### DIFF
--- a/scripts/wrappers/dashboard_proxy.py
+++ b/scripts/wrappers/dashboard_proxy.py
@@ -60,6 +60,8 @@ def dashboard_proxy():
     Enable the dashboard add-on and configures port-forwarding
     to allow accessing the dashboard from the local machine.
     """
+    print("DEPRECATION WARNING: 'dashboard-proxy' is deprecated and will be removed in 1.36.")
+    print("")
     print("Checking if Dashboard is running.")
     command = [MICROK8S_ENABLE, "dashboard"]
     output = check_output(command)


### PR DESCRIPTION
## Summary

Add deprecation warning to the dashboard-proxy command. Users will now see a clear warning that this command is deprecated and will be removed in 1.36.

## Changes

- scripts/wrappers/dashboard_proxy.py: Print deprecation warning at the start of the command

## Acceptance Criteria

- [x] dashboard-proxy command emits a deprecation warning on invocation

## Notes

The dashboard-proxy command is being removed in 1.36 along with the dashboard addon. This provides users one release cycle of warning to migrate.