### PR TITLE
fix(strict): remove duplicate kubernetes-support sub-profile causing AppArmor failure

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -376,7 +376,6 @@ apps:
     start-timeout: 5m
     install-mode: disable
     plugs:
-      - k8s-journald
       - network-bind
       - docker-privileged
       - firewall-control
@@ -415,7 +414,6 @@ apps:
       - network-bind
       - network-observe
       - network-control
-      - k8s-journald
       - kubernetes-support
   daemon-apiserver-proxy:
     command: run-apiserver-proxy-with-args


### PR DESCRIPTION
## Problem

The strict snap fails to install on Ubuntu 24.04 (including GitHub Actions runners) with:

```
cannot setup profiles for snap "microk8s": cannot load apparmor profiles: exit status 1
apparmor_parser output:
Multiple definitions for hat systemd_run in profile (null) exist, bailing out.
```

This blocks all CI tests for `latest/edge/strict` in the [microk8s-core-addons repo](https://github.com/canonical/microk8s-core-addons/actions/runs/25422501572/job/76690142267).

## Root Cause

`daemon-containerd` and `daemon-apiserver-kicker` each plug both:
- `k8s-journald` → `kubernetes-support` interface ([flavor: `autobind-unix`](https://github.com/canonical/snapd/blame/master/interfaces/builtin/kubernetes_support.go#L336))
- `kubernetes-support` → `kubernetes-support` interface (default flavor)

Both connections are of the **same interface type** (`kubernetes-support`). snapd generates a `^systemd_run` child profile (hat) for each connection. On older AppArmor parsers these duplicate hats were silently merged, but AppArmor 4.x (shipped with Ubuntu 24.04) rejects them outright.

## Fix

Remove `k8s-journald` from the two affected apps. The bare `kubernetes-support` plug (default flavor) is a superset that already includes the `autobind-unix` permissions, so no functionality is lost.

## Testing

Tested manually in an LXD container running Ubuntu 24.04 (Noble).

### Reproducing the bug (before fix)

```console
$ snap install microk8s --channel=latest/edge/strict
error: cannot perform the following tasks:
- Setup snap "microk8s" (8894) security profiles for auto-connections (cannot setup profiles for snap "microk8s": cannot load apparmor profiles: exit status 1
apparmor_parser output:
Multiple definitions for hat systemd_run in profile (null) exist,bailing out.
Multiple definitions for hat systemd_run in profile (null) exist,bailing out.
...
)
```

### Verifying the fix

Patched the downloaded `latest/edge/strict` snap by removing `k8s-journald` from `daemon-containerd` and `daemon-apiserver-kicker` in `meta/snap.yaml`, then repacked with `snap pack`:

```console
$ snap install /root/microk8s-fixed.snap --dangerous
microk8s v1.36.0 installed

$ snap connect microk8s:docker-privileged
$ snap connect microk8s:kubernetes-support
$ snap connect microk8s:k8s-journald
$ snap connect microk8s:firewall-control
$ snap connect microk8s:network-control
$ snap connect microk8s:network-observe
$ snap connect microk8s:mount-observe
$ snap connect microk8s:kernel-module-control
$ snap connect microk8s:kernel-module-observe
$ snap connect microk8s:process-control
$ snap connect microk8s:system-observe
$ snap connect microk8s:log-observe

$ microk8s start
(exit 0)

$ snap services microk8s
Service                           Startup  Current   Notes
microk8s.daemon-apiserver-kicker  enabled  active    -
microk8s.daemon-apiserver-proxy   enabled  inactive  -
microk8s.daemon-cluster-agent     enabled  active    -
microk8s.daemon-containerd        enabled  active    -
microk8s.daemon-etcd              enabled  inactive  -
microk8s.daemon-flanneld          enabled  inactive  -
microk8s.daemon-k8s-dqlite        enabled  active    -
microk8s.daemon-kubelite          enabled  active    -
```

All core services start successfully. The node does not fully register due to a separate RPATH issue (binaries trying to load libs from `/snap/core22/...` which AppArmor denies) — that is addressed in #5491.
