### PR TITLE
fix: bump urllib3, requests, idna to resolve CVEs

### DIFF
--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -1,13 +1,13 @@
-urllib3==1.26.19
+urllib3==2.7.0
 click==7.1.2
 progressbar33==2.4
 psutil==5.9.0
-requests==2.32.2
+requests==2.33.0
 requests_unixsocket==0.1.5
 simplejson==3.8.2
 toml==0.10.0
 certifi==2024.7.4
-chardet==3.0.4
-idna==3.7
+charset-normalizer==3.4.7
+idna==3.15
 pyinstaller
 PyYAML==6.0.2; sys_platform == 'win32'

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -12,11 +12,11 @@ setup(
     install_requires=[
         "click~=7.0",
         "progressbar33==2.4",
-        "requests==2.32.2",
+        "requests==2.33.0",
         "requests_unixsocket==0.1.5",
         "simplejson==3.8.2",
         "toml==0.10.0",
-        "urllib3==1.26.19",
+        "urllib3==2.7.0",
     ],
     platforms="any",
     entry_points={


### PR DESCRIPTION
## Security Fix

**Findings:** 8 CVEs across 3 packages (4 high, 4 medium)
**Tool:** Dependabot
**Alerts:** #22–#39

| Package | Old | New | CVEs Fixed |
|---------|-----|-----|------------|
| urllib3 | 1.26.19 | 2.7.0 | CVE-2026-44431, CVE-2026-21441, CVE-2025-66471, CVE-2025-66418, CVE-2025-50181 |
| requests | 2.32.2 | 2.33.0 | CVE-2026-25645, CVE-2024-47081 |
| idna | 3.7 | 3.15 | CVE-2026-45409 |

## What changed

- Bumped `urllib3` from 1.x to 2.7.0 (major version bump — API compatible for this usage)
- Bumped `requests` to 2.33.0
- Bumped `idna` to 3.15
- Replaced `chardet==3.0.4` with `charset-normalizer==3.4.7` (required by requests 2.33+)

Changes in both `installer/requirements.txt` and `installer/setup.py`.

## Verification

- [x] `pip install --dry-run` confirms all packages resolve without conflicts
- [x] `requests-unixsocket==0.1.5` compatible with urllib3 2.x (verified)
- [ ] CI installer build passes
- [ ] Human reviewer approval

## Notes

- urllib3 2.x is a major version bump but the microk8s installer uses only basic HTTP functionality (requests library abstracts urllib3 internals)
- `chardet` → `charset-normalizer` swap is required because requests 2.33+ dropped chardet in favor of charset-normalizer