### PR TITLE
fix(test): wait for cluster ready before checking coredns after start

### DIFF
--- a/tests/test-simple.py
+++ b/tests/test-simple.py
@@ -146,5 +146,10 @@ class TestSimple(object):
 
         utils.run_until_success("/snap/bin/microk8s.start", timeout_insec=180)
 
+        # microk8s.start returns once snap services are up, but coredns (a pod
+        # scheduled by kubelite) takes a few more seconds.  Wait for the cluster
+        # to be fully Ready before asserting coredns is running.
+        utils.wait_for_installation()
+
         new_coredns_procs = utils._get_process("coredns")
         assert len(new_coredns_procs) > 0, "Expected to find a new coredns process running."


### PR DESCRIPTION
## Problem

`test_microk8s_stop_start` was intermittently flaky. After calling `microk8s.start` (which returns once snap services are started), it immediately checked for coredns processes with no wait. coredns is a pod scheduled by kubelite — it takes a few extra seconds after the services are up to be scheduled and running.

## Fix

Add a call to `utils.wait_for_installation()` after `microk8s.start`, before asserting coredns is running. This polls until the node is `Ready` (plus a 30s buffer), which guarantees coredns is scheduled and running. This is the idiomatic pattern already used elsewhere in the test suite.

No logic changes — just inserting the existing wait helper at the right point.

## Context

Discovered while working on [canonical/k8s-dqlite#369](https://github.com/canonical/k8s-dqlite/pull/369), which runs this test suite in CI and had to use `continue-on-error: true` to work around the flakiness.