### PR TITLE
fix: add keyUsage extension to CA certificates (#4864)

### DIFF
--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -11,7 +11,8 @@ runs:
       shell: bash
       run: |
         set -x
-        pip3 install -r ./tests/requirements.txt
+        sudo apt-get remove -y python3-yaml
+        sudo pip3 install -r ./tests/requirements.txt
     # Docker sets iptables rules that interfere with LXD and K8s.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         set -x
-        sudo pip3 install -r ./tests/requirements.txt
+        pip3 install -r ./tests/requirements.txt
     # Docker sets iptables rules that interfere with LXD and K8s.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -690,12 +690,26 @@ produce_certs() {
 
     # Generate apiserver CA
     if ! [ -f ${SNAP_DATA}/certs/ca.crt ]; then
-        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/ca.key -subj "/CN=10.152.183.1" -out ${SNAP_DATA}/certs/ca.crt
+        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 \
+            -key ${SNAP_DATA}/certs/ca.key \
+            -subj "/CN=10.152.183.1" \
+            -addext "basicConstraints=critical,CA:TRUE" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign" \
+            -addext "subjectKeyIdentifier=hash" \
+            -addext "authorityKeyIdentifier=keyid:always,issuer" \
+            -out ${SNAP_DATA}/certs/ca.crt
     fi
 
     # Generate front proxy CA
     if ! [ -f ${SNAP_DATA}/certs/front-proxy-ca.crt ]; then
-        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/front-proxy-ca.key -subj "/CN=front-proxy-ca" -out ${SNAP_DATA}/certs/front-proxy-ca.crt
+        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 \
+            -key ${SNAP_DATA}/certs/front-proxy-ca.key \
+            -subj "/CN=front-proxy-ca" \
+            -addext "basicConstraints=critical,CA:TRUE" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign" \
+            -addext "subjectKeyIdentifier=hash" \
+            -addext "authorityKeyIdentifier=keyid:always,issuer" \
+            -out ${SNAP_DATA}/certs/front-proxy-ca.crt
     fi
 
     # Produce certificates based on the rendered csr.conf.rendered.


### PR DESCRIPTION
## Summary

- Add `keyUsage`, `basicConstraints`, `subjectKeyIdentifier`, and `authorityKeyIdentifier` extensions to the generated CA certificates (`ca.crt` and `front-proxy-ca.crt`)
- Fixes Python 3.13+ TLS verification failures caused by `VERIFY_X509_STRICT` requiring the `keyUsage` extension on CA certs

## Problem

Python 3.13 now enables `VERIFY_X509_STRICT` by default in its SSL context. This causes any Python-based Kubernetes client (e.g., `kopf`, `lightkube`, the official `kubernetes` package) to fail with:

```
SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: CA cert does not include key usage extension
```

The root CA certificates generated by microk8s did not include any X509v3 extensions.

## Fix

Both CA cert generation commands now include:

| Extension | Value |
|-----------|-------|
| `basicConstraints` | `critical, CA:TRUE` |
| `keyUsage` | `critical, keyCertSign, cRLSign` |
| `subjectKeyIdentifier` | `hash` |
| `authorityKeyIdentifier` | `keyid:always, issuer` |

Uses OpenSSL's `-addext` flag (available since OpenSSL 1.1.1).

## Note for existing clusters

This only affects newly generated certificates (the code skips generation if the cert file already exists). Existing clusters will need to regenerate their CA certs, e.g. via `microk8s refresh-certs --cert ca.crt`, to pick up the fix.

Fixes #4864