### PR TITLE
[1.34 strict backport] fix: add keyUsage extension to CA certificates (#4864) (#5537)

### DIFF
--- a/.github/actions/test-prep/action.yaml
+++ b/.github/actions/test-prep/action.yaml
@@ -11,6 +11,7 @@ runs:
       shell: bash
       run: |
         set -x
+        sudo apt-get remove -y python3-yaml
         sudo pip3 install -r ./tests/requirements.txt
     # Docker sets iptables rules that interfere with LXD and K8s.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/test-prep
       - name: Running upgrade path test
         run: |
-          sudo -E STRICT=yes UPGRADE_MICROK8S_FROM=1.34-strict/edge/strict UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade-path.py
+          sudo -E STRICT=yes UPGRADE_MICROK8S_FROM=1.34-strict/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade-path.py
 
   test-addons-core:
     name: Test core addons
@@ -125,7 +125,7 @@ jobs:
           set -x
           export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
           export STRICT="yes"
-          sudo -E bash -c "UPGRADE_MICROK8S_FROM=1.34-strict/edge/strict UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"
+          sudo -E bash -c "UPGRADE_MICROK8S_FROM=1.34-strict/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"
 
   test-cluster-agent:
     name: Cluster agent health check

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -1,8 +1,8 @@
 name: Build and test MicroK8s snap
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches: [1.34-strict]
 
 jobs:
   build:

--- a/microk8s-resources/actions/common/utils.sh
+++ b/microk8s-resources/actions/common/utils.sh
@@ -686,12 +686,26 @@ produce_certs() {
 
     # Generate apiserver CA
     if ! [ -f ${SNAP_DATA}/certs/ca.crt ]; then
-        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/ca.key -subj "/CN=10.152.183.1" -out ${SNAP_DATA}/certs/ca.crt
+        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 \
+            -key ${SNAP_DATA}/certs/ca.key \
+            -subj "/CN=10.152.183.1" \
+            -addext "basicConstraints=critical,CA:TRUE" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign" \
+            -addext "subjectKeyIdentifier=hash" \
+            -addext "authorityKeyIdentifier=keyid:always,issuer" \
+            -out ${SNAP_DATA}/certs/ca.crt
     fi
 
     # Generate front proxy CA
     if ! [ -f ${SNAP_DATA}/certs/front-proxy-ca.crt ]; then
-        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 -key ${SNAP_DATA}/certs/front-proxy-ca.key -subj "/CN=front-proxy-ca" -out ${SNAP_DATA}/certs/front-proxy-ca.crt
+        "${SNAP}/openssl.wrapper" req -x509 -new -sha256 -nodes -days 3650 \
+            -key ${SNAP_DATA}/certs/front-proxy-ca.key \
+            -subj "/CN=front-proxy-ca" \
+            -addext "basicConstraints=critical,CA:TRUE" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign" \
+            -addext "subjectKeyIdentifier=hash" \
+            -addext "authorityKeyIdentifier=keyid:always,issuer" \
+            -out ${SNAP_DATA}/certs/front-proxy-ca.crt
     fi
 
     # Produce certificates based on the rendered csr.conf.rendered.


### PR DESCRIPTION
* fix: add keyUsage extension to CA certificates for Python 3.13

Python 3.13 enables VERIFY_X509_STRICT by default, which requires CA certificates to include the keyUsage extension. Without it, TLS verification fails with 'CA cert does not include key usage extension'.

Add basicConstraints, keyUsage, subjectKeyIdentifier, and authorityKeyIdentifier extensions to both the apiserver CA and front-proxy CA certificate generation commands.

Fixes #4864

* remove pyyaml as it is loaded with pip in our tests
