### PR TITLE
fix(apparmor): allow signal send from cri-containerd to daemon-containerd

### DIFF
--- a/microk8s-resources/containerd-profile
+++ b/microk8s-resources/containerd-profile
@@ -42,6 +42,6 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   ptrace (trace,read) peer=cri-containerd.apparmor.d,
 
   signal (receive) peer=snap.microk8s.daemon-kubelite,
-  signal (receive) peer=snap.microk8s.daemon-containerd,
+  signal (send,receive) peer=snap.microk8s.daemon-containerd,
   signal (send,receive) peer=cri-containerd.apparmor.d//&unconfined,
 }


### PR DESCRIPTION
## Summary

- Allow `cri-containerd.apparmor.d` to **send** signals to `snap.microk8s.daemon-containerd`, fixing container initialization in strict mode.

## Problem

In strict confinement, `runc:[2:INIT]` (running under `cri-containerd.apparmor.d`) sends `SIGRTMIN+1` to the containerd daemon (running under `snap.microk8s.daemon-containerd`) to complete the container startup handshake. The existing AppArmor rule only permitted `receive`, so AppArmor denied the send and containers entered a restart loop.

```
apparmor="DENIED" operation="signal" profile="cri-containerd.apparmor.d"
comm="runc:[2:INIT]" requested_mask="send" denied_mask="send"
signal=rtmin+1 peer="snap.microk8s.daemon-containerd"
```

This does not affect classic mode because the containerd daemon escapes to `unconfined` via `aa-exec`.

## Fix

Change the signal rule from `signal (receive)` to `signal (send,receive)` for the `snap.microk8s.daemon-containerd` peer.

Fixes #5543