### PR TITLE
fix: cannot join by ipv6 (4614)

### DIFF
--- a/scripts/wrappers/common/cluster/utils.py
+++ b/scripts/wrappers/common/cluster/utils.py
@@ -570,7 +570,7 @@ def get_valid_connection_parts(connection):
             "Expected format: <master_IP>:<master_PORT>/<token>[/<fingerprint>]"
         )
 
-    master_ep = connection_parts[0].split(":")
+    master_ep = connection_parts[0].rsplit(":", 1)
     if len(master_ep) != 2:
         raise InvalidConnectionError(
             "Expected format: <master_IP>:<master_PORT>/<token>[/<fingerprint>]"


### PR DESCRIPTION


#### Summary

Allow passing ipv6 address in the join command.
AFAIK (and I am not an expert) the validator is not correct for parsing connection like:

`microk8s join ff00::1:25000/token`

References #4614

#### Changes

Fix the validator

#### Testing

I couldn't test this since this would requires a full setup locally.

But, with this, command like this should at least past validation.

`microk8s join ff00::1:25000/token`

I did a small check later in the code, and it seem that there are no blocking points.

#### Possible Regressions

This could allow ipv6 join command to pass validation while the rest of the code would fail. But I had a small look, it seem ok.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [X] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
