### PR TITLE
fix: fall back to nftables kube-proxy on ip_tables-less kernels

### DIFF
--- a/microk8s-resources/wrappers/run-kubelite-with-args
+++ b/microk8s-resources/wrappers/run-kubelite-with-args
@@ -73,6 +73,16 @@ else
   sanitise_args_kube_controller_manager
 fi
 
+# Fall back to kube-proxy nftables mode on kernels that do not ship the
+# ip_tables module. This avoids a silent crash loop on nftables-only hosts
+# (see canonical/microk8s#5525) while preserving any user-selected proxy-mode.
+if ! grep -qE '^--proxy-mode[= ]' "$SNAP_DATA/args/kube-proxy" &&
+   ! (/sbin/modprobe -n -q ip_tables &> /dev/null || modprobe -n -q ip_tables &> /dev/null)
+then
+  echo "ip_tables kernel module is unavailable; configuring kube-proxy to use nftables mode."
+  refresh_opt_in_local_config "proxy-mode" "nftables" kube-proxy
+fi
+
 ## Kubelet configuration
 pod_cidr="$(cat $SNAP_DATA/args/kube-proxy | grep "cluster-cidr" | tr "=" " "| gawk '{print $2}')"
 if [ -z "$pod_cidr" ]

--- a/scripts/inspect.sh
+++ b/scripts/inspect.sh
@@ -212,6 +212,13 @@ function suggest_fixes {
     fi
   fi
 
+  if journalctl -n 50 -u snap.microk8s.daemon-kubelite 2>/dev/null | grep -q 'Module ip_tables not found'
+  then
+    printf -- '\033[0;33m WARNING: \033[0m Your kernel does not provide the ip_tables module.\n'
+    printf -- 'MicroK8s will auto-switch kube-proxy to nftables mode on startup.\n'
+    printf -- 'If the cluster still fails to start, inspect the kube-proxy args under /var/snap/microk8s/current/args/kube-proxy.\n'
+  fi
+
   if iptables -L 2>&1 | grep FORWARD | grep DROP &> /dev/null
   then
     printf -- '\033[0;33m WARNING: \033[0m IPtables FORWARD policy is DROP. '


### PR DESCRIPTION
## Summary
- Detect kernels that do not provide the `ip_tables` module
- Auto-configure kube-proxy to use nftables mode on startup
- Add an inspect warning that points to the root cause and fallback

## Why
This addresses [canonical/microk8s#5525](https://github.com/canonical/microk8s/issues/5525), where MicroK8s can fail silently on nftables-only kernels because kube-proxy cannot load `ip_tables`.

## Verification
- `bash -n microk8s-resources/wrappers/run-kubelite-with-args scripts/inspect.sh`
- `git diff --check`

Fixes [canonical/microk8s#5525](https://github.com/canonical/microk8s/issues/5525)
