### PR TITLE
fix: build from 1.35 branches

### DIFF
--- a/build-scripts/addons/repositories.sh
+++ b/build-scripts/addons/repositories.sh
@@ -3,8 +3,8 @@
 # List of addon repositories to bundle in the snap
 # (name),(repository),(reference)
 ADDONS_REPOS="
-core,https://github.com/canonical/microk8s-core-addons,main
-community,https://github.com/canonical/microk8s-community-addons,main
+core,https://github.com/canonical/microk8s-core-addons,1.35
+community,https://github.com/canonical/microk8s-community-addons,1.35
 "
 
 # List of addon repositories to automatically enable

--- a/build-scripts/components/cluster-agent/version.sh
+++ b/build-scripts/components/cluster-agent/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "main"
+echo "1.35"


### PR DESCRIPTION
#### Summary
Updating 1.35-strict build to use the 1.35 branches.

