### PR TITLE
fix: use no-patchelf to prevent core22 RPATHs in staged binaries (strict)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -123,7 +123,7 @@ parts:
   iptables:
     after: [libnftnl]
     source: https://www.netfilter.org/projects/iptables/files/iptables-1.8.6.tar.bz2
-    build-attributes: [enable-patchelf]
+    build-attributes: [no-patchelf]
     plugin: autotools
     build-environment:
       - LIBMNL_LIBS: $CRAFT_STAGE/usr/lib
@@ -154,7 +154,7 @@ parts:
 
   bash-utils:
     plugin: nil
-    build-attributes: [enable-patchelf]
+    build-attributes: [no-patchelf]
     stage-packages:
       - conntrack
       - coreutils
@@ -277,7 +277,7 @@ parts:
 
   python-runtime:
     after: [build-deps]
-    build-attributes: [enable-patchelf]
+    build-attributes: [no-patchelf]
     plugin: nil
     source: build-scripts/components/python
     override-build: |


### PR DESCRIPTION
## Problem

Binaries staged from Ubuntu packages in the `bash-utils`, `iptables`, and `python-runtime` parts carry a hardcoded RPATH injected by snapcraft's patchelf step at build time:

```
RPATH: /snap/core22/current/lib/x86_64-linux-gnu
```

In strict confinement the AppArmor profile only permits access to `/snap/microk8s/...` paths. When the dynamic linker resolves shared libraries it follows the RPATH first, hitting `/snap/core22/<revision>/...` and generating AppArmor denials in dmesg on every binary invocation. **262 affected binaries** were observed across the three parts:

```
apparmor="DENIED" operation="open" class="file"
  profile="snap.microk8s.daemon-apiserver-kicker"
  name="/snap/core22/2411/usr/lib/x86_64-linux-gnu/libpcre.so.3.13.3" ...
```

The denials are non-fatal (the linker falls back to the standard paths provided by the snap mount namespace) but they pollute dmesg and represent a genuine policy violation on every microk8s operation.

## Root cause

The three affected parts have `build-attributes: [enable-patchelf]`. snapcraft's patchelf integration rewrites RPATH entries in staged ELF binaries to point at the build's prime directory. For stage-packages binaries this results in an absolute `/snap/core22/current/lib/...` RPATH baked into the binary at build time.

In the snap mount namespace the core22 base snap is mounted as the root filesystem, making all core22 libraries available at their standard paths (`/lib`, `/usr/lib`, ...) without any RPATH. The rewritten RPATH is both unnecessary and harmful under strict confinement.

## Fix

Set `build-attributes: [no-patchelf]` on the three affected parts (`bash-utils`, `iptables`, `python-runtime`). This explicitly disables patchelf so it never rewrites the RPATH entries in the first place.

This is the canonical solution. An earlier draft of this fix used `enable-patchelf` + `override-prime` to remove the RPATHs after priming, but the snapcraft build log revealed that combination was already disabling patchelf as an undocumented side-effect:

```
Warning: 'enable-patchelf' feature will not apply to files primed by parts
that use the 'override-prime' keyword. It's not possible to track file
changes in the prime directory.
```

`no-patchelf` achieves the same outcome explicitly and without the confusing interaction.

## Validation

Built the snap locally (`snapcraft --use-lxd`, 2026-05-08) and inspected the packaged snap:

```
$ unsquashfs -d snap-verify microk8s_v1.36.0_amd64.snap 'bin/*' 'sbin/*' 'usr/bin/*' 'usr/sbin/*' 'usr/lib/python3*'
$ find snap-verify -type f | wc -l
2648
$ find snap-verify -type f -exec sh -c 'readelf -d "$1" 2>/dev/null | grep -q core22 && echo "$1"' _ {} \; | wc -l
0
```

| Binary | RPATH after fix |
|---|---|
| `usr/bin/jq` | none |
| `usr/bin/gawk` | none |
| `bin/ls` | none |
| `bin/grep` | none |
| `bin/sed` | none |
| `sbin/ip` | none |
| `sbin/xtables-legacy-multi` (iptables) | none |

**2,648 ELF files checked — 0 with a core22 RPATH.**

Before the fix the same snap contained 262 binaries with `/snap/core22/current/lib/x86_64-linux-gnu` as their RPATH, generating AppArmor denials on every microk8s operation.