### PR TITLE
strict: backport runc v1.4.2 strict patches

### DIFF
--- a/build-scripts/components/runc/strict-patches/v1.4.2/0001-apparmor-change-profile-immediately-not-on-exec.patch
+++ b/build-scripts/components/runc/strict-patches/v1.4.2/0001-apparmor-change-profile-immediately-not-on-exec.patch
@@ -1,0 +1,41 @@
+From 7e1a29ce3a8f6fb737610241bf66604fad90d105 Mon Sep 17 00:00:00 2001
+From: Alberto Mardegan <mardy@users.sourceforge.net>
+Date: Wed, 6 May 2026 14:44:12 +0200
+Subject: [PATCH 1/3] apparmor: change profile immediately, not on exec
+
+---
+ libcontainer/apparmor/apparmor_linux.go | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/libcontainer/apparmor/apparmor_linux.go b/libcontainer/apparmor/apparmor_linux.go
+index 9bb4fb2..87d8af0 100644
+--- a/libcontainer/apparmor/apparmor_linux.go
++++ b/libcontainer/apparmor/apparmor_linux.go
+@@ -49,20 +49,20 @@ func setProcAttr(attr, value string) error {
+ 	return err
+ }
+ 
+-// changeOnExec reimplements aa_change_onexec from libapparmor in Go.
+-func changeOnExec(name string) error {
+-	if err := setProcAttr("exec", "exec "+name); err != nil {
++// changeProfile reimplements aa_change_profile from libapparmor in Go.
++func changeProfile(name string) error {
++	if err := setProcAttr("current", "changeprofile "+name); err != nil {
+ 		return fmt.Errorf("apparmor failed to apply profile: %w", err)
+ 	}
+ 	return nil
+ }
+ 
+ // applyProfile will apply the profile with the specified name to the process
+-// after the next exec.
++// immediately.
+ func applyProfile(name string) error {
+ 	if name == "" {
+ 		return nil
+ 	}
+ 
+-	return changeOnExec(name)
++	return changeProfile(name)
+ }
+-- 
+2.41.0

--- a/build-scripts/components/runc/strict-patches/v1.4.2/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
+++ b/build-scripts/components/runc/strict-patches/v1.4.2/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
@@ -1,0 +1,46 @@
+From 09a4b856844ce2a8c4cf668ed53958cfb2bd2478 Mon Sep 17 00:00:00 2001
+From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
+Date: Wed, 6 May 2026 14:44:12 +0200
+Subject: [PATCH 2/3] setns_init_linux: set the NNP flag after changing the
+ apparmor profile
+
+With the current version of the AppArmor kernel module, it's not possible to switch the AppArmor profile if the NoNewPrivileges flag is set. So, we invert the order of the two operations.
+
+Adjusts the previous patch for runc version v1.4.2
+
+Co-Authored-By: Alberto Mardegan <mardy@users.sourceforge.net>
+
+---
+ libcontainer/setns_init_linux.go | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/libcontainer/setns_init_linux.go b/libcontainer/setns_init_linux.go
+index 7f7c077..b96ddae 100644
+--- a/libcontainer/setns_init_linux.go
++++ b/libcontainer/setns_init_linux.go
+@@ -64,11 +64,6 @@ func (l *linuxSetnsInit) Init() error {
+ 			return fmt.Errorf("failed to setup pidfd: %w", err)
+ 		}
+ 	}
+-	if l.config.NoNewPrivileges {
+-		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+-			return err
+-		}
+-	}
+ 	if l.config.Config.Umask != nil {
+ 		unix.Umask(int(*l.config.Config.Umask))
+ 	}
+@@ -122,6 +117,11 @@ func (l *linuxSetnsInit) Init() error {
+ 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+ 		return err
+ 	}
++	if l.config.NoNewPrivileges {
++		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++			return err
++		}
++	}
+ 	// Check for the arg early to make sure it exists.
+ 	name, err := exec.LookPath(l.config.Args[0])
+ 	if err != nil {
+-- 
+2.41.0

--- a/build-scripts/components/runc/strict-patches/v1.4.2/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
+++ b/build-scripts/components/runc/strict-patches/v1.4.2/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
@@ -1,0 +1,54 @@
+From 5007ab516cb619db9e75218f9739c555762e26da Mon Sep 17 00:00:00 2001
+From: Alberto Mardegan <mardy@users.sourceforge.net>
+Date: Wed, 6 May 2026 14:44:12 +0200
+Subject: [PATCH 3/3] standard_init_linux: change AppArmor profile as late as
+ possible
+
+---
+ libcontainer/standard_init_linux.go | 17 ++++++++---------
+ 1 file changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
+index 570472b..1d54a02 100644
+--- a/libcontainer/standard_init_linux.go
++++ b/libcontainer/standard_init_linux.go
+@@ -129,10 +129,6 @@ func (l *linuxStandardInit) Init() error {
+ 			return &os.SyscallError{Syscall: "setdomainname", Err: err}
+ 		}
+ 	}
+-	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+-		return fmt.Errorf("unable to apply apparmor profile: %w", err)
+-	}
+-
+ 	if err := sys.WriteSysctls(l.config.Config.Sysctl); err != nil {
+ 		return err
+ 	}
+@@ -149,11 +145,6 @@ func (l *linuxStandardInit) Init() error {
+ 	if err != nil {
+ 		return fmt.Errorf("can't get pdeath signal: %w", err)
+ 	}
+-	if l.config.NoNewPrivileges {
+-		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+-			return &os.SyscallError{Syscall: "prctl(SET_NO_NEW_PRIVS)", Err: err}
+-		}
+-	}
+ 
+ 	if err := setupScheduler(l.config); err != nil {
+ 		return err
+@@ -180,6 +171,14 @@ func (l *linuxStandardInit) Init() error {
+ 	if err := syncParentReady(l.pipe); err != nil {
+ 		return fmt.Errorf("sync ready: %w", err)
+ 	}
++	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
++		return fmt.Errorf("apply apparmor profile: %w", err)
++	}
++	if l.config.NoNewPrivileges {
++		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++			return fmt.Errorf("set nonewprivileges: %w", err)
++		}
++	}
+ 	if l.config.ProcessLabel != "" {
+ 		if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
+ 			return fmt.Errorf("can't set process label: %w", err)
+-- 
+2.41.0


### PR DESCRIPTION
## Summary
- cherry-pick the merged `master` change from #5489 onto `strict`
- add the strict `runc` patch set for `v1.4.2`
- keep strict builds selecting a version-matched patch directory for `runc`

## Context
`strict` still needed the `runc v1.4.2` strict patch set that landed on `master` in #5489. Without this backport, strict builds can fall back to the older `v1.3.0` patch series, which does not match the `runc v1.4.2` sources.

## Notes
- cherry-picked from `77c1e68bbc075908791f8e9582cc42e275427c98`
- branch: `backport-5489-to-strict`