### PR TITLE
fix(runc): apply AppArmor profile after finalizeNamespace in standard_init (strict)

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -214,6 +214,10 @@ jobs:
   upload_sarifs_matrix:
     needs: security-scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read          # for actions/checkout
+      actions: read           # for download-artifact (same-run Artifacts API)
+      security-events: write  # for codeql-action/upload-sarif
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -215,9 +215,9 @@ jobs:
     needs: security-scan
     runs-on: ubuntu-latest
     permissions:
-      contents: read          # for actions/checkout
-      actions: read           # for download-artifact (same-run Artifacts API)
-      security-events: write  # for codeql-action/upload-sarif
+      contents: read # for actions/checkout
+      actions: read # for download-artifact (same-run Artifacts API)
+      security-events: write # for codeql-action/upload-sarif
     strategy:
       fail-fast: true
       matrix:

--- a/build-scripts/components/runc/strict-patches/v1.4.2/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
+++ b/build-scripts/components/runc/strict-patches/v1.4.2/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
@@ -1,15 +1,29 @@
-From 5007ab516cb619db9e75218f9739c555762e26da Mon Sep 17 00:00:00 2001
+From 8b06d0fcf51fbaee145b8108c83a03b6dd8cdeb6 Mon Sep 17 00:00:00 2001
 From: Alberto Mardegan <mardy@users.sourceforge.net>
-Date: Wed, 6 May 2026 14:44:12 +0200
-Subject: [PATCH 3/3] standard_init_linux: change AppArmor profile as late as
+Date: Thu, 18 Jun 2026 10:41:03 +0300
+Subject: [PATCH] standard_init_linux: change AppArmor profile as late as
  possible
 
+Apply the AppArmor profile (and set NoNewPrivileges) after
+finalizeNamespace rather than before it, mirroring the ordering already
+used in setns_init_linux.
+
+With runc's immediate profile change (aa_change_profile instead of
+aa_change_onexec), relabelling the calling thread before finalizeNamespace
+runs setuid(2) leaves the Go runtime's sibling threads under the old
+profile. glibc's NPTL setxid broadcast (SIGRTMIN+1) then crosses two
+AppArmor profiles and is denied by AppArmor 4.x, breaking container
+creation for pods with allowPrivilegeEscalation: false (NoNewPrivileges).
+
+Performing setuid(2) while all threads still share a single profile keeps
+the broadcast intra-profile. NoNewPrivileges must still be set after the
+profile change, as the kernel forbids switching profile once it is set.
 ---
- libcontainer/standard_init_linux.go | 17 ++++++++---------
- 1 file changed, 8 insertions(+), 9 deletions(-)
+ libcontainer/standard_init_linux.go | 24 +++++++++++++++---------
+ 1 file changed, 15 insertions(+), 9 deletions(-)
 
 diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
-index 570472b..1d54a02 100644
+index 570472b..9ec98af 100644
 --- a/libcontainer/standard_init_linux.go
 +++ b/libcontainer/standard_init_linux.go
 @@ -129,10 +129,6 @@ func (l *linuxStandardInit) Init() error {
@@ -35,10 +49,17 @@ index 570472b..1d54a02 100644
  
  	if err := setupScheduler(l.config); err != nil {
  		return err
-@@ -180,6 +171,14 @@ func (l *linuxStandardInit) Init() error {
- 	if err := syncParentReady(l.pipe); err != nil {
- 		return fmt.Errorf("sync ready: %w", err)
+@@ -207,6 +198,21 @@ func (l *linuxStandardInit) Init() error {
+ 	if err := pdeath.Restore(); err != nil {
+ 		return fmt.Errorf("can't restore pdeath signal: %w", err)
  	}
++	// Apply the AppArmor profile and set NoNewPrivileges as late as possible,
++	// after finalizeNamespace has changed the user/group. Doing the setuid(2)
++	// while all of the Go runtime's threads still share a single AppArmor
++	// profile keeps glibc's NPTL setxid broadcast (SIGRTMIN+1) intra-profile;
++	// relabelling earlier splits the threads across two profiles and the
++	// broadcast is then denied by AppArmor. NNP must follow the profile
++	// change, as the kernel forbids switching profile once NNP is set.
 +	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
 +		return fmt.Errorf("apply apparmor profile: %w", err)
 +	}
@@ -47,8 +68,9 @@ index 570472b..1d54a02 100644
 +			return fmt.Errorf("set nonewprivileges: %w", err)
 +		}
 +	}
- 	if l.config.ProcessLabel != "" {
- 		if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
- 			return fmt.Errorf("can't set process label: %w", err)
+ 
+ 	// In case we have any StartContainer hooks to run, and they don't
+ 	// have environment configured explicitly, make sure they will be run
 -- 
-2.41.0
+2.43.0
+


### PR DESCRIPTION
## Summary
Reorders the strict-mode runc **v1.4.2** patch `0003-standard_init_linux-change-AppArmor-profile-as-late-` so the AppArmor profile change (and `NoNewPrivileges`) happen **after** `finalizeNamespace` runs `setuid(2)`, mirroring the ordering already used in `setns_init_linux`.

## Background
This fixes the second AppArmor denial seen when deploying workloads such as metallb in strict mode on AppArmor 4.x hosts (e.g. Plucky 25.10):

```
profile="snap.microk8s.daemon-containerd" comm="runc:[2:INIT]"
requested_mask="receive" denied_mask="receive" signal=rtmin+1
peer="cri-containerd.apparmor.d"
```

## Root cause
The strict patches switch the container's AppArmor profile **immediately** (`aa_change_profile`) instead of on exec (`aa_change_onexec`) — this is required because the kernel forbids gaining a profile on `execve` once `NO_NEW_PRIVS` is set, and Kubernetes pods with `allowPrivilegeEscalation: false` set NNP.

In `standard_init_linux.go` (container **creation**, `runc:[2:INIT]`), patch `0003` applied the profile right after `syncParentReady`, i.e. **before** `finalizeNamespace` calls `setuid(2)`. That relabels only the calling thread to `cri-containerd.apparmor.d`, while the Go runtime's sibling threads stay under `snap.microk8s.daemon-containerd`. The subsequent `setuid(2)` triggers glibc's NPTL setxid broadcast (`SIGRTMIN+1`) **across the two profiles**, which AppArmor 4.x denies → pod creation fails.

`setns_init_linux.go` (container **exec**) already does `finalizeNamespace` → `ApplyProfile` → NNP, which is why `kubectl exec` works but pod creation does not. This change makes `standard_init` follow the same proven ordering.

## Why Docker's containerd is unaffected
The Docker snap uses stock upstream runc with `aa_change_onexec`, which defers the transition to `execve`; all threads share one profile during the `setuid` handshake, so the cross-profile signal never occurs. Only microk8s's immediate-relabel patches create the split, so this is fixed here rather than in snapd's `docker-support` interface.

## Change
- `build-scripts/components/runc/strict-patches/v1.4.2/0003-...patch`: move the `ApplyProfile` + `NNP` block from after `syncParentReady` to after `finalizeNamespace`/`pdeath.Restore()`. NNP still follows the profile change (the kernel forbids switching profile once NNP is set).

Only the currently-built version (v1.4.2) is touched.

## Verification
- All three strict patches `git am` cleanly on a fresh `v1.4.2` checkout.
- `go build ./libcontainer/` succeeds; `gofmt` clean.
- Pending: strict snap build + metallb repro on an AppArmor 4.x host to confirm no `rtmin+1` denials on either `snap.microk8s.daemon-containerd` or `cri-containerd.apparmor.d`, and that `kubectl exec` still works.

## Related
Complements the `containerd-profile` signal rule change in #5550 / #5551, which is retained as defense-in-depth on the send side. Refs #5543.