### PR TITLE
fix(strict): assign k8s-kubeproxy to daemon-apiserver-proxy to prevent AppArmor 4.x duplicate hat

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -423,6 +423,7 @@ apps:
       - network-bind
       - network-observe
       - network-control
+      - k8s-kubeproxy
   daemon-cluster-agent:
     command: run-cluster-agent-with-args
     daemon: simple


### PR DESCRIPTION
## Problem

On Ubuntu 24.04+ with AppArmor 4.x, connecting the `k8s-kubeproxy` interface fails with:

```
Multiple definitions for hat systemd_run in profile (null) exist, bailing out.
```

## Root Cause

The `k8s-kubeproxy` plug (snapcraft.yaml)
```
  k8s-kubeproxy:
    interface: kubernetes-support
    flavor: kubeproxy
```
is defined in the top-level `plugs:` section but never explicitly assigned to any app. When a plug is unassigned, snapd implicitly assigns it to **all** apps. This means every app that already has the `kubernetes-support` plug (which generates a `^systemd_run` hat) also gets `k8s-kubeproxy` (which generates its own identical `^systemd_run` hat) — resulting in duplicate hat definitions that AppArmor 4.x rejects.

Older AppArmor parsers (< 4.x) silently merged duplicate hats, masking this bug.

## Fix

Explicitly assign `k8s-kubeproxy` to `daemon-apiserver-proxy`, which does **not** have the `kubernetes-support` plug and therefore has no conflicting hat. This prevents the implicit assignment to all apps.

## Testing

Tested on Ubuntu 24.04 LXD container (AppArmor 4.x):

```
$ snap install microk8s_fixed.snap --dangerous
microk8s v1.36.0 installed

$ snap connect microk8s:kubernetes-support && echo OK
kubernetes-support OK

$ snap connect microk8s:k8s-journald && echo OK
k8s-journald OK

$ snap connect microk8s:k8s-kubelet && echo OK
k8s-kubelet OK

$ snap connect microk8s:k8s-kubeproxy && echo OK
k8s-kubeproxy OK
```

All four `kubernetes-support` interface variants connect successfully.

## Related

- Supersedes #5501 (which only fixed `k8s-journald` duplicates but missed `k8s-kubeproxy`)
- Fixes the AppArmor failure blocking CI on microk8s-core-addons