### PR TITLE
fix: fall back to nftables proxy mode on nftables-only kernels

### DIFF
--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -1316,6 +1316,25 @@ wait_for_default_route() {
   done
 }
 
+is_kernel_module_available() {
+  # Return 0 if the given kernel module is loaded, built-in, or loadable.
+  local mod="$1"
+  # Loaded or built-in modules show up under /sys/module (no binary required).
+  if [ -d "/sys/module/${mod}" ]
+  then
+    return 0
+  fi
+  # Otherwise check whether modprobe can find it, using a dry-run so that we do
+  # not actually insert the module. Prefer the host modprobe, fall back to the
+  # one shipped with the snap (see the br_netfilter handling in
+  # run-kubelite-with-args for the same pattern).
+  if /sbin/modprobe -nq "${mod}" 2>/dev/null || modprobe -nq "${mod}" 2>/dev/null
+  then
+    return 0
+  fi
+  return 1
+}
+
 is_ec2_instance() {
   if [ -f "/sys/hypervisor/uuid" ]
   then

--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -204,6 +204,22 @@ then
   fi
 fi
 
+# kube-proxy defaults to the 'iptables' proxy mode, which requires the
+# 'ip_tables' kernel module. On nftables-only kernels this module is absent,
+# so kube-proxy fails to start ("modprobe: FATAL: Module ip_tables not found")
+# and the node enters a crash-restart loop. If the user has not explicitly
+# selected a proxy mode and 'ip_tables' is unavailable, fall back to the
+# nftables proxy mode when 'nf_tables' can be used.
+# See https://github.com/canonical/microk8s/issues/5525
+if ! grep -qE -- "--proxy-mode" "$SNAP_DATA/args/kube-proxy"
+then
+  if ! is_kernel_module_available ip_tables && is_kernel_module_available nf_tables
+  then
+    echo "The 'ip_tables' kernel module is unavailable; falling back to the nftables proxy mode for kube-proxy."
+    refresh_opt_in_local_config "proxy-mode" "nftables" kube-proxy
+  fi
+fi
+
 # kube-proxy reads some values related to the 'nf_conntrack' kernel
 # module from procfs on startup, so we must ensure it is loaded:
 if ! [ -f /proc/sys/net/netfilter/nf_conntrack_max ]

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -357,6 +357,19 @@ function suggest_fixes {
     printf -- "\033[0;33mWARNING: \033[0m Please ensure br_netfilter kernel module is loaded on the host. \n"
   fi
 
+  # kube-proxy runs in iptables mode by default, which needs the 'ip_tables'
+  # kernel module. On nftables-only kernels it is absent and kube-proxy enters
+  # a crash-restart loop. See https://github.com/canonical/microk8s/issues/5525
+  if ! is_kernel_module_available ip_tables &&
+     ! grep -qE -- "--proxy-mode=nftables" "${SNAP_DATA}/args/kube-proxy" 2>/dev/null
+  then
+    printf -- "\033[0;33mWARNING: \033[0m The ip_tables kernel module is not available on this host. \n"
+    printf -- "\t  kube-proxy defaults to iptables mode and will fail to start (crash-restart loop). \n"
+    printf -- "\t  Switch kube-proxy to nftables mode with: \n"
+    printf -- "\t  \t echo '--proxy-mode=nftables' | sudo tee -a ${SNAP_DATA}/args/kube-proxy \n"
+    printf -- "\t  \t sudo snap restart microk8s \n"
+  fi
+
   if ! ( ip route; ip -6 route ) | grep "^default" &>/dev/null
   then
     printf -- "


### PR DESCRIPTION
#### Summary

MicroK8s fails silently on nftables-only kernels (kernels shipped without the
`ip_tables` module). kube-proxy runs in the default `iptables` proxy mode, which
needs the `ip_tables` kernel module; when it is absent, kube-proxy fails to start
with `modprobe: FATAL: Module ip_tables not found` and the node enters a
crash-restart loop. Neither `microk8s status` nor `microk8s inspect` surface the
cause — the error is only visible in `journalctl`.

Fixes #5525

#### Changes

- **`microk8s-resources/actions/common/utils.sh`**: add an `is_kernel_module_available`
  helper that checks `/sys/module` for loaded/built-in modules and falls back to a
  `modprobe -nq` dry-run for loadable ones, mirroring the existing
  `nf_conntrack`/`br_netfilter` handling in `run-kubelite-with-args`.
- **`microk8s-resources/wrappers/run-kubelite-with-args`**: before starting kubelite,
  if the user has **not** explicitly set a proxy mode and `ip_tables` is unavailable
  while `nf_tables` can be used, fall back to `--proxy-mode=nftables`. A
  user-selected proxy mode is never overridden, and the check is idempotent across
  restarts.
- **`scripts/inspect.sh`**: add a `suggest_fixes` warning that surfaces the missing
  `ip_tables` module and the manual workaround, for the cases the auto-fallback
  cannot cover (e.g. `nf_tables` also missing, or the user pinned
  `--proxy-mode=iptables`).

#### Testing

- Verified `is_kernel_module_available` against a real loaded module (reports
  available) and a non-existent module name (reports unavailable).
- Exercised the fallback decision across 5 scenarios using the actual code block
  from `run-kubelite-with-args` (mocking module availability and
  `refresh_opt_in_local_config`):
  - `ip_tables` missing + `nf_tables` available + no mode set → `--proxy-mode=nftables` added
  - `ip_tables` available → no change
  - both modules missing → no change (cannot fall back)
  - user pinned `--proxy-mode=iptables` → preserved, not overridden
  - already `--proxy-mode=nftables` → unchanged
- `codespell` is clean on the changed files and `shellcheck` reports no new
  findings versus `master`.
- I do not have access to an nftables-only kernel; the `--proxy-mode=nftables`
  workaround was confirmed working on the affected hardware by the reporter in #5525.

#### Possible Regressions

- On kernels where `ip_tables` is present (the common case) the helper short-circuits
  via `/sys/module` and no fallback is applied — behavior is unchanged.
- A user-selected `--proxy-mode` (including `iptables`) is always respected.
- The fallback only triggers when `nf_tables` is usable; if neither module is
  available no change is made and `microk8s inspect` surfaces the problem instead.
- The nftables proxy mode is GA since Kubernetes 1.33 and beta (on by default) since
  1.31, so this is safe on `master`/latest. If backported below 1.31 it would require
  enabling the `NFTablesProxyMode` feature gate.

#### Checklist

* [x] Read the [contributions](https://github.com/canonical/microk8s/blob/master/CONTRIBUTING.md) page.
* [x] Submitted the [CLA form](https://ubuntu.com/legal/contributors/agreement), if you are a first time contributor.
* [ ] The introduced changes are covered by unit and/or integration tests.

#### Notes

The shell wrappers (`run-kubelite-with-args`, `inspect.sh`) have no in-tree unit-test
harness, so the changes were validated manually as described under Testing rather than
with a committed test. Happy to add coverage if you can point me at the preferred place
for wrapper-level tests. This targets `master`; let me know if you'd like it backported
and to which release branches.