### PR TITLE
fix(runc): apply AppArmor profile after finalizeNamespace in standard_init

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -210,9 +210,9 @@ jobs:
     needs: security-scan
     runs-on: ubuntu-latest
     permissions:
-      contents: read          # for actions/checkout
-      actions: read           # for download-artifact (same-run Artifacts API)
-      security-events: write  # for codeql-action/upload-sarif
+      contents: read # for actions/checkout
+      actions: read # for download-artifact (same-run Artifacts API)
+      security-events: write # for codeql-action/upload-sarif
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -209,6 +209,10 @@ jobs:
   upload_sarifs_matrix:
     needs: security-scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read          # for actions/checkout
+      actions: read           # for download-artifact (same-run Artifacts API)
+      security-events: write  # for codeql-action/upload-sarif
     strategy:
       fail-fast: true
       matrix:

--- a/build-scripts/components/runc/strict-patches/v1.4.2/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
+++ b/build-scripts/components/runc/strict-patches/v1.4.2/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
@@ -1,15 +1,29 @@
-From 5007ab516cb619db9e75218f9739c555762e26da Mon Sep 17 00:00:00 2001
+From 8b06d0fcf51fbaee145b8108c83a03b6dd8cdeb6 Mon Sep 17 00:00:00 2001
 From: Alberto Mardegan <mardy@users.sourceforge.net>
-Date: Wed, 6 May 2026 14:44:12 +0200
-Subject: [PATCH 3/3] standard_init_linux: change AppArmor profile as late as
+Date: Thu, 18 Jun 2026 10:41:03 +0300
+Subject: [PATCH] standard_init_linux: change AppArmor profile as late as
  possible
 
+Apply the AppArmor profile (and set NoNewPrivileges) after
+finalizeNamespace rather than before it, mirroring the ordering already
+used in setns_init_linux.
+
+With runc's immediate profile change (aa_change_profile instead of
+aa_change_onexec), relabelling the calling thread before finalizeNamespace
+runs setuid(2) leaves the Go runtime's sibling threads under the old
+profile. glibc's NPTL setxid broadcast (SIGRTMIN+1) then crosses two
+AppArmor profiles and is denied by AppArmor 4.x, breaking container
+creation for pods with allowPrivilegeEscalation: false (NoNewPrivileges).
+
+Performing setuid(2) while all threads still share a single profile keeps
+the broadcast intra-profile. NoNewPrivileges must still be set after the
+profile change, as the kernel forbids switching profile once it is set.
 ---
- libcontainer/standard_init_linux.go | 17 ++++++++---------
- 1 file changed, 8 insertions(+), 9 deletions(-)
+ libcontainer/standard_init_linux.go | 24 +++++++++++++++---------
+ 1 file changed, 15 insertions(+), 9 deletions(-)
 
 diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
-index 570472b..1d54a02 100644
+index 570472b..9ec98af 100644
 --- a/libcontainer/standard_init_linux.go
 +++ b/libcontainer/standard_init_linux.go
 @@ -129,10 +129,6 @@ func (l *linuxStandardInit) Init() error {
@@ -35,10 +49,17 @@ index 570472b..1d54a02 100644
  
  	if err := setupScheduler(l.config); err != nil {
  		return err
-@@ -180,6 +171,14 @@ func (l *linuxStandardInit) Init() error {
- 	if err := syncParentReady(l.pipe); err != nil {
- 		return fmt.Errorf("sync ready: %w", err)
+@@ -207,6 +198,21 @@ func (l *linuxStandardInit) Init() error {
+ 	if err := pdeath.Restore(); err != nil {
+ 		return fmt.Errorf("can't restore pdeath signal: %w", err)
  	}
++	// Apply the AppArmor profile and set NoNewPrivileges as late as possible,
++	// after finalizeNamespace has changed the user/group. Doing the setuid(2)
++	// while all of the Go runtime's threads still share a single AppArmor
++	// profile keeps glibc's NPTL setxid broadcast (SIGRTMIN+1) intra-profile;
++	// relabelling earlier splits the threads across two profiles and the
++	// broadcast is then denied by AppArmor. NNP must follow the profile
++	// change, as the kernel forbids switching profile once NNP is set.
 +	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
 +		return fmt.Errorf("apply apparmor profile: %w", err)
 +	}
@@ -47,8 +68,9 @@ index 570472b..1d54a02 100644
 +			return fmt.Errorf("set nonewprivileges: %w", err)
 +		}
 +	}
- 	if l.config.ProcessLabel != "" {
- 		if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
- 			return fmt.Errorf("can't set process label: %w", err)
+ 
+ 	// In case we have any StartContainer hooks to run, and they don't
+ 	// have environment configured explicitly, make sure they will be run
 -- 
-2.41.0
+2.43.0
+


### PR DESCRIPTION
## Summary

Master counterpart of the runc init-order fix being landed on `strict`. Cherry-picks the same three commits onto `master` (which also builds runc v1.4.2).

- **fix(runc): apply AppArmor profile after finalizeNamespace in standard_init** — Reorders the strict-mode runc v1.4.2 patch so the AppArmor profile change (and NoNewPrivileges) happen after `finalizeNamespace` runs `setuid(2)`, mirroring `setns_init_linux`. Because the strict patches switch the profile immediately (`aa_change_profile`) instead of on exec, relabelling before `setuid` left the Go runtime's sibling threads under the old profile; glibc's NPTL setxid broadcast (SIGRTMIN+1) then crossed two AppArmor profiles and was denied by AppArmor 4.x, breaking pod creation for workloads with `allowPrivilegeEscalation: false` (e.g. metallb).
- **ci: grant security-events write permission for SARIF upload** — Adds a job-scoped `permissions` block to `upload_sarifs_matrix` so `codeql-action/upload-sarif` can upload (fixes "Resource not accessible by integration").
- **ci: normalize permission comment formatting in build-snap workflow** — Whitespace-only cleanup of the comments added above.

## Notes
- The runc patch file (`strict-patches/v1.4.2/0003-...`) is byte-identical to the version landing on `strict`.
- A `1.35-strict` counterpart is **not** included here: that branch builds runc **v1.3.3** (no `v1.4.2` patch dir), so the fix must be hand-ported to `strict-patches/v1.3.3/0003-...` separately.
