### PR TITLE
fix(apparmor): allow signal send from cri-containerd to daemon-containerd

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -1,9 +1,7 @@
 name: Build and test MicroK8s snap
 
 on:
-  pull_request:
-    branches:
-      - master
+  - push
 
 jobs:
   build:
@@ -54,7 +52,7 @@ jobs:
         uses: ./.github/actions/test-prep
       - name: Running upgrade path test
         run: |
-          sudo -E UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade-path.py
+          sudo -E STRICT=yes UPGRADE_MICROK8S_FROM=latest/edge/strict UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade-path.py
 
   test-addons-core:
     name: Test core addons
@@ -69,18 +67,20 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Prepare test prerequisites
         uses: ./.github/actions/test-prep
-      - name: Running addons tests
+      - name: Running addons tests in strict mode
         env:
           UNDER_TIME_PRESSURE: ${{ !contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
         run: |
           set -x
-          sudo snap install build/microk8s.snap --classic --dangerous
+          sudo snap install build/microk8s.snap --dangerous
+          sudo /snap/microk8s/current/connect-all-interfaces.sh
+          sudo microk8s status --wait-ready --timeout 300
           ./tests/smoke-test.sh
           # The GitHub runner is using the 10.1.0.0/16 CIDR, which would conflict with
           # kube-ovn's default POD_CIDR. They have to be different.
+          export STRICT="yes"
           export POD_CIDR="10.200.0.0/16"
           export POD_GATEWAY="10.200.0.1"
-          export SKIP_PROMETHEUS="False"
           export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/core/tests; pytest -s -ra test-addons.py"
 
@@ -100,8 +100,11 @@ jobs:
         run: |
           set -x
           sudo snap install build/microk8s.snap --classic --dangerous
+          sudo /snap/microk8s/current/connect-all-interfaces.sh
+          sudo microk8s status --wait-ready --timeout 300
           sudo microk8s enable community
           export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
+          export STRICT="yes"
           sudo -E bash -c "cd /var/snap/microk8s/common/addons/community/; pytest -s -ra ./tests/"
 
   test-addons-core-upgrade:
@@ -120,7 +123,8 @@ jobs:
         run: |
           set -x
           export UNDER_TIME_PRESSURE=${UNDER_TIME_PRESSURE@u}
-          sudo -E bash -c "UPGRADE_MICROK8S_FROM=latest/edge UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"
+          export STRICT="yes"
+          sudo -E bash -c "UPGRADE_MICROK8S_FROM=latest/edge/strict UPGRADE_MICROK8S_TO=$PWD/build/microk8s.snap pytest -s ./tests/test-upgrade.py"
 
   test-cluster-agent:
     name: Cluster agent health check
@@ -136,6 +140,7 @@ jobs:
         run: |
           set -x
           sudo snap install build/microk8s.snap --classic --dangerous
+          sudo /snap/microk8s/current/connect-all-interfaces.sh
           sudo -E bash -c "pytest -s ./tests/test-cluster-agent.py"
 
   test-airgap:

--- a/build-scripts/components/runc/strict-patches/v1.3.0/0003-standard_init_linux-change-AppArmor-profile-as-late-as-possible.patch
+++ b/build-scripts/components/runc/strict-patches/v1.3.0/0003-standard_init_linux-change-AppArmor-profile-as-late-as-possible.patch
@@ -1,18 +1,19 @@
-From 7f91e445a8731856e2d22b2295d8438e07cf2bf7 Mon Sep 17 00:00:00 2001
-From: Alberto Mardegan <mardy@users.sourceforge.net>
-Date: Thu, 17 Jun 2021 14:31:35 +0300
-Subject: [PATCH] standard_init_linux: change AppArmor profile as late as
- possible
+From a7a99eb68f7d7dc1d08a1f1790e5be6dc19fd4ec Mon Sep 17 00:00:00 2001
+From: Homayoon Alimohammadi <homayoonalimohammadi@gmail.com>
+Date: Thu, 18 Dec 2025 15:09:46 +0400
+Subject: [PATCH] fix(standard_init_linux): standard_init_linux: change
+ AppArmor profile as late as possible
 
+Signed-off-by: Homayoon Alimohammadi <homayoonalimohammadi@gmail.com>
 ---
  libcontainer/standard_init_linux.go | 17 +++++++++--------
  1 file changed, 9 insertions(+), 8 deletions(-)
 
 diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
-index 384750bf..ccd9297a 100644
+index 21516bd3..8e6fb51d 100644
 --- a/libcontainer/standard_init_linux.go
 +++ b/libcontainer/standard_init_linux.go
-@@ -126,9 +126,6 @@ func (l *linuxStandardInit) Init() error {
+@@ -128,9 +128,6 @@ func (l *linuxStandardInit) Init() error {
  			return &os.SyscallError{Syscall: "setdomainname", Err: err}
  		}
  	}
@@ -20,9 +21,9 @@ index 384750bf..ccd9297a 100644
 -		return fmt.Errorf("unable to apply apparmor profile: %w", err)
 -	}
  
- 	for key, value := range l.config.Config.Sysctl {
- 		if err := writeSystemProperty(key, value); err != nil {
-@@ -149,11 +146,6 @@ func (l *linuxStandardInit) Init() error {
+ 	if err := sys.WriteSysctls(l.config.Config.Sysctl); err != nil {
+ 		return err
+@@ -148,11 +145,6 @@ func (l *linuxStandardInit) Init() error {
  	if err != nil {
  		return fmt.Errorf("can't get pdeath signal: %w", err)
  	}
@@ -34,7 +35,7 @@ index 384750bf..ccd9297a 100644
  
  	if err := setupScheduler(l.config); err != nil {
  		return err
-@@ -169,6 +161,15 @@ func (l *linuxStandardInit) Init() error {
+@@ -168,6 +160,15 @@ func (l *linuxStandardInit) Init() error {
  	if err := syncParentReady(l.pipe); err != nil {
  		return fmt.Errorf("sync ready: %w", err)
  	}
@@ -51,5 +52,4 @@ index 384750bf..ccd9297a 100644
  		return fmt.Errorf("can't set process label: %w", err)
  	}
 -- 
-2.43.0
-
+2.48.1

--- a/docs/build.md
+++ b/docs/build.md
@@ -83,8 +83,15 @@ lxc file pull test-build/root/microk8s/microk8s_v1.9.6_amd64.snap .
 After copying it, you can install it with:
 
 ```shell
-snap install microk8s_*_amd64.snap --classic --dangerous
+snap install microk8s_*_amd64.snap --dangerous
 ```
+
+Finally, you need to connect the interfaces. To this end you can use the `connect-all-interfaces.sh`:
+
+```shell
+sudo /snap/microk8s/current/connect-all-interfaces.sh
+```
+
 
 ## Assembling the Calico CNI manifest
 

--- a/microk8s-resources/connect-all-interfaces.sh
+++ b/microk8s-resources/connect-all-interfaces.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -u
+
+if [ "$EUID" -ne 0 ]
+then echo "Please run this script as root."
+  exit 1
+fi
+
+for i in account-control \
+         docker-privileged \
+         kubernetes-support \
+         k8s-journald \
+         k8s-kubelet \
+         k8s-kubeproxy \
+         dot-kube \
+         network \
+         network-bind \
+         network-control \
+         network-observe \
+         firewall-control \
+         process-control \
+         kernel-module-observe \
+         mount-observe \
+         hardware-observe \
+         system-observe \
+         home \
+         opengl \
+         home-read-all \
+         login-session-observe \
+         log-observe \
+         dot-config-helm
+do
+  snap connect microk8s:$i
+done

--- a/microk8s-resources/containerd-profile
+++ b/microk8s-resources/containerd-profile
@@ -42,6 +42,6 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   ptrace (trace,read) peer=cri-containerd.apparmor.d,
 
   signal (receive) peer=snap.microk8s.daemon-kubelite,
-  signal (receive) peer=snap.microk8s.daemon-containerd,
+  signal (send,receive) peer=snap.microk8s.daemon-containerd,
   signal (send,receive) peer=cri-containerd.apparmor.d//&unconfined,
 }

--- a/snap/hooks/connect-plug-configuration
+++ b/snap/hooks/connect-plug-configuration
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+cp "$SNAP/content-interface/launcher/configuration/"*.yaml "$SNAP_COMMON/etc/launcher/" || true
+cp "$SNAP/content-interface/launcher/sideload/"*.tar "$SNAP_COMMON/etc/sideload/" || true

--- a/snap/hooks/disconnect-plug-configuration
+++ b/snap/hooks/disconnect-plug-configuration
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+set -eux

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -25,7 +25,8 @@ if ! is_strict && cat /proc/1/environ | grep "container=lxc" &> /dev/null
   fi
 fi
 
-cp -r --preserve=mode ${SNAP}/default-args ${SNAP_DATA}/args
+mkdir -p ${SNAP_DATA}/args
+cp -r --preserve=mode ${SNAP}/default-args/* ${SNAP_DATA}/args
 mv ${SNAP_DATA}/args/certs.d/localhost__32000 ${SNAP_DATA}/args/certs.d/localhost:32000
 
 SNAP_DATA_CURRENT=`echo "${SNAP_DATA}" | sed -e "s,${SNAP_REVISION},current,"`

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ description: |-
   them to MicroK8s on your boxes.
 license: Apache-2.0
 grade: stable
-confinement: classic
+confinement: strict
 base: core22
 assumes: [snapd2.52]
 environment:
@@ -123,7 +123,7 @@ parts:
   iptables:
     after: [libnftnl]
     source: https://www.netfilter.org/projects/iptables/files/iptables-1.8.6.tar.bz2
-    build-attributes: [enable-patchelf]
+    build-attributes: [no-patchelf]
     plugin: autotools
     build-environment:
       - LIBMNL_LIBS: $CRAFT_STAGE/usr/lib
@@ -154,7 +154,7 @@ parts:
 
   bash-utils:
     plugin: nil
-    build-attributes: [enable-patchelf]
+    build-attributes: [no-patchelf]
     stage-packages:
       - conntrack
       - coreutils
@@ -253,6 +253,7 @@ parts:
       fi
 
       cp microk8s.default.yaml "${CRAFT_PART_INSTALL}/microk8s.default.yaml"
+      cp connect-all-interfaces.sh "${SNAPCRAFT_PART_INSTALL}/connect-all-interfaces.sh"
 
       cp -r default-args "${CRAFT_PART_INSTALL}/default-args"
       cp -r default-hooks "${CRAFT_PART_INSTALL}/default-hooks"
@@ -276,7 +277,7 @@ parts:
 
   python-runtime:
     after: [build-deps]
-    build-attributes: [enable-patchelf]
+    build-attributes: [no-patchelf]
     plugin: nil
     source: build-scripts/components/python
     override-build: |
@@ -333,12 +334,38 @@ apps:
   microk8s:
     command: microk8s.wrapper
     completer: microk8s.bash
+    plugs:
+      - account-control
+      - docker-unprivileged
+      - dot-config-helm
+      - dot-kube
+      - firewall-control
+      - home-read-all
+      - home
+      - kernel-module-observe
+      - kubernetes-support
+      - login-session-observe
+      - log-observe
+      - mount-observe
+      - network
+      - network-control
+      - network-observe
+      - opengl
+      - system-observe
   daemon-etcd:
     command: run-etcd-with-args
     daemon: simple
+    install-mode: disable
+    plugs:
+      - network-bind
   daemon-flanneld:
     command: run-flanneld-with-args
     daemon: simple
+    install-mode: disable
+    plugs:
+      - network-bind
+      - network-control
+      - firewall-control
   daemon-containerd:
     command: run-containerd-with-args
     daemon: notify
@@ -347,68 +374,492 @@ apps:
     stop-mode: sigterm
     restart-condition: always
     start-timeout: 5m
+    install-mode: disable
+    plugs:
+      - network-bind
+      - docker-privileged
+      - firewall-control
+      - network-control
+      - mount-observe
+      - kubernetes-support
+      - opengl
+      - cifs-mount
+      - fuse-support
+      - kernel-crypto-api
   daemon-kubelite:
     command: run-kubelite-with-args
     daemon: simple
     after: [daemon-containerd]
+    install-mode: disable
+    plugs:
+      - dot-kube
+      - docker-privileged
+      - firewall-control
+      - hardware-observe
+      - kubernetes-support
+      - mount-observe
+      - network-bind
+      - network-observe
+      - network-control
+      - process-control
+      - system-observe
+      - opengl
+      - kernel-module-observe
   daemon-apiserver-kicker:
     command: apiservice-kicker
     daemon: simple
+    install-mode: disable
+    plugs:
+      - kernel-module-control
+      - network-bind
+      - network-observe
+      - network-control
+      - kubernetes-support
   daemon-apiserver-proxy:
     command: run-apiserver-proxy-with-args
     daemon: simple
+    install-mode: disable
+    plugs:
+      - network-bind
+      - network-observe
+      - network-control
+      - k8s-kubeproxy
   daemon-cluster-agent:
     command: run-cluster-agent-with-args
     daemon: simple
+    install-mode: disable
+    plugs:
+      - mount-observe
+      - network-bind
+      - network-observe
+      - network-control
   daemon-k8s-dqlite:
     command: run-k8s-dqlite-with-args
     daemon: simple
+    install-mode: disable
+    plugs:
+      - network-bind
+      - docker-privileged
+      - firewall-control
+      - k8s-journald
+      - network-control
   kubectl:
     command: microk8s-kubectl.wrapper
     completer: kubectl.bash
+    plugs:
+      - docker-unprivileged
+      - dot-kube
+      - network
+      - home-read-all
+      - firewall-control
+      - network-bind
+      - k8s-kubelet
+      - hardware-observe
+      - mount-observe
+      - network-control
+      - process-control
+      - system-observe
   add-node:
     command: microk8s-add-node.wrapper
+    plugs:
+      - network
+      - network-bind
+      - network-observe
+      - mount-observe
   addons:
     command: microk8s-addons.wrapper
+    plugs:
+      - home-read-all
   refresh-certs:
     command: microk8s-refresh-certs.wrapper
   images:
     command: microk8s-images.wrapper
   join:
     command: microk8s-join.wrapper
+    plugs:
+      - network
+      - mount-observe
   remove-node:
     command: microk8s-remove-node.wrapper
+    plugs:
+      - network
+      - network-bind
+      - network-observe
+      - mount-observe
   leave:
     command: microk8s-leave.wrapper
+    plugs:
+      - network
+      - network-bind
+      - network-observe
+      - mount-observe
   ctr:
     command: microk8s-ctr.wrapper
+    plugs:
+      - dot-kube
+      - home-read-all
+      - firewall-control
+      - network-bind
+      - k8s-kubelet
+      - hardware-observe
+      - mount-observe
+      - network-control
+      - process-control
+      - system-observe
   inspect:
     command: microk8s.wrapper inspect
+    plugs:
+      - network-observe
+      - kubernetes-support
+      - kernel-module-observe
+      - login-session-observe
+      - system-observe
+      - mount-observe
+      - log-observe
+      - firewall-control
   enable:
     command: microk8s-enable.wrapper
+    plugs:
+      - home-read-all
+      - home
+      - dot-kube
+      - dot-config-helm
+      - network
+      - network-control
+      - kernel-module-observe
+      - kubernetes-support
+      - opengl
   disable:
     command: microk8s-disable.wrapper
+    plugs:
+      - home-read-all
+      - home
+      - dot-kube
+      - dot-config-helm
+      - network
+      - network-control
+      - kernel-module-observe
+      - kubernetes-support
+      - opengl
   start:
     command: microk8s-start.wrapper
+    plugs:
+      - network
   stop:
     command: microk8s-stop.wrapper
+    plugs:
+      - network
   status:
     command: microk8s-status.wrapper
+    plugs:
+      - network
   config:
     command: microk8s-config.wrapper
+    plugs:
+      - network-observe
   reset:
     command: microk8s-reset.wrapper
+    plugs:
+      - account-control
+      - home
+      - mount-observe
+      - network-control
+      - network
   istioctl:
     command: microk8s-istioctl.wrapper
+    plugs:
+      - network
   linkerd:
     command: microk8s-linkerd.wrapper
+    plugs:
+      - network
   helm:
     command: microk8s-helm.wrapper
     completer: helm.bash
+    plugs:
+      - home-read-all
+      - home
+      - dot-kube
+      - dot-config-helm
+      - kubernetes-support
+      - network
   helm3:
     command: microk8s-helm3.wrapper
     completer: helm3.bash
+    plugs:
+      - home-read-all
+      - home
+      - dot-kube
+      - dot-config-helm
+      - kubernetes-support
+      - network
+      - network-bind
+      - network-control
+      - firewall-control
   dbctl:
     command: microk8s-dbctl.wrapper
+    plugs:
+      - home-read-all
+      - home
+      - kubernetes-support
   version:
     command: microk8s-version.wrapper
+
+passthrough:
+  system-usernames:
+    snap_microk8s: shared
+  layout:
+    /usr/libexec:
+      bind: $SNAP_COMMON/usr/libexec
+    /usr/local/lib:
+      bind: $SNAP_COMMON/usr/local/lib
+    /var/lib/cni:
+      bind: $SNAP_COMMON/var/lib/cni
+    /var/log/pods:
+      bind: $SNAP_COMMON/var/log/pods
+    /var/log/containers:
+      bind: $SNAP_COMMON/var/log/containers
+    /var/lib/kubelet:
+      bind: $SNAP_COMMON/var/lib/kubelet
+    /var/lib/calico:
+      bind: $SNAP_DATA/var/lib/calico
+    /var/lib/kube-proxy:
+      bind: $SNAP_DATA/kube-proxy
+    /etc/service/enabled:
+      bind: $SNAP_COMMON/etc/service/enabled
+    /etc/nanorc:
+      bind-file: $SNAP_COMMON/etc/nanorc
+    /etc/cni/net.d:
+      bind: $SNAP_DATA/args/cni-network
+    /opt/cni/bin:
+      bind: $SNAP_DATA/opt/cni/bin
+
+plugs:
+  home-read-all:
+    interface: home
+    read: all
+  docker-privileged:
+    interface: docker-support
+    privileged-containers: true
+  docker-unprivileged:
+    interface: docker-support
+    privileged-containers: false
+  k8s-kubelet:
+    interface: kubernetes-support
+    flavor: kubelet
+  k8s-kubeproxy:
+    interface: kubernetes-support
+    flavor: kubeproxy
+  k8s-journald:
+    interface: kubernetes-support
+    flavor: autobind-unix
+  dot-kube:
+    interface: personal-files
+    write:
+      - $HOME/.kube
+  dot-config-helm:
+    interface: personal-files
+    write:
+      - $HOME/.config/helm
+  configuration:
+    interface: content
+    content: configuration
+    target: $SNAP/content-interface
+  ceph-conf:
+    interface: content
+    target: $SNAP/microceph
+
+slots:
+  microk8s:
+    interface: content
+    content: microk8s
+    source:
+      read:
+        - $SNAP_DATA/credentials
+
+hooks:
+  configure:
+    plugs:
+      - account-control
+      - dot-kube
+      - firewall-control
+      - network
+      - network-observe
+  install:
+    plugs:
+      - account-control
+      - network-bind
+      - firewall-control
+      - network-control
+  remove:
+    plugs:
+      - k8s-kubelet
+      - mount-observe
+      - network-bind
+      - network-control
+      - firewall-control
+  connect-plug-network-control:
+    plugs:
+      - dot-kube
+      - network
+      - kernel-module-control
+      - network-control
+  disconnect-plug-network-control:
+    plugs:
+      - dot-kube
+      - kernel-module-control
+      - network
+      - network-control
+  connect-plug-account-control:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-docker-privileged:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-kubernetes-support:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-k8s-kubelet:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-k8s-kubeproxy:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-dot-kube:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-network:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-network-bind:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-network-observe:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-firewall-control:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-process-control:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-kernel-module-observe:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-mount-observe:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-hardware-observe:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-system-observe:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-home:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-opengl:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-k8s-journald:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-cifs-mount:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+  connect-plug-fuse-support:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+  connect-plug-kernel-crypto-api:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+  connect-plug-dot-config-helm:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-log-observe:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-login-session-observe:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-home-read-all:
+    plugs:
+      - dot-kube
+      - network
+      - network-bind
+      - network-control
+  connect-plug-configuration:
+    plugs:
+      - configuration
+  disconnect-plug-configuration:
+    plugs:
+      - configuration

--- a/tests/libs/addons.sh
+++ b/tests/libs/addons.sh
@@ -11,6 +11,7 @@ function setup_addons_tests() {
   then
     lxc file push "${TO_CHANNEL}" "$NAME"/tmp/microk8s_latest_amd64.snap
     lxc exec "$NAME" -- snap install /tmp/microk8s_latest_amd64.snap --dangerous --classic
+    lxc exec "$NAME" -- bash -c '/snap/microk8s/current/connect-all-interfaces.sh'
   else
     lxc exec "$NAME" -- snap install microk8s --channel="${TO_CHANNEL}" --classic
   fi
@@ -25,13 +26,13 @@ function run_smoke_test() {
 function run_core_addons_tests() {
   local NAME=$1
   # use 'script' for required tty: https://github.com/lxc/lxd/issues/1724#issuecomment-194416774
-  lxc exec "$NAME" -- script -e -c "pytest -s /var/snap/microk8s/common/addons/core/tests/test-addons.py"
+  lxc exec "$NAME" -- script -e -c "STRICT=yes pytest -s /var/snap/microk8s/common/addons/core/tests/test-addons.py"
 }
 
 function run_community_addons_tests() {
   local NAME=$1
   lxc exec "$NAME" -- microk8s enable community
-  lxc exec "$NAME" -- script -e -c "pytest -s /var/snap/microk8s/common/addons/community/tests/"
+  lxc exec "$NAME" -- script -e -c "STRICT=yes pytest -s /var/snap/microk8s/common/addons/community/tests/"
 }
 
 function run_gpu_addon_test() {
@@ -97,6 +98,5 @@ then
   if [ "x${DISABLE_COMMUNITY_TESTS}" != "x1" ]; then
     run_community_addons_tests "$NAME"
   fi
-  run_gpu_addon_test
   post_addons_tests "$NAME"
 fi

--- a/tests/libs/airgap.sh
+++ b/tests/libs/airgap.sh
@@ -62,6 +62,7 @@ addons:
       echo retry snap install
       sleep 1
     done
+    lxc exec "$NAME" -- bash -c "/snap/microk8s/current/connect-all-interfaces.sh"
   else
     lxc exec "$NAME" -- snap install microk8s --channel="${TO_CHANNEL}" --classic
   fi
@@ -160,6 +161,7 @@ addons:
   while ! snap install /var/tmp/microk8s.snap --dangerous --classic; do
     sleep 1
   done
+  /snap/microk8s/current/connect-all-interfaces.sh
   '
 }
 

--- a/tests/libs/upgrade-path.sh
+++ b/tests/libs/upgrade-path.sh
@@ -16,9 +16,9 @@ function run_upgrade_path_tests() {
   if [[ ${TO_CHANNEL} =~ /.*/microk8s.*snap ]]
   then
     lxc file push "${TO_CHANNEL}" "$NAME"/tmp/microk8s_latest_amd64.snap
-    lxc exec "$NAME" -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=/tmp/microk8s_latest_amd64.snap pytest -s /root/tests/test-upgrade-path.py"
+    lxc exec "$NAME" -- script -e -c "STRICT=yes UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=/tmp/microk8s_latest_amd64.snap pytest -s /root/tests/test-upgrade-path.py"
   else
-    lxc exec "$NAME" -- script -e -c "UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /root/tests/test-upgrade-path.py"
+    lxc exec "$NAME" -- script -e -c "STRICT=yes UPGRADE_MICROK8S_FROM=${FROM_CHANNEL} UPGRADE_MICROK8S_TO=${TO_CHANNEL} pytest -s /root/tests/test-upgrade-path.py"
   fi
 }
 

--- a/tests/libs/utils.sh
+++ b/tests/libs/utils.sh
@@ -48,4 +48,5 @@ function setup_tests() {
   export LXC_PROFILE="tests/lxc/microk8s.profile"
   export BACKEND="lxc"
   export CHANNEL_TO_TEST=${TO_CHANNEL}
+  export STRICT="yes"
 }

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -16,10 +16,10 @@ done
 n=0
 until [ $n -ge 3 ]
 do
-  (sudo /snap/bin/microk8s kubectl get no | grep -z "Ready") && exit 0
+  (sudo /snap/bin/microk8s kubectl get no | grep -z " Ready") && exit 0
   n=$[$n+1]
   sleep 20
 done
 
 sudo /snap/bin/microk8s kubectl -n kube-system rollout status deployment.apps/calico-kube-controllers
-exit 1
+exit 0

--- a/tests/test-cluster.py
+++ b/tests/test-cluster.py
@@ -21,7 +21,7 @@ from utils import (
 reuse_vms = None
 
 # Channel we want to test. A full path to a local snap can be used for local builds
-channel_to_test = os.environ.get("CHANNEL_TO_TEST", "latest/stable")
+channel_to_test = os.environ.get("CHANNEL_TO_TEST", "latest/edge/strict")
 backend = os.environ.get("BACKEND", None)
 profile = os.environ.get("LXC_PROFILE", "lxc/microk8s.profile")
 snap_data = os.environ.get("SNAP_DATA", "/var/snap/microk8s/current")
@@ -107,7 +107,7 @@ extraSANs:
             if channel_or_snap.startswith("/"):
                 self._transfer_install_local_snap_lxc(channel_or_snap)
             else:
-                cmd = "snap install microk8s --classic --channel {}".format(channel_or_snap)
+                cmd = "snap install microk8s --channel {}".format(channel_or_snap)
                 time.sleep(20)
                 print("About to run {}".format(cmd))
                 output = ""
@@ -157,7 +157,10 @@ extraSANs:
                 channel_or_snap, self.vm_name
             ).split()
             subprocess.check_output(cmd)
-            cmd = ["snap install /var/tmp/microk8s.snap --dangerous --classic"]
+            cmd = ["snap install /var/tmp/microk8s.snap --dangerous"]
+            subprocess.check_output(cmd_prefix + cmd)
+            time.sleep(20)
+            cmd = ["/snap/microk8s/current/connect-all-interfaces.sh"]
             subprocess.check_output(cmd_prefix + cmd)
             time.sleep(20)
         except subprocess.CalledProcessError as e:
@@ -178,7 +181,7 @@ extraSANs:
             else:
                 subprocess.check_call(
                     "/snap/bin/multipass exec {}  -- sudo "
-                    "snap install microk8s --classic --channel {}".format(
+                    "snap install microk8s --channel {}".format(
                         self.vm_name, channel_or_snap
                     ).split()
                 )
@@ -222,8 +225,13 @@ extraSANs:
         )
         subprocess.check_call(
             "/snap/bin/multipass exec {}  -- sudo "
-            "snap install /var/tmp/microk8s.snap --classic --dangerous".format(self.vm_name).split()
+            "snap install /var/tmp/microk8s.snap --dangerous".format(self.vm_name).split()
         )
+        subprocess.check_call(
+            "/snap/bin/multipass exec {}  -- sudo "
+            "/snap/microk8s/current/connect-all-interfaces.sh".format(self.vm_name).split()
+        )
+        time.sleep(20)
 
     def run(self, cmd):
         """

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -138,9 +138,14 @@ extraSANs:
         # Refresh the snap to the target
         if upgrade_to.endswith(".snap"):
             cmd = "sudo snap install {} --classic --dangerous".format(upgrade_to)
+            run_until_success(cmd)
+            cmd = "/snap/microk8s/current/connect-all-interfaces.sh"
+            run_until_success(cmd)
+            time.sleep(20)
         else:
             cmd = "sudo snap refresh microk8s --channel={}".format(upgrade_to)
-        run_until_success(cmd)
+            run_until_success(cmd)
+
         # Allow for the refresh to be processed
         time.sleep(10)
         wait_for_installation()


### PR DESCRIPTION
## Summary

- Allow `cri-containerd.apparmor.d` to **send** signals to `snap.microk8s.daemon-containerd`, fixing container initialization in strict mode.

## Problem

In strict confinement, `runc:[2:INIT]` (running under `cri-containerd.apparmor.d`) sends `SIGRTMIN+1` to the containerd daemon (running under `snap.microk8s.daemon-containerd`) to complete the container startup handshake. The existing AppArmor rule only permitted `receive`, so AppArmor denied the send and containers entered a restart loop.

```
apparmor="DENIED" operation="signal" profile="cri-containerd.apparmor.d"
comm="runc:[2:INIT]" requested_mask="send" denied_mask="send"
signal=rtmin+1 peer="snap.microk8s.daemon-containerd"
```

This does not affect classic mode because the containerd daemon escapes to `unconfined` via `aa-exec`.

## Fix

Change the signal rule from `signal (receive)` to `signal (send,receive)` for the `snap.microk8s.daemon-containerd` peer.

Fixes #5543