### PR TITLE
fix: detect silent k8s-dqlite datastore failures in inspect

### DIFF
--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -186,6 +186,51 @@ function store_dqlite_info {
 }
 
 
+function check_dqlite {
+  # Surface k8s-dqlite datastore problems that otherwise fail silently. When the
+  # datastore cannot start the daemon wrapper exits before the binary can log a
+  # fatal error, so neither 'microk8s status' nor the rest of this report points
+  # at the cause (issue #5524).
+  local backend="${SNAP_DATA}/var/kubernetes/backend"
+
+  # The dqlite TLS keypair lives in the backend directory. If it is missing (for
+  # example the backend directory was wiped) the binary aborts on start with
+  # "failed to load keypair from cluster.crt and cluster.key" and never runs.
+  if [ ! -e "${backend}/cluster.crt" ] || [ ! -e "${backend}/cluster.key" ]
+  then
+    printf -- '\033[31m FAIL: \033[0m The k8s-dqlite TLS certificate or key is missing from %s.\n' "${backend}"
+    printf -- '\t  The datastore cannot start without them, so MicroK8s will not come up.\n'
+    printf -- '\t  Restore the backend directory from a backup, or redeploy/rejoin the node.\n'
+    RETURN_CODE=1
+  fi
+
+  # After a hostname change the address stored in the raft state can still point
+  # at the old name, so dqlite never confirms quorum with itself and loops with
+  # "no available dqlite leader server found".
+  if [ -e "${backend}/info.yaml" ]
+  then
+    local stored_addr stored_host current_host
+    stored_addr="$(awk '/^Address:/ {print $2; exit}' "${backend}/info.yaml" 2>/dev/null)"
+    stored_addr="${stored_addr//\"/}"   # strip surrounding quotes if any
+    stored_host="${stored_addr%:*}"     # drop the :port suffix
+    stored_host="${stored_host#\[}"     # drop the IPv6 opening bracket
+    stored_host="${stored_host%\]}"     # drop the IPv6 closing bracket
+    current_host="$(hostname)"
+    # Only warn when the stored address is a hostname (not an IPv4/IPv6 literal)
+    # that no longer matches the current hostname.
+    if [ -n "${stored_host}" ] &&
+       [[ "${stored_host}" != *:* ]] &&
+       ! [[ "${stored_host}" =~ ^[0-9.]+$ ]] &&
+       [ "${stored_host}" != "${current_host}" ]
+    then
+      printf -- "\033[0;33mWARNING: \033[0m The k8s-dqlite node address '%s' does not match the current hostname '%s'.\n" "${stored_host}" "${current_host}"
+      printf -- '\t  If the hostname was changed, dqlite may fail to elect a leader\n'
+      printf -- '\t  ("no available dqlite leader server found") and MicroK8s will not start.\n'
+    fi
+  fi
+}
+
+
 function suggest_fixes {
   # Propose fixes
   printf '\n'
@@ -554,6 +599,11 @@ if [ -e "${SNAP_DATA}/var/lock/ha-cluster" ]
 then
   printf -- 'Inspecting dqlite\n'
   store_dqlite_info
+  if ! [ -e "${SNAP_DATA}/var/lock/no-k8s-dqlite" ]
+  then
+    # workers do not run dqlite, so only check the datastore on control-plane nodes
+    check_dqlite
+  fi
 fi
 
 suggest_fixes


### PR DESCRIPTION
#### Summary

Addresses #5524. `microk8s inspect` gave no actionable hint when the
k8s-dqlite datastore could not start, because the daemon wrapper
(`run-k8s-dqlite-with-args`) exits before the binary can log its fatal
error. The reporter hit two variants of this silent failure:

1. **Missing TLS keypair** — wiping the backend directory
   (`var/kubernetes/backend/`) also removes `cluster.crt` / `cluster.key`,
   so dqlite aborts on start with
   `failed to load keypair from cluster.crt and cluster.key` while
   `microk8s status` / `microk8s inspect` show nothing wrong.
2. **Stale raft node address after a hostname rename** — the stored node
   address still pointed at the old hostname, so dqlite looped with
   `no available dqlite leader server found`. The existing uppercase-hostname
   warning disappears once the host is renamed to lowercase, leaving nothing
   pointing at the stale address.

As the reporter notes, the real gap is the silent `inspect`, so this PR makes
both conditions visible.

#### Changes

`scripts/inspect.sh`: new `check_dqlite` step, run on control-plane (non-worker)
HA nodes alongside the existing dqlite inspection:

- **FAIL** if `cluster.crt` or `cluster.key` is missing from the backend
  directory, with a short recovery hint (sets a non-zero return code, like the
  other `FAIL` checks).
- **WARNING** if the node `Address` in `info.yaml` is a hostname that no longer
  matches the current hostname.

The address check intentionally ignores IPv4/IPv6 literals, so the default
single-node (`127.0.0.1`) deployment and IP-based clusters never trigger a
false positive — `info.yaml` always stores this node's own address, so a
mismatch genuinely indicates a stale name.

#### Testing

`scripts/inspect.sh` has no unit-test harness (it is a pure bash diagnostic
script, consistent with how previous inspect checks were added). I verified the
new logic in isolation across these cases:

| Scenario | Result |
| --- | --- |
| single-node default (`127.0.0.1:19001`) | no output |
| clustered IPv4 (`10.0.0.5:19001`) | no output |
| bracketed IPv6 (`[fd00::5]:19001`) | no output |
| address hostname matches current host | no output |
| stale hostname (`oldname` vs `newname`) | WARNING |
| uppercase rename (`MyHost` vs `myhost`) | WARNING |
| missing cert/key (backend wiped) | FAIL, return code 1 |
| missing cert/key + no `info.yaml` | FAIL, return code 1 |

`bash -n scripts/inspect.sh` and `codespell` (the lint config used in CI) both
pass.
